### PR TITLE
fix: debug and refine to JOSS quality; add Tkinter GUI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,25 @@
+# Python bytecode
+__pycache__/
+*.py[cod]
+*.pyo
+
+# Distribution / packaging
+*.egg-info/
+dist/
+build/
+*.egg
+
+# Virtual environments
+.venv/
+venv/
+env/
+
+# Test / coverage artefacts
+.pytest_cache/
+.coverage
+htmlcov/
+
+# Editor / OS
+.DS_Store
+*.swp
+*.swo

--- a/README.md
+++ b/README.md
@@ -1,1 +1,158 @@
 # litcluster
+
+**Topic-based clustering of scientific literature** using TF-IDF and k-means.
+
+Given a BibTeX file, CSV table, or JSONL record set, `litcluster` tokenises
+each paper's title + abstract + keywords, builds sparse TF-IDF vectors, and
+partitions the corpus into *k* topical clusters using Lloyd's algorithm with
+k-means++ initialisation.  No external dependencies — pure Python stdlib.
+
+[![CI](https://github.com/vdeshmukh203/litcluster/actions/workflows/ci.yml/badge.svg)](https://github.com/vdeshmukh203/litcluster/actions)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+
+---
+
+## Installation
+
+```bash
+pip install .
+```
+
+Python ≥ 3.8 required; no third-party packages needed.
+
+---
+
+## Quick start
+
+### Command line
+
+```bash
+# Cluster a BibTeX file into 6 topics, print a summary
+litcluster refs.bib -k 6
+
+# Export cluster assignments to CSV
+litcluster refs.bib -k 6 --format csv -o clusters.csv
+
+# Export as JSON
+litcluster refs.bib -k 6 --format json -o clusters.json
+
+# Cluster a CSV or JSONL file
+litcluster papers.csv -k 5 --seed 123 --min-freq 3
+litcluster papers.jsonl -k 4
+```
+
+**All options:**
+
+| Option | Default | Description |
+|---|---|---|
+| `-k / --clusters` | 5 | Number of clusters |
+| `--format` | summary | Output format: `summary`, `csv`, `json` |
+| `-o / --output` | stdout / auto | Output path |
+| `--seed` | 42 | Random seed for reproducibility |
+| `--max-iter` | 100 | Maximum k-means iterations |
+| `--min-freq` | 2 | Minimum document frequency for vocabulary |
+| `--version` | — | Print version and exit |
+
+### Graphical interface
+
+```bash
+litcluster-gui
+# or
+python litcluster_gui.py
+```
+
+The GUI lets you browse for an input file, tune parameters, inspect cluster
+summaries and paper assignments in a tabbed view, and export results — all
+without touching the command line.
+
+### Python API
+
+```python
+from pathlib import Path
+from litcluster import LitCluster
+
+# Load and cluster a BibTeX file
+lc = LitCluster.from_bibtex(Path("refs.bib"), k=5, seed=42)
+lc.fit()
+
+print(lc.summary())
+
+# Inspect clusters
+for cluster in lc.clusters:
+    print(cluster.label, "—", len(cluster.papers), "papers")
+    for paper in cluster.papers:
+        print("  •", paper.title)
+
+# Export
+lc.export_csv(Path("clusters.csv"))
+lc.export_json(Path("clusters.json"))
+```
+
+---
+
+## Input formats
+
+### BibTeX (`.bib`)
+
+Standard BibTeX entries.  The fields `title`, `abstract`, `author`, `year`,
+`journal`/`booktitle`, `doi`, and `keywords` are extracted automatically.
+Nested brace-delimited values (e.g. `title = {The {BERT} Model}`) are handled
+correctly.
+
+### CSV (`.csv`)
+
+A header row followed by one paper per row.  Recognised column names:
+`paper_id`, `title`, `abstract`, `authors`, `year`, `venue`, `doi`,
+`keywords`.  Only `title` is required; missing columns default to empty
+strings.
+
+### JSONL (`.jsonl`)
+
+One JSON object per line with the same keys as the CSV columns.
+
+---
+
+## How it works
+
+1. **Tokenisation** — titles, abstracts, and keywords are lower-cased, split
+   on non-alpha characters, and filtered for stopwords and tokens shorter than
+   three characters.
+2. **TF-IDF** — sparse term-frequency/inverse-document-frequency vectors are
+   built with smoothed IDF: `idf(t) = log((N+1)/(df(t)+1)) + 1`.  Terms
+   appearing in fewer than `--min-freq` documents are excluded.
+3. **K-means++** — centroids are seeded proportionally to their cosine
+   distance from already-chosen centroids (k-means++ criterion), then refined
+   by Lloyd's algorithm until convergence or `--max-iter` iterations.
+4. **Cluster labelling** — each cluster is labelled by its top-10 TF-IDF
+   terms (sum of member vectors), with the top-3 used in the short label.
+
+---
+
+## Running the tests
+
+```bash
+pip install pytest
+pytest tests/ -v
+```
+
+---
+
+## Citation
+
+If you use `litcluster` in published research, please cite:
+
+```bibtex
+@software{litcluster,
+  author  = {Deshmukh, V.A.},
+  title   = {litcluster: Topic modelling and semantic clustering of scientific literature},
+  year    = {2026},
+  url     = {https://github.com/vdeshmukh203/litcluster},
+  license = {MIT},
+}
+```
+
+---
+
+## License
+
+MIT — see [LICENSE](LICENSE).

--- a/litcluster.py
+++ b/litcluster.py
@@ -1,8 +1,15 @@
 #!/usr/bin/env python3
 """
-litcluster.py — Literature Clustering Tool
-Clusters academic papers by topic using TF-IDF + k-means (pure stdlib).
-Stdlib-only. No external dependencies.
+litcluster — Literature Clustering Tool
+
+Clusters academic papers by topic using TF-IDF + k-means (stdlib only).
+Supports BibTeX (.bib), CSV, and JSONL input formats.
+
+Usage
+-----
+    litcluster papers.bib -k 6 --format json -o results.json
+    litcluster papers.csv -k 5 --format summary
+    python litcluster.py papers.jsonl -k 4
 """
 
 from __future__ import annotations
@@ -17,37 +24,50 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
+__version__ = "0.1.0"
+
 
 # ---------------------------------------------------------------------------
 # Text processing
 # ---------------------------------------------------------------------------
 
 _STOPWORDS = {
-    'a','an','the','and','or','but','in','on','at','to','for','of','with',
-    'by','from','is','was','are','were','be','been','being','have','has',
-    'had','do','does','did','will','would','could','should','may','might',
-    'this','that','these','those','it','its','we','our','they','their',
-    'as','if','not','no','nor','so','yet','both','either','whether',
-    'each','few','more','most','other','some','such','than','too','very',
-    'just','also','only','then','here','there','when','where','who','which',
-    'how','all','any','can','into','through','during','before','after',
-    'above','below','between','out','off','over','under','again','further',
-    'once','i','my','me','he','she','his','her','him','you','your',
+    'a', 'an', 'the', 'and', 'or', 'but', 'in', 'on', 'at', 'to', 'for',
+    'of', 'with', 'by', 'from', 'is', 'was', 'are', 'were', 'be', 'been',
+    'being', 'have', 'has', 'had', 'do', 'does', 'did', 'will', 'would',
+    'could', 'should', 'may', 'might', 'this', 'that', 'these', 'those',
+    'it', 'its', 'we', 'our', 'they', 'their', 'as', 'if', 'not', 'no',
+    'nor', 'so', 'yet', 'both', 'either', 'whether', 'each', 'few', 'more',
+    'most', 'other', 'some', 'such', 'than', 'too', 'very', 'just', 'also',
+    'only', 'then', 'here', 'there', 'when', 'where', 'who', 'which', 'how',
+    'all', 'any', 'can', 'into', 'through', 'during', 'before', 'after',
+    'above', 'below', 'between', 'out', 'off', 'over', 'under', 'again',
+    'further', 'once', 'i', 'my', 'me', 'he', 'she', 'his', 'her', 'him',
+    'you', 'your',
 }
 
 
 def _tokenise(text: str) -> List[str]:
+    """Lowercase, extract alpha tokens ≥3 chars, remove stopwords."""
     tokens = re.findall(r"[a-zA-Z]{3,}", text.lower())
     return [t for t in tokens if t not in _STOPWORDS]
 
 
-def _tfidf(documents: List[List[str]]) -> Tuple[List[Dict[str,float]], List[str]]:
-    """Compute TF-IDF vectors. Returns (vectors, vocab)."""
+def _tfidf(documents: List[List[str]]) -> Tuple[List[Dict[str, float]], List[str]]:
+    """Compute TF-IDF vectors for tokenised documents.
+
+    Uses smoothed IDF: idf(t) = log((N+1)/(df(t)+1)) + 1, which avoids
+    zero weights for terms appearing in all documents.
+
+    Returns
+    -------
+    vectors : sparse dicts mapping term → TF-IDF weight, one per document
+    vocab   : sorted list of all unique terms
+    """
     n = len(documents)
     if n == 0:
         return [], []
 
-    # Build vocab
     vocab_set: set = set()
     for doc in documents:
         vocab_set.update(doc)
@@ -55,15 +75,12 @@ def _tfidf(documents: List[List[str]]) -> Tuple[List[Dict[str,float]], List[str]
     term_idx = {t: i for i, t in enumerate(vocab)}
     V = len(vocab)
 
-    # Document frequency
     df = [0] * V
     for doc in documents:
-        doc_set = set(doc)
-        for t in doc_set:
+        for t in set(doc):
             if t in term_idx:
                 df[term_idx[t]] += 1
 
-    # TF-IDF
     vectors: List[Dict[str, float]] = []
     for doc in documents:
         tf: Dict[int, int] = {}
@@ -83,12 +100,50 @@ def _tfidf(documents: List[List[str]]) -> Tuple[List[Dict[str,float]], List[str]
 
 
 def _cosine(a: Dict[str, float], b: Dict[str, float]) -> float:
-    dot = sum(a.get(t, 0.0) * b.get(t, 0.0) for t in b)
-    norm_a = math.sqrt(sum(v*v for v in a.values()))
-    norm_b = math.sqrt(sum(v*v for v in b.values()))
+    """Cosine similarity between two sparse TF-IDF vectors."""
+    dot = sum(a.get(t, 0.0) * v for t, v in b.items())
+    norm_a = math.sqrt(sum(v * v for v in a.values()))
+    norm_b = math.sqrt(sum(v * v for v in b.values()))
     if norm_a == 0 or norm_b == 0:
         return 0.0
     return dot / (norm_a * norm_b)
+
+
+def _kmeanspp_init(
+    vectors: List[Dict[str, float]],
+    k: int,
+    rng,
+) -> List[int]:
+    """K-means++ centroid seeding for better initial spread.
+
+    Selects k diverse starting centroids by choosing each successive
+    centroid proportionally to its distance from the nearest already-chosen
+    centroid (distance = 1 − cosine similarity).
+    """
+    n = len(vectors)
+    chosen = [rng.randint(0, n - 1)]
+    for _ in range(k - 1):
+        dists = []
+        for i, vec in enumerate(vectors):
+            if i in chosen:
+                dists.append(0.0)
+            else:
+                max_sim = max(_cosine(vec, vectors[c]) for c in chosen)
+                dists.append(max(0.0, 1.0 - max_sim))
+        total = sum(dists)
+        if total == 0:
+            chosen.append(rng.randint(0, n - 1))
+            continue
+        r = rng.random() * total
+        cumulative = 0.0
+        for i, d in enumerate(dists):
+            cumulative += d
+            if cumulative >= r:
+                chosen.append(i)
+                break
+        else:
+            chosen.append(n - 1)
+    return chosen
 
 
 def _kmeans(
@@ -97,44 +152,101 @@ def _kmeans(
     max_iter: int = 100,
     seed: int = 42,
 ) -> List[int]:
-    """Lloyd's k-means on sparse TF-IDF vectors."""
+    """Lloyd's k-means on sparse TF-IDF vectors using cosine similarity.
+
+    Centres are initialised with k-means++ for better convergence.
+    Empty clusters are re-seeded with a random point to avoid degeneracy.
+
+    Returns
+    -------
+    labels : cluster index for each input vector (length == len(vectors))
+    """
+    import random
+
     n = len(vectors)
     if n == 0:
         return []
     k = min(k, n)
+    if k == 0:
+        return []
 
-    # Seeded centroid initialisation (evenly spaced)
-    import random
     rng = random.Random(seed)
-    centroid_indices = rng.sample(range(n), k)
+    centroid_indices = _kmeanspp_init(vectors, k, rng)
     centroids = [dict(vectors[i]) for i in centroid_indices]
-    labels = [0] * n
+    labels: List[int] = [-1] * n
 
     for _ in range(max_iter):
-        # Assignment
-        new_labels = []
-        for vec in vectors:
-            best = max(range(k), key=lambda c: _cosine(vec, centroids[c]))
-            new_labels.append(best)
-
+        new_labels = [
+            max(range(k), key=lambda c, v=vec: _cosine(v, centroids[c]))
+            for vec in vectors
+        ]
         if new_labels == labels:
             break
         labels = new_labels
 
-        # Update centroids
         for c in range(k):
-            members = [vectors[i] for i, l in enumerate(labels) if l == c]
+            members = [vectors[i] for i, lbl in enumerate(labels) if lbl == c]
             if not members:
-                centroids[c] = dict(vectors[rng.randint(0, n-1)])
+                centroids[c] = dict(vectors[rng.randint(0, n - 1)])
                 continue
             new_centroid: Dict[str, float] = {}
             for vec in members:
                 for t, v in vec.items():
                     new_centroid[t] = new_centroid.get(t, 0.0) + v
-            total = len(members)
-            centroids[c] = {t: v/total for t, v in new_centroid.items()}
+            m = len(members)
+            centroids[c] = {t: v / m for t, v in new_centroid.items()}
 
     return labels
+
+
+# ---------------------------------------------------------------------------
+# BibTeX parser helpers
+# ---------------------------------------------------------------------------
+
+def _bibtex_field(entry: str, field_name: str) -> str:
+    """Extract the value of a BibTeX field, handling nested braces.
+
+    Supports both brace-delimited  ``field = {value}``  and
+    quote-delimited  ``field = "value"``  forms, as well as bare numeric
+    values such as  ``year = 2020``.
+    """
+    pattern = re.compile(
+        rf'\b{re.escape(field_name)}\s*=\s*', re.IGNORECASE
+    )
+    m = pattern.search(entry)
+    if not m:
+        return ""
+    pos = m.end()
+    while pos < len(entry) and entry[pos] == ' ':
+        pos += 1
+    if pos >= len(entry):
+        return ""
+
+    start_char = entry[pos]
+    if start_char == '{':
+        depth = 0
+        result: List[str] = []
+        for ch in entry[pos:]:
+            if ch == '{':
+                depth += 1
+                if depth > 1:
+                    result.append(ch)
+            elif ch == '}':
+                depth -= 1
+                if depth == 0:
+                    break
+                result.append(ch)
+            else:
+                result.append(ch)
+        return ''.join(result).strip()
+    elif start_char == '"':
+        end = entry.find('"', pos + 1)
+        if end == -1:
+            return ""
+        return entry[pos + 1:end].strip()
+    else:
+        m2 = re.match(r'[\w\-.]+', entry[pos:])
+        return m2.group(0) if m2 else ""
 
 
 # ---------------------------------------------------------------------------
@@ -143,6 +255,28 @@ def _kmeans(
 
 @dataclass
 class Paper:
+    """A single academic paper with bibliographic metadata.
+
+    Parameters
+    ----------
+    paper_id : str
+        Unique identifier (BibTeX key, row index, or explicit id).
+    title : str
+        Paper title (required for meaningful clustering).
+    abstract : str
+        Abstract text.
+    authors : str
+        Author list as a single string.
+    year : str
+        Publication year.
+    venue : str
+        Journal or conference name.
+    doi : str
+        Digital Object Identifier.
+    keywords : str
+        Author-supplied keywords.
+    """
+
     paper_id: str
     title: str
     abstract: str = ""
@@ -154,24 +288,43 @@ class Paper:
 
     @property
     def text(self) -> str:
+        """Text fed to TF-IDF: title + abstract + keywords."""
         return f"{self.title} {self.abstract} {self.keywords}"
 
     def to_dict(self) -> dict:
         return {
-            "paper_id": self.paper_id, "title": self.title, "abstract": self.abstract,
-            "authors": self.authors, "year": self.year, "venue": self.venue,
-            "doi": self.doi, "keywords": self.keywords,
+            "paper_id": self.paper_id,
+            "title": self.title,
+            "abstract": self.abstract,
+            "authors": self.authors,
+            "year": self.year,
+            "venue": self.venue,
+            "doi": self.doi,
+            "keywords": self.keywords,
         }
 
 
 @dataclass
 class Cluster:
+    """A cluster of thematically related papers.
+
+    Parameters
+    ----------
+    cluster_id : int
+        Cluster index (0-based).
+    papers : list of Paper
+        Papers assigned to this cluster.
+    top_terms : list of str
+        Highest TF-IDF terms characterising this cluster.
+    """
+
     cluster_id: int
     papers: List[Paper] = field(default_factory=list)
     top_terms: List[str] = field(default_factory=list)
 
     @property
     def label(self) -> str:
+        """Short descriptive label using the top-3 terms."""
         return f"Cluster {self.cluster_id}: {', '.join(self.top_terms[:3])}"
 
     def to_dict(self) -> dict:
@@ -189,8 +342,46 @@ class Cluster:
 # ---------------------------------------------------------------------------
 
 class LitCluster:
-    def __init__(self, k: int = 5, max_iter: int = 100, seed: int = 42,
-                 min_term_freq: int = 2):
+    """Topic clustering of academic papers using TF-IDF and k-means.
+
+    Ingests BibTeX, CSV, or JSONL files, builds sparse TF-IDF vectors from
+    title + abstract + keywords, and partitions papers into *k* topical
+    clusters using Lloyd's algorithm with k-means++ initialisation.
+
+    Parameters
+    ----------
+    k : int
+        Number of clusters (must be ≥ 1).
+    max_iter : int
+        Maximum k-means iterations (must be ≥ 1).
+    seed : int
+        Random seed for reproducibility.
+    min_term_freq : int
+        Minimum document frequency for a term to enter the vocabulary
+        (must be ≥ 1).  Raising this value prunes very rare terms and
+        can improve cluster coherence for larger corpora.
+
+    Examples
+    --------
+    >>> lc = LitCluster.from_csv(Path("papers.csv"), k=4)
+    >>> lc.fit()
+    >>> print(lc.summary())
+    """
+
+    def __init__(
+        self,
+        k: int = 5,
+        max_iter: int = 100,
+        seed: int = 42,
+        min_term_freq: int = 2,
+    ):
+        if k < 1:
+            raise ValueError(f"k must be >= 1, got {k!r}")
+        if max_iter < 1:
+            raise ValueError(f"max_iter must be >= 1, got {max_iter!r}")
+        if min_term_freq < 1:
+            raise ValueError(f"min_term_freq must be >= 1, got {min_term_freq!r}")
+
         self.k = k
         self.max_iter = max_iter
         self.seed = seed
@@ -201,8 +392,18 @@ class LitCluster:
         self._vectors: List[Dict[str, float]] = []
         self._vocab: List[str] = []
 
+    # ------------------------------------------------------------------
+    # Loaders
+    # ------------------------------------------------------------------
+
     @classmethod
     def from_csv(cls, path: Path, **kwargs) -> "LitCluster":
+        """Load papers from a CSV file.
+
+        Expected columns (all optional except *title*): ``paper_id``,
+        ``title``, ``abstract``, ``authors``, ``year``, ``venue``,
+        ``doi``, ``keywords``.
+        """
         obj = cls(**kwargs)
         with path.open(encoding="utf-8", errors="replace", newline="") as fh:
             reader = csv.DictReader(fh)
@@ -221,6 +422,10 @@ class LitCluster:
 
     @classmethod
     def from_jsonl(cls, path: Path, **kwargs) -> "LitCluster":
+        """Load papers from a JSONL file (one JSON object per line).
+
+        Expected keys match the CSV column names above.
+        """
         obj = cls(**kwargs)
         with path.open(encoding="utf-8") as fh:
             for i, line in enumerate(fh):
@@ -242,56 +447,91 @@ class LitCluster:
 
     @classmethod
     def from_bibtex(cls, path: Path, **kwargs) -> "LitCluster":
-        """Parse a BibTeX file for titles, abstracts, keywords."""
+        """Load papers from a BibTeX (.bib) file.
+
+        Parses ``@article``, ``@inproceedings``, ``@misc``, etc. entries.
+        Supports brace- and quote-delimited field values and handles
+        nested braces (e.g. ``title = {The {ABC} Method}``).
+        """
         obj = cls(**kwargs)
         text = path.read_text(encoding="utf-8", errors="replace")
         entries = re.split(r'(?=@\w+\s*\{)', text)
         for i, entry in enumerate(entries):
             if not entry.strip() or not entry.startswith('@'):
                 continue
-            def _get(field):
-                m = re.search(rf'{field}\s*=\s*[{{"](.*?)[}}"\,]', entry, re.IGNORECASE | re.DOTALL)
-                return m.group(1).strip() if m else ""
-            m_key = re.match(r'@\w+\s*\{\s*(\S+?)[,}]', entry)
+            m_key = re.match(r'@\w+\s*\{\s*([^\s,{]+)', entry)
             key = m_key.group(1) if m_key else str(i)
+            venue = (_bibtex_field(entry, 'journal') or
+                     _bibtex_field(entry, 'booktitle'))
             obj.papers.append(Paper(
-                paper_id=key, title=_get('title'), abstract=_get('abstract'),
-                authors=_get('author'), year=_get('year'),
-                venue=_get('journal') or _get('booktitle'),
-                doi=_get('doi'), keywords=_get('keywords'),
+                paper_id=key,
+                title=_bibtex_field(entry, 'title'),
+                abstract=_bibtex_field(entry, 'abstract'),
+                authors=_bibtex_field(entry, 'author'),
+                year=_bibtex_field(entry, 'year'),
+                venue=venue,
+                doi=_bibtex_field(entry, 'doi'),
+                keywords=_bibtex_field(entry, 'keywords'),
             ))
         return obj
 
+    # ------------------------------------------------------------------
+    # Clustering
+    # ------------------------------------------------------------------
+
     def fit(self) -> "LitCluster":
+        """Vectorise papers with TF-IDF and cluster with k-means.
+
+        Returns
+        -------
+        self : LitCluster
+            Allows method chaining: ``LitCluster.from_csv(p).fit()``.
+
+        Notes
+        -----
+        Papers with an empty ``text`` property (no title, abstract, or
+        keywords) produce zero vectors and are assigned to whatever
+        cluster their zero vector maps to; they do not affect centroid
+        computation.
+        """
         if not self.papers:
             return self
+
         tokens_list = [_tokenise(p.text) for p in self.papers]
 
-        # Filter rare terms
         if self.min_term_freq > 1:
             freq: Dict[str, int] = {}
             for tokens in tokens_list:
                 for t in set(tokens):
                     freq[t] = freq.get(t, 0) + 1
-            tokens_list = [[t for t in tokens if freq.get(t, 0) >= self.min_term_freq]
-                           for tokens in tokens_list]
+            tokens_list = [
+                [t for t in tokens if freq.get(t, 0) >= self.min_term_freq]
+                for tokens in tokens_list
+            ]
 
         self._vectors, self._vocab = _tfidf(tokens_list)
         self._labels = _kmeans(self._vectors, self.k, self.max_iter, self.seed)
 
-        # Build cluster objects
-        clusters: Dict[int, List] = {}
-        for paper, label in zip(self.papers, self._labels):
-            clusters.setdefault(label, []).append(paper)
+        clusters_map: Dict[int, List[Paper]] = {}
+        for paper, lbl in zip(self.papers, self._labels):
+            clusters_map.setdefault(lbl, []).append(paper)
 
-        self.clusters = []
-        for cid in sorted(clusters):
-            top_terms = self._top_terms_for_cluster(cid, n=10)
-            self.clusters.append(Cluster(cluster_id=cid, papers=clusters[cid], top_terms=top_terms))
+        self.clusters = [
+            Cluster(
+                cluster_id=cid,
+                papers=clusters_map[cid],
+                top_terms=self._top_terms_for_cluster(cid, n=10),
+            )
+            for cid in sorted(clusters_map)
+        ]
         return self
 
     def _top_terms_for_cluster(self, cid: int, n: int = 10) -> List[str]:
-        member_vecs = [self._vectors[i] for i, l in enumerate(self._labels) if l == cid]
+        member_vecs = [
+            self._vectors[i]
+            for i, lbl in enumerate(self._labels)
+            if lbl == cid
+        ]
         if not member_vecs:
             return []
         scores: Dict[str, float] = {}
@@ -300,23 +540,46 @@ class LitCluster:
                 scores[t] = scores.get(t, 0.0) + v
         return sorted(scores, key=lambda t: -scores[t])[:n]
 
+    # ------------------------------------------------------------------
+    # Export
+    # ------------------------------------------------------------------
+
     def export_csv(self, path: Path) -> None:
+        """Write cluster assignments to a CSV file.
+
+        Columns: ``cluster_id``, ``cluster_label``, ``paper_id``,
+        ``title``, ``authors``, ``year``, ``venue``, ``doi``.
+        """
         with path.open("w", newline="", encoding="utf-8") as fh:
             w = csv.writer(fh)
-            w.writerow(["cluster_id","cluster_label","paper_id","title","authors","year","venue","doi"])
+            w.writerow(["cluster_id", "cluster_label", "paper_id",
+                        "title", "authors", "year", "venue", "doi"])
             for cluster in self.clusters:
                 for p in cluster.papers:
-                    w.writerow([cluster.cluster_id, cluster.label, p.paper_id,
-                                p.title, p.authors, p.year, p.venue, p.doi])
+                    w.writerow([
+                        cluster.cluster_id, cluster.label, p.paper_id,
+                        p.title, p.authors, p.year, p.venue, p.doi,
+                    ])
 
     def export_json(self, path: Path) -> None:
+        """Write clusters and their papers to a JSON file."""
         with path.open("w", encoding="utf-8") as fh:
-            json.dump([c.to_dict() for c in self.clusters], fh, indent=2, ensure_ascii=False)
+            json.dump(
+                [c.to_dict() for c in self.clusters],
+                fh,
+                indent=2,
+                ensure_ascii=False,
+            )
 
     def summary(self) -> str:
-        lines = [f"LitCluster: {len(self.papers)} papers in {len(self.clusters)} clusters", ""]
+        """Return a plain-text summary of clustering results."""
+        lines = [
+            f"LitCluster v{__version__}: "
+            f"{len(self.papers)} papers → {len(self.clusters)} clusters",
+            "",
+        ]
         for c in self.clusters:
-            lines.append(f"  [{c.cluster_id}] {c.label} ({len(c.papers)} papers)")
+            lines.append(f"  [{c.cluster_id}] {c.label}  ({len(c.papers)} papers)")
         return "\n".join(lines)
 
 
@@ -325,42 +588,79 @@ class LitCluster:
 # ---------------------------------------------------------------------------
 
 def _parse_args(argv=None):
-    p = argparse.ArgumentParser(prog="litcluster",
-                                description="Cluster academic papers by topic using TF-IDF + k-means.")
-    p.add_argument("input", help="Input file: CSV, JSONL, or .bib")
-    p.add_argument("-k", "--clusters", type=int, default=5, dest="k",
-                   help="Number of clusters (default: 5)")
-    p.add_argument("--format", choices=["csv","json","summary"], default="summary")
-    p.add_argument("--output", "-o", default=None, help="Output file (default: stdout/auto)")
-    p.add_argument("--seed", type=int, default=42)
-    p.add_argument("--max-iter", type=int, default=100)
-    p.add_argument("--min-freq", type=int, default=2,
-                   help="Minimum term frequency to include in vocabulary (default: 2)")
+    p = argparse.ArgumentParser(
+        prog="litcluster",
+        description=(
+            "Cluster academic papers by topic using TF-IDF + k-means.\n"
+            "Input can be a BibTeX (.bib), CSV, or JSONL file."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    p.add_argument("input", help="Input file (.bib, .csv, or .jsonl)")
+    p.add_argument(
+        "-k", "--clusters", type=int, default=5, dest="k",
+        help="Number of clusters (default: 5)",
+    )
+    p.add_argument(
+        "--format", choices=["csv", "json", "summary"], default="summary",
+        help="Output format (default: summary)",
+    )
+    p.add_argument(
+        "--output", "-o", default=None,
+        help="Output file path (default: stdout for summary, auto-named for csv/json)",
+    )
+    p.add_argument("--seed", type=int, default=42,
+                   help="Random seed (default: 42)")
+    p.add_argument("--max-iter", type=int, default=100,
+                   help="Maximum k-means iterations (default: 100)")
+    p.add_argument(
+        "--min-freq", type=int, default=2,
+        help="Minimum document frequency for vocabulary terms (default: 2)",
+    )
+    p.add_argument("--version", action="version", version=f"%(prog)s {__version__}")
     return p.parse_args(argv)
 
 
 def main(argv=None) -> int:
+    """CLI entry point. Returns 0 on success, 1 on error."""
     args = _parse_args(argv)
+
     path = Path(args.input)
     if not path.is_file():
-        print(f"Error: {path} not found", file=sys.stderr)
+        print(f"Error: file not found: {path}", file=sys.stderr)
         return 1
 
-    suffix = path.suffix.lower()
-    kwargs = dict(k=args.k, max_iter=args.max_iter, seed=args.seed, min_term_freq=args.min_freq)
-    if suffix == ".bib":
-        lc = LitCluster.from_bibtex(path, **kwargs)
-    elif suffix == ".jsonl":
-        lc = LitCluster.from_jsonl(path, **kwargs)
-    else:
-        lc = LitCluster.from_csv(path, **kwargs)
+    kwargs = dict(
+        k=args.k,
+        max_iter=args.max_iter,
+        seed=args.seed,
+        min_term_freq=args.min_freq,
+    )
 
-    lc.fit()
+    try:
+        suffix = path.suffix.lower()
+        if suffix == ".bib":
+            lc = LitCluster.from_bibtex(path, **kwargs)
+        elif suffix == ".jsonl":
+            lc = LitCluster.from_jsonl(path, **kwargs)
+        else:
+            lc = LitCluster.from_csv(path, **kwargs)
+
+        if not lc.papers:
+            print(f"Error: no papers found in {path}", file=sys.stderr)
+            return 1
+
+        lc.fit()
+
+    except (ValueError, OSError, json.JSONDecodeError) as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
 
     if args.format == "summary":
         output = lc.summary()
         if args.output:
             Path(args.output).write_text(output, encoding="utf-8")
+            print(f"Summary written to {args.output}")
         else:
             print(output)
     elif args.format == "csv":
@@ -373,6 +673,9 @@ def main(argv=None) -> int:
         print(f"Clusters written to {out}")
 
     return 0
+
+
+_cli = main  # alias used by pyproject.toml entry point
 
 
 if __name__ == "__main__":

--- a/litcluster_gui.py
+++ b/litcluster_gui.py
@@ -1,0 +1,387 @@
+#!/usr/bin/env python3
+"""
+litcluster_gui — Graphical interface for LitCluster.
+
+Launch with:
+    python litcluster_gui.py
+    litcluster-gui          # after pip install
+"""
+
+from __future__ import annotations
+
+import sys
+import threading
+from pathlib import Path
+from tkinter import filedialog, messagebox
+import tkinter as tk
+import tkinter.ttk as ttk
+
+# Support running directly from the repo without installation
+sys.path.insert(0, str(Path(__file__).parent))
+from litcluster import LitCluster, __version__
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _natural_sort_key(text: str):
+    """Sort key that handles embedded integers naturally."""
+    import re
+    parts = re.split(r'(\d+)', text)
+    return [int(p) if p.isdigit() else p.lower() for p in parts]
+
+
+# ---------------------------------------------------------------------------
+# Main application window
+# ---------------------------------------------------------------------------
+
+class LitClusterApp:
+    """Tkinter front-end for LitCluster."""
+
+    _FORMATS = ("summary", "csv", "json")
+    _PAD = {"padx": 6, "pady": 4}
+
+    def __init__(self, root: tk.Tk) -> None:
+        self.root = root
+        self.root.title(f"LitCluster {__version__} — Literature Clustering")
+        self.root.minsize(740, 560)
+        self.root.columnconfigure(0, weight=1)
+        self.root.rowconfigure(1, weight=1)
+
+        self._lc: LitCluster | None = None
+        self._input_path: Path | None = None
+
+        self._build_toolbar()
+        self._build_results()
+        self._build_statusbar()
+        self._set_status("Ready. Load a BibTeX (.bib), CSV, or JSONL file to begin.")
+
+    # ------------------------------------------------------------------
+    # UI construction
+    # ------------------------------------------------------------------
+
+    def _build_toolbar(self) -> None:
+        toolbar = ttk.Frame(self.root, padding=6)
+        toolbar.grid(row=0, column=0, sticky="ew")
+        toolbar.columnconfigure(1, weight=1)
+
+        # ---- Row 0: file selector ----
+        ttk.Label(toolbar, text="Input file:").grid(row=0, column=0, sticky="w", **self._PAD)
+
+        self._path_var = tk.StringVar()
+        path_entry = ttk.Entry(toolbar, textvariable=self._path_var, state="readonly")
+        path_entry.grid(row=0, column=1, sticky="ew", **self._PAD)
+
+        ttk.Button(toolbar, text="Browse…", command=self._browse).grid(
+            row=0, column=2, sticky="e", **self._PAD)
+
+        # ---- Row 1: parameters ----
+        params = ttk.LabelFrame(toolbar, text="Parameters", padding=4)
+        params.grid(row=1, column=0, columnspan=3, sticky="ew", pady=(4, 0))
+
+        labels_vars = [
+            ("Clusters (k):", "k_var", 5, 1, 99),
+            ("Seed:", "seed_var", 42, 0, 9999),
+            ("Max iterations:", "iter_var", 100, 1, 9999),
+            ("Min term freq:", "freq_var", 2, 1, 999),
+        ]
+        self.k_var = tk.IntVar(value=5)
+        self.seed_var = tk.IntVar(value=42)
+        self.iter_var = tk.IntVar(value=100)
+        self.freq_var = tk.IntVar(value=2)
+
+        spin_cfg = [
+            ("Clusters (k):", self.k_var, 1, 99),
+            ("Seed:", self.seed_var, 0, 9999),
+            ("Max iterations:", self.iter_var, 1, 9999),
+            ("Min term freq:", self.freq_var, 1, 999),
+        ]
+        for col, (lbl, var, lo, hi) in enumerate(spin_cfg):
+            ttk.Label(params, text=lbl).grid(row=0, column=col * 2, sticky="e", padx=(8, 2))
+            sb = ttk.Spinbox(params, textvariable=var, from_=lo, to=hi, width=6)
+            sb.grid(row=0, column=col * 2 + 1, sticky="w", padx=(0, 8))
+
+        # ---- Row 2: run + export ----
+        actions = ttk.Frame(toolbar)
+        actions.grid(row=2, column=0, columnspan=3, sticky="ew", pady=(6, 0))
+
+        self._run_btn = ttk.Button(
+            actions, text="▶  Run Clustering", command=self._run_async,
+        )
+        self._run_btn.pack(side="left", padx=(0, 12))
+
+        ttk.Separator(actions, orient="vertical").pack(side="left", fill="y", padx=6)
+
+        ttk.Label(actions, text="Export:").pack(side="left", padx=(0, 4))
+        ttk.Button(actions, text="CSV", command=lambda: self._export("csv")).pack(
+            side="left", padx=2)
+        ttk.Button(actions, text="JSON", command=lambda: self._export("json")).pack(
+            side="left", padx=2)
+        ttk.Button(actions, text="Summary TXT", command=lambda: self._export("summary")).pack(
+            side="left", padx=2)
+
+    def _build_results(self) -> None:
+        nb = ttk.Notebook(self.root)
+        nb.grid(row=1, column=0, sticky="nsew", padx=6, pady=4)
+        self._notebook = nb
+
+        # ---- Summary tab ----
+        summary_frame = ttk.Frame(nb, padding=4)
+        nb.add(summary_frame, text="Summary")
+        summary_frame.columnconfigure(0, weight=1)
+        summary_frame.rowconfigure(0, weight=1)
+
+        self._summary_text = tk.Text(
+            summary_frame, wrap="word", font=("Courier", 10),
+            state="disabled", relief="flat",
+        )
+        sb1 = ttk.Scrollbar(summary_frame, command=self._summary_text.yview)
+        self._summary_text.configure(yscrollcommand=sb1.set)
+        self._summary_text.grid(row=0, column=0, sticky="nsew")
+        sb1.grid(row=0, column=1, sticky="ns")
+
+        # ---- Clusters tab ----
+        cluster_frame = ttk.Frame(nb, padding=4)
+        nb.add(cluster_frame, text="Clusters")
+        cluster_frame.columnconfigure(0, weight=1)
+        cluster_frame.rowconfigure(0, weight=1)
+
+        cols = ("cluster", "size", "top_terms")
+        self._cluster_tree = ttk.Treeview(
+            cluster_frame, columns=cols, show="headings", height=10,
+        )
+        self._cluster_tree.heading("cluster", text="Cluster")
+        self._cluster_tree.heading("size", text="Papers")
+        self._cluster_tree.heading("top_terms", text="Top Terms")
+        self._cluster_tree.column("cluster", width=130, anchor="w")
+        self._cluster_tree.column("size", width=60, anchor="center")
+        self._cluster_tree.column("top_terms", width=420, anchor="w")
+        sb2 = ttk.Scrollbar(cluster_frame, command=self._cluster_tree.yview)
+        self._cluster_tree.configure(yscrollcommand=sb2.set)
+        self._cluster_tree.grid(row=0, column=0, sticky="nsew")
+        sb2.grid(row=0, column=1, sticky="ns")
+        self._cluster_tree.bind("<<TreeviewSelect>>", self._on_cluster_select)
+
+        # ---- Papers tab ----
+        papers_frame = ttk.Frame(nb, padding=4)
+        nb.add(papers_frame, text="Papers")
+        papers_frame.columnconfigure(0, weight=1)
+        papers_frame.rowconfigure(0, weight=1)
+
+        pcols = ("cluster", "paper_id", "title", "year", "authors")
+        self._papers_tree = ttk.Treeview(
+            papers_frame, columns=pcols, show="headings", height=18,
+        )
+        for col, w in zip(pcols, (100, 100, 320, 55, 160)):
+            self._papers_tree.heading(col, text=col.replace("_", " ").title())
+            self._papers_tree.column(col, width=w, anchor="w")
+        sb3 = ttk.Scrollbar(papers_frame, command=self._papers_tree.yview)
+        self._papers_tree.configure(yscrollcommand=sb3.set)
+        self._papers_tree.grid(row=0, column=0, sticky="nsew")
+        sb3.grid(row=0, column=1, sticky="ns")
+
+    def _build_statusbar(self) -> None:
+        bar = ttk.Frame(self.root, relief="sunken", padding=(6, 2))
+        bar.grid(row=2, column=0, sticky="ew")
+        bar.columnconfigure(0, weight=1)
+
+        self._status_var = tk.StringVar(value="Ready")
+        ttk.Label(bar, textvariable=self._status_var, anchor="w").grid(
+            row=0, column=0, sticky="ew")
+
+        self._progress = ttk.Progressbar(bar, mode="indeterminate", length=120)
+        self._progress.grid(row=0, column=1, sticky="e", padx=(8, 0))
+
+    # ------------------------------------------------------------------
+    # Event handlers
+    # ------------------------------------------------------------------
+
+    def _browse(self) -> None:
+        filetypes = [
+            ("Supported files", "*.bib *.csv *.jsonl"),
+            ("BibTeX files", "*.bib"),
+            ("CSV files", "*.csv"),
+            ("JSONL files", "*.jsonl"),
+            ("All files", "*.*"),
+        ]
+        path = filedialog.askopenfilename(
+            title="Select input file", filetypes=filetypes,
+        )
+        if path:
+            self._path_var.set(path)
+            self._input_path = Path(path)
+            self._set_status(f"Loaded: {path}")
+
+    def _run_async(self) -> None:
+        if not self._input_path or not self._input_path.is_file():
+            messagebox.showerror("No file", "Please select a valid input file first.")
+            return
+        try:
+            k = self.k_var.get()
+            seed = self.seed_var.get()
+            max_iter = self.iter_var.get()
+            min_freq = self.freq_var.get()
+        except tk.TclError:
+            messagebox.showerror("Invalid parameters", "All parameters must be integers.")
+            return
+
+        self._run_btn.configure(state="disabled")
+        self._progress.start(10)
+        self._set_status("Clustering…")
+        threading.Thread(
+            target=self._run_clustering,
+            args=(k, seed, max_iter, min_freq),
+            daemon=True,
+        ).start()
+
+    def _run_clustering(self, k: int, seed: int, max_iter: int, min_freq: int) -> None:
+        try:
+            path = self._input_path
+            kwargs = dict(k=k, seed=seed, max_iter=max_iter, min_term_freq=min_freq)
+            suffix = path.suffix.lower()
+            if suffix == ".bib":
+                lc = LitCluster.from_bibtex(path, **kwargs)
+            elif suffix == ".jsonl":
+                lc = LitCluster.from_jsonl(path, **kwargs)
+            else:
+                lc = LitCluster.from_csv(path, **kwargs)
+
+            if not lc.papers:
+                raise ValueError("No papers found in the input file.")
+
+            lc.fit()
+            self._lc = lc
+            self.root.after(0, self._display_results)
+        except Exception as exc:
+            self.root.after(0, lambda: self._on_error(str(exc)))
+
+    def _on_cluster_select(self, _event=None) -> None:
+        """When a cluster row is selected, jump to Papers tab filtered by it."""
+        selection = self._cluster_tree.selection()
+        if not selection or self._lc is None:
+            return
+        item = self._cluster_tree.item(selection[0])
+        cid_str = item["values"][0]
+        # cid_str is like "Cluster 2: term1, term2, term3" — parse the integer
+        import re
+        m = re.match(r"Cluster\s+(\d+)", str(cid_str))
+        if not m:
+            return
+        cid = int(m.group(1))
+        self._populate_papers(filter_cid=cid)
+        self._notebook.select(2)  # switch to Papers tab
+
+    # ------------------------------------------------------------------
+    # Result population
+    # ------------------------------------------------------------------
+
+    def _display_results(self) -> None:
+        self._progress.stop()
+        self._run_btn.configure(state="normal")
+        lc = self._lc
+        n_papers = len(lc.papers)
+        n_clusters = len(lc.clusters)
+        self._set_status(
+            f"Done: {n_papers} papers → {n_clusters} clusters  "
+            f"(k={lc.k}, seed={lc.seed})"
+        )
+
+        # Summary tab
+        self._summary_text.configure(state="normal")
+        self._summary_text.delete("1.0", "end")
+        self._summary_text.insert("end", lc.summary())
+        self._summary_text.configure(state="disabled")
+
+        # Clusters tab
+        for row in self._cluster_tree.get_children():
+            self._cluster_tree.delete(row)
+        for c in lc.clusters:
+            self._cluster_tree.insert(
+                "", "end",
+                values=(c.label, len(c.papers), ", ".join(c.top_terms)),
+            )
+
+        # Papers tab (all)
+        self._populate_papers()
+        self._notebook.select(0)
+
+    def _populate_papers(self, filter_cid: int | None = None) -> None:
+        for row in self._papers_tree.get_children():
+            self._papers_tree.delete(row)
+        if self._lc is None:
+            return
+        for c in self._lc.clusters:
+            if filter_cid is not None and c.cluster_id != filter_cid:
+                continue
+            tag = f"c{c.cluster_id % 2}"
+            for p in c.papers:
+                self._papers_tree.insert(
+                    "", "end", tags=(tag,),
+                    values=(c.cluster_id, p.paper_id, p.title, p.year, p.authors),
+                )
+        self._papers_tree.tag_configure("c0", background="#f0f4ff")
+        self._papers_tree.tag_configure("c1", background="#ffffff")
+
+    # ------------------------------------------------------------------
+    # Export
+    # ------------------------------------------------------------------
+
+    def _export(self, fmt: str) -> None:
+        if self._lc is None:
+            messagebox.showinfo("No results", "Run clustering first.")
+            return
+        if fmt == "csv":
+            path = filedialog.asksaveasfilename(
+                defaultextension=".csv",
+                filetypes=[("CSV files", "*.csv"), ("All files", "*.*")],
+                title="Export CSV",
+            )
+            if path:
+                self._lc.export_csv(Path(path))
+                self._set_status(f"Exported CSV → {path}")
+        elif fmt == "json":
+            path = filedialog.asksaveasfilename(
+                defaultextension=".json",
+                filetypes=[("JSON files", "*.json"), ("All files", "*.*")],
+                title="Export JSON",
+            )
+            if path:
+                self._lc.export_json(Path(path))
+                self._set_status(f"Exported JSON → {path}")
+        elif fmt == "summary":
+            path = filedialog.asksaveasfilename(
+                defaultextension=".txt",
+                filetypes=[("Text files", "*.txt"), ("All files", "*.*")],
+                title="Export Summary",
+            )
+            if path:
+                Path(path).write_text(self._lc.summary(), encoding="utf-8")
+                self._set_status(f"Exported summary → {path}")
+
+    # ------------------------------------------------------------------
+    # Utilities
+    # ------------------------------------------------------------------
+
+    def _on_error(self, msg: str) -> None:
+        self._progress.stop()
+        self._run_btn.configure(state="normal")
+        self._set_status(f"Error: {msg}")
+        messagebox.showerror("Clustering error", msg)
+
+    def _set_status(self, msg: str) -> None:
+        self._status_var.set(msg)
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    root = tk.Tk()
+    app = LitClusterApp(root)
+    root.mainloop()
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,8 @@ classifiers = [
 ]
 
 [project.scripts]
-litcluster = "litcluster:_cli"
+litcluster = "litcluster:main"
+litcluster-gui = "litcluster_gui:main"
 
 [tool.setuptools]
-py-modules = ["litcluster"]
+py-modules = ["litcluster", "litcluster_gui"]

--- a/src/litcluster/__init__.py
+++ b/src/litcluster/__init__.py
@@ -1,18 +1,34 @@
 """
 litcluster: Semantic clustering and topic modelling of scientific literature.
 
-Ingests collections of scientific abstracts or full papers (via DOI lists,
-BibTeX files, or arXiv IDs), embeds them using sentence-transformers, and
-applies hierarchical clustering and topic modelling to produce interactive
-visualisations and structured cluster summaries for systematic literature
-reviews.
+Ingests BibTeX files, CSV tables, or JSONL records; builds sparse TF-IDF
+vectors from title + abstract + keywords; and partitions papers into k
+topical clusters using Lloyd's algorithm with k-means++ initialisation.
+Outputs plain-text summaries, CSV, or JSON — no external dependencies.
 """
 
-__version__ = "0.1.0"
-__author__ = "Vaibhav Deshmukh"
-__license__ = "MIT"
+from litcluster import (  # noqa: F401
+    LitCluster,
+    Paper,
+    Cluster,
+    __version__,
+    _tokenise,
+    _tfidf,
+    _cosine,
+    _kmeans,
+    _bibtex_field,
+    main,
+)
 
-from .cluster import LitCluster
-from .embed import PaperEmbedder
-
-__all__ = ["LitCluster", "PaperEmbedder"]
+__all__ = [
+    "LitCluster",
+    "Paper",
+    "Cluster",
+    "__version__",
+    "_tokenise",
+    "_tfidf",
+    "_cosine",
+    "_kmeans",
+    "_bibtex_field",
+    "main",
+]

--- a/tests/test_litcluster.py
+++ b/tests/test_litcluster.py
@@ -1,19 +1,570 @@
-import sys, pathlib
-sys.path.insert(0, str(pathlib.Path(__file__).parent.parent))
+"""Tests for litcluster.py — JOSS quality checks."""
 
-def test_import():
-    import litcluster as lc
-    assert hasattr(lc, 'LitCluster')
+from __future__ import annotations
 
-def test_paper():
-    import litcluster as lc
-    assert hasattr(lc, 'Paper')
+import csv
+import json
+import math
+import sys
+import textwrap
+from pathlib import Path
 
-def test_cluster():
-    import litcluster as lc
-    assert hasattr(lc, 'Cluster')
+import pytest
 
-def test_tokenise():
-    import litcluster as lc
-    tokens = lc._tokenise('hello world test foo bar')
-    assert isinstance(tokens, list) and len(tokens) > 0
+# Allow running from repo root without installation
+sys.path.insert(0, str(Path(__file__).parent.parent))
+import litcluster as lc
+from litcluster import (
+    LitCluster, Paper, Cluster,
+    _tokenise, _tfidf, _cosine, _kmeans, _bibtex_field,
+    __version__,
+)
+
+
+# ---------------------------------------------------------------------------
+# _tokenise
+# ---------------------------------------------------------------------------
+
+class TestTokenise:
+    def test_basic(self):
+        tokens = _tokenise("Machine learning neural network")
+        assert "machine" in tokens
+        assert "learning" in tokens
+        assert "neural" in tokens
+        assert "network" in tokens
+
+    def test_stopwords_removed(self):
+        tokens = _tokenise("the cat sat on the mat")
+        assert "the" not in tokens
+        assert "on" not in tokens
+
+    def test_short_tokens_excluded(self):
+        tokens = _tokenise("go do it ok no")  # all < 3 chars
+        assert tokens == []
+
+    def test_case_normalisation(self):
+        assert _tokenise("CLUSTERING") == _tokenise("clustering")
+
+    def test_non_alpha_stripped(self):
+        tokens = _tokenise("deep-learning: 2024 (special)")
+        assert "deep" in tokens
+        assert "learning" in tokens
+        assert "2024" not in tokens
+
+    def test_empty_string(self):
+        assert _tokenise("") == []
+
+    def test_returns_list(self):
+        assert isinstance(_tokenise("hello world test"), list)
+
+
+# ---------------------------------------------------------------------------
+# _tfidf
+# ---------------------------------------------------------------------------
+
+class TestTfidf:
+    def test_empty_input(self):
+        vecs, vocab = _tfidf([])
+        assert vecs == []
+        assert vocab == []
+
+    def test_single_document(self):
+        vecs, vocab = _tfidf([["cat", "dog", "cat"]])
+        assert len(vecs) == 1
+        assert "cat" in vecs[0]
+        assert "dog" in vecs[0]
+
+    def test_vector_count_matches_documents(self):
+        docs = [["a", "b"], ["b", "c"], ["c", "d"]]
+        vecs, vocab = _tfidf(docs)
+        assert len(vecs) == 3
+
+    def test_vocab_sorted(self):
+        docs = [["zebra", "apple", "mango"]]
+        _, vocab = _tfidf(docs)
+        assert vocab == sorted(vocab)
+
+    def test_rare_term_has_higher_idf(self):
+        # "rare" appears only in one document; "common" appears in all three
+        docs = [
+            ["common", "rare"],
+            ["common"],
+            ["common"],
+        ]
+        vecs, _ = _tfidf(docs)
+        # For doc 0: tf("rare") == tf("common") == 0.5, but idf("rare") > idf("common")
+        assert vecs[0]["rare"] > vecs[0]["common"]
+
+    def test_all_values_non_negative(self):
+        docs = [["alpha", "beta"], ["beta", "gamma"]]
+        vecs, _ = _tfidf(docs)
+        for vec in vecs:
+            for v in vec.values():
+                assert v >= 0
+
+
+# ---------------------------------------------------------------------------
+# _cosine
+# ---------------------------------------------------------------------------
+
+class TestCosine:
+    def test_identical_vectors(self):
+        v = {"a": 1.0, "b": 2.0}
+        assert abs(_cosine(v, v) - 1.0) < 1e-9
+
+    def test_orthogonal_vectors(self):
+        a = {"x": 1.0}
+        b = {"y": 1.0}
+        assert _cosine(a, b) == 0.0
+
+    def test_zero_vector(self):
+        a = {"x": 0.0}
+        b = {"x": 1.0}
+        assert _cosine(a, b) == 0.0
+
+    def test_empty_vectors(self):
+        assert _cosine({}, {}) == 0.0
+
+    def test_symmetry(self):
+        a = {"a": 1.0, "b": 3.0}
+        b = {"b": 2.0, "c": 1.0}
+        assert abs(_cosine(a, b) - _cosine(b, a)) < 1e-12
+
+    def test_range(self):
+        a = {"x": 2.0, "y": 1.0}
+        b = {"x": 1.0, "y": 3.0}
+        sim = _cosine(a, b)
+        assert 0.0 <= sim <= 1.0
+
+
+# ---------------------------------------------------------------------------
+# _kmeans
+# ---------------------------------------------------------------------------
+
+class TestKmeans:
+    def _make_vecs(self):
+        """Two well-separated clusters of 4 docs each."""
+        group_a = [{"cat": 1.0, "dog": 0.8} for _ in range(4)]
+        group_b = [{"deep": 1.0, "neural": 0.9} for _ in range(4)]
+        return group_a + group_b
+
+    def test_empty_input(self):
+        assert _kmeans([], k=3) == []
+
+    def test_k_larger_than_n_clips(self):
+        vecs = [{"x": 1.0}, {"y": 1.0}]
+        labels = _kmeans(vecs, k=10)
+        assert len(labels) == 2
+
+    def test_k_equals_1(self):
+        vecs = [{"a": 1.0}, {"b": 1.0}, {"c": 1.0}]
+        labels = _kmeans(vecs, k=1)
+        assert all(lbl == 0 for lbl in labels)
+
+    def test_label_count_matches_input(self):
+        vecs = self._make_vecs()
+        labels = _kmeans(vecs, k=2)
+        assert len(labels) == len(vecs)
+
+    def test_separable_clusters(self):
+        vecs = self._make_vecs()
+        labels = _kmeans(vecs, k=2, seed=0)
+        # First 4 should share a label; last 4 should share the other
+        assert len(set(labels[:4])) == 1
+        assert len(set(labels[4:])) == 1
+        assert labels[0] != labels[4]
+
+    def test_reproducible_with_seed(self):
+        vecs = self._make_vecs()
+        assert _kmeans(vecs, k=2, seed=7) == _kmeans(vecs, k=2, seed=7)
+
+    def test_different_seeds_may_differ(self):
+        vecs = [{"a": float(i)} for i in range(10)]
+        r1 = _kmeans(vecs, k=3, seed=1)
+        r2 = _kmeans(vecs, k=3, seed=2)
+        # Not a guaranteed difference, but with very different seeds on
+        # spread-out data they should diverge
+        assert isinstance(r1, list) and isinstance(r2, list)
+
+
+# ---------------------------------------------------------------------------
+# _bibtex_field
+# ---------------------------------------------------------------------------
+
+class TestBibtexField:
+    def test_brace_delimited(self):
+        entry = '@article{key, title = {My Paper Title}, year = {2020}}'
+        assert _bibtex_field(entry, 'title') == 'My Paper Title'
+
+    def test_quote_delimited(self):
+        entry = '@article{key, title = "My Paper Title", year = "2020"}'
+        assert _bibtex_field(entry, 'title') == 'My Paper Title'
+
+    def test_bare_year(self):
+        entry = '@article{key, year = 2021, author = {Smith}}'
+        assert _bibtex_field(entry, 'year') == '2021'
+
+    def test_nested_braces(self):
+        entry = '@article{key, title = {The {ABC} Method}, year = {2020}}'
+        assert _bibtex_field(entry, 'title') == 'The {ABC} Method'
+
+    def test_missing_field_returns_empty(self):
+        entry = '@article{key, title = {Foo}}'
+        assert _bibtex_field(entry, 'abstract') == ''
+
+    def test_case_insensitive(self):
+        entry = '@article{key, TITLE = {Caps Title}}'
+        assert _bibtex_field(entry, 'title') == 'Caps Title'
+
+
+# ---------------------------------------------------------------------------
+# Paper
+# ---------------------------------------------------------------------------
+
+class TestPaper:
+    def test_text_property(self):
+        p = Paper(paper_id="1", title="Deep Learning",
+                  abstract="Neural networks", keywords="classification")
+        assert "Deep Learning" in p.text
+        assert "Neural networks" in p.text
+        assert "classification" in p.text
+
+    def test_to_dict_keys(self):
+        p = Paper(paper_id="1", title="T")
+        d = p.to_dict()
+        for key in ("paper_id", "title", "abstract", "authors", "year", "venue", "doi", "keywords"):
+            assert key in d
+
+    def test_defaults_are_empty_strings(self):
+        p = Paper(paper_id="x", title="T")
+        assert p.abstract == ""
+        assert p.doi == ""
+
+
+# ---------------------------------------------------------------------------
+# Cluster
+# ---------------------------------------------------------------------------
+
+class TestCluster:
+    def test_label_format(self):
+        c = Cluster(cluster_id=2, top_terms=["alpha", "beta", "gamma", "delta"])
+        assert c.label == "Cluster 2: alpha, beta, gamma"
+
+    def test_to_dict_includes_papers(self):
+        papers = [Paper(paper_id="1", title="A"), Paper(paper_id="2", title="B")]
+        c = Cluster(cluster_id=0, papers=papers, top_terms=["foo"])
+        d = c.to_dict()
+        assert d["size"] == 2
+        assert len(d["papers"]) == 2
+
+    def test_empty_top_terms_label(self):
+        c = Cluster(cluster_id=0)
+        assert "Cluster 0" in c.label
+
+
+# ---------------------------------------------------------------------------
+# LitCluster — construction and validation
+# ---------------------------------------------------------------------------
+
+class TestLitClusterInit:
+    def test_defaults(self):
+        lc = LitCluster()
+        assert lc.k == 5
+        assert lc.seed == 42
+
+    def test_invalid_k_raises(self):
+        with pytest.raises(ValueError, match="k"):
+            LitCluster(k=0)
+
+    def test_invalid_max_iter_raises(self):
+        with pytest.raises(ValueError, match="max_iter"):
+            LitCluster(max_iter=0)
+
+    def test_invalid_min_term_freq_raises(self):
+        with pytest.raises(ValueError, match="min_term_freq"):
+            LitCluster(min_term_freq=0)
+
+    def test_fit_empty_papers_returns_self(self):
+        obj = LitCluster()
+        result = obj.fit()
+        assert result is obj
+        assert obj.clusters == []
+
+
+# ---------------------------------------------------------------------------
+# LitCluster — loaders (via tmp files)
+# ---------------------------------------------------------------------------
+
+class TestLitClusterLoaders:
+    def test_from_csv(self, tmp_path):
+        f = tmp_path / "papers.csv"
+        f.write_text(
+            "paper_id,title,abstract,authors,year,venue,doi,keywords\n"
+            "1,Machine Learning,An intro to ML,Smith,2020,ICML,,supervised\n"
+            "2,Deep Networks,A paper on deep nets,Jones,2021,NeurIPS,,unsupervised\n",
+            encoding="utf-8",
+        )
+        obj = LitCluster.from_csv(f)
+        assert len(obj.papers) == 2
+        assert obj.papers[0].title == "Machine Learning"
+
+    def test_from_csv_missing_columns(self, tmp_path):
+        f = tmp_path / "minimal.csv"
+        f.write_text("title\nOnly Title\n", encoding="utf-8")
+        obj = LitCluster.from_csv(f)
+        assert len(obj.papers) == 1
+        assert obj.papers[0].abstract == ""
+
+    def test_from_jsonl(self, tmp_path):
+        f = tmp_path / "papers.jsonl"
+        f.write_text(
+            '{"paper_id":"p1","title":"Clustering Methods","abstract":"K-means and DBSCAN"}\n'
+            '{"paper_id":"p2","title":"Topic Modelling","abstract":"LDA and NMF approaches"}\n',
+            encoding="utf-8",
+        )
+        obj = LitCluster.from_jsonl(f)
+        assert len(obj.papers) == 2
+        assert obj.papers[1].title == "Topic Modelling"
+
+    def test_from_jsonl_skips_blank_lines(self, tmp_path):
+        f = tmp_path / "papers.jsonl"
+        f.write_text(
+            '{"title":"A"}\n\n{"title":"B"}\n',
+            encoding="utf-8",
+        )
+        obj = LitCluster.from_jsonl(f)
+        assert len(obj.papers) == 2
+
+    def test_from_bibtex(self, tmp_path):
+        bib = textwrap.dedent("""\
+            @article{smith2020,
+              title  = {A Survey of Deep Learning},
+              author = {Smith, J.},
+              year   = {2020},
+              journal = {Nature},
+              abstract = {Deep learning has transformed AI.},
+            }
+            @inproceedings{jones2021,
+              title   = {Efficient Transformers},
+              author  = {Jones, A.},
+              year    = {2021},
+              booktitle = {NeurIPS},
+              abstract  = {We propose efficient transformer models.},
+            }
+        """)
+        f = tmp_path / "refs.bib"
+        f.write_text(bib, encoding="utf-8")
+        obj = LitCluster.from_bibtex(f)
+        assert len(obj.papers) == 2
+        titles = {p.title for p in obj.papers}
+        assert "A Survey of Deep Learning" in titles
+        assert "Efficient Transformers" in titles
+
+    def test_from_bibtex_nested_braces(self, tmp_path):
+        bib = textwrap.dedent("""\
+            @article{key,
+              title = {The {BERT} Model for NLP},
+              year  = {2019},
+            }
+        """)
+        f = tmp_path / "refs.bib"
+        f.write_text(bib, encoding="utf-8")
+        obj = LitCluster.from_bibtex(f)
+        assert "BERT" in obj.papers[0].title
+
+
+# ---------------------------------------------------------------------------
+# LitCluster — fit and clustering behaviour
+# ---------------------------------------------------------------------------
+
+class TestLitClusterFit:
+    def _make_lc(self, n_per_topic=6, k=2):
+        """Two clearly distinct topic groups."""
+        papers = []
+        for i in range(n_per_topic):
+            papers.append(Paper(
+                paper_id=f"ml{i}",
+                title="Machine Learning Classification",
+                abstract="Support vector machines decision trees random forests supervised learning",
+            ))
+        for i in range(n_per_topic):
+            papers.append(Paper(
+                paper_id=f"bio{i}",
+                title="Protein Structure Prediction",
+                abstract="Amino acids folding molecular dynamics bioinformatics genomics",
+            ))
+        obj = LitCluster(k=k, seed=0, min_term_freq=1)
+        obj.papers = papers
+        return obj
+
+    def test_fit_returns_self(self):
+        obj = self._make_lc()
+        assert obj.fit() is obj
+
+    def test_correct_cluster_count(self):
+        obj = self._make_lc(k=2).fit()
+        assert len(obj.clusters) == 2
+
+    def test_cluster_sizes_sum_to_total(self):
+        obj = self._make_lc(n_per_topic=5, k=2).fit()
+        total = sum(len(c.papers) for c in obj.clusters)
+        assert total == 10
+
+    def test_top_terms_populated(self):
+        obj = self._make_lc(k=2).fit()
+        for c in obj.clusters:
+            assert len(c.top_terms) > 0
+
+    def test_separable_topics_assigned_correctly(self):
+        obj = self._make_lc(n_per_topic=8, k=2).fit()
+        for cluster in obj.clusters:
+            ids = {p.paper_id[:2] for p in cluster.papers}
+            assert len(ids) == 1, "mixed topics ended up in the same cluster"
+
+    def test_k_larger_than_papers_clamps(self):
+        obj = LitCluster(k=20, min_term_freq=1)
+        obj.papers = [Paper(paper_id=str(i), title=f"Paper {i}") for i in range(3)]
+        obj.fit()
+        assert len(obj.clusters) <= 3
+
+    def test_min_term_freq_1_uses_all_terms(self):
+        obj = LitCluster(k=1, min_term_freq=1)
+        obj.papers = [
+            Paper(paper_id="a", title="unique rare obscure"),
+            Paper(paper_id="b", title="common shared frequent"),
+        ]
+        obj.fit()
+        assert len(obj.clusters) == 1
+
+
+# ---------------------------------------------------------------------------
+# LitCluster — export
+# ---------------------------------------------------------------------------
+
+class TestLitClusterExport:
+    def _fitted_lc(self):
+        obj = LitCluster(k=2, seed=0, min_term_freq=1)
+        obj.papers = [
+            Paper(paper_id="1", title="Neural Network Deep Learning", abstract="Backprop gradient"),
+            Paper(paper_id="2", title="Neural Network Classification", abstract="SVM features"),
+            Paper(paper_id="3", title="Protein Folding Structure", abstract="Molecular dynamics"),
+            Paper(paper_id="4", title="Genome Sequencing Analysis", abstract="Bioinformatics pipeline"),
+        ]
+        return obj.fit()
+
+    def test_export_csv_creates_file(self, tmp_path):
+        out = tmp_path / "out.csv"
+        self._fitted_lc().export_csv(out)
+        assert out.exists()
+
+    def test_export_csv_has_header(self, tmp_path):
+        out = tmp_path / "out.csv"
+        self._fitted_lc().export_csv(out)
+        rows = list(csv.reader(out.read_text(encoding="utf-8").splitlines()))
+        assert rows[0][0] == "cluster_id"
+        assert "title" in rows[0]
+
+    def test_export_csv_row_count(self, tmp_path):
+        out = tmp_path / "out.csv"
+        lc_obj = self._fitted_lc()
+        lc_obj.export_csv(out)
+        rows = list(csv.reader(out.read_text(encoding="utf-8").splitlines()))
+        assert len(rows) == 1 + len(lc_obj.papers)  # header + one row per paper
+
+    def test_export_json_creates_file(self, tmp_path):
+        out = tmp_path / "out.json"
+        self._fitted_lc().export_json(out)
+        assert out.exists()
+
+    def test_export_json_valid_structure(self, tmp_path):
+        out = tmp_path / "out.json"
+        lc_obj = self._fitted_lc()
+        lc_obj.export_json(out)
+        data = json.loads(out.read_text(encoding="utf-8"))
+        assert isinstance(data, list)
+        for cluster in data:
+            assert "cluster_id" in cluster
+            assert "papers" in cluster
+            assert "top_terms" in cluster
+
+    def test_summary_contains_paper_count(self):
+        lc_obj = self._fitted_lc()
+        s = lc_obj.summary()
+        assert "4" in s
+
+    def test_summary_contains_cluster_count(self):
+        lc_obj = self._fitted_lc()
+        s = lc_obj.summary()
+        assert "2" in s
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+class TestCLI:
+    def test_cli_summary(self, tmp_path, capsys):
+        f = tmp_path / "papers.csv"
+        f.write_text(
+            "title,abstract\n"
+            + "\n".join(
+                f"Paper {i},Abstract about topic {i % 2}" for i in range(10)
+            ),
+            encoding="utf-8",
+        )
+        from litcluster import main
+        rc = main([str(f), "-k", "2", "--min-freq", "1"])
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "papers" in out.lower() or "cluster" in out.lower()
+
+    def test_cli_missing_file(self, capsys):
+        from litcluster import main
+        rc = main(["nonexistent_file.csv"])
+        assert rc == 1
+
+    def test_cli_json_output(self, tmp_path):
+        f = tmp_path / "papers.csv"
+        f.write_text(
+            "title,abstract\n"
+            + "\n".join(f"Paper {i},Text {i}" for i in range(6)),
+            encoding="utf-8",
+        )
+        out = tmp_path / "result.json"
+        from litcluster import main
+        rc = main([str(f), "-k", "2", "--format", "json", "-o", str(out), "--min-freq", "1"])
+        assert rc == 0
+        assert out.exists()
+        data = json.loads(out.read_text(encoding="utf-8"))
+        assert isinstance(data, list)
+
+    def test_cli_csv_output(self, tmp_path):
+        f = tmp_path / "papers.csv"
+        f.write_text(
+            "title,abstract\n" + "\n".join(f"Paper {i},Text {i}" for i in range(6)),
+            encoding="utf-8",
+        )
+        out = tmp_path / "result.csv"
+        from litcluster import main
+        rc = main([str(f), "-k", "2", "--format", "csv", "-o", str(out), "--min-freq", "1"])
+        assert rc == 0
+        assert out.exists()
+
+
+# ---------------------------------------------------------------------------
+# Module-level attributes (JOSS: importable, versioned)
+# ---------------------------------------------------------------------------
+
+def test_version_string():
+    assert isinstance(__version__, str)
+    parts = __version__.split(".")
+    assert len(parts) == 3
+    assert all(p.isdigit() for p in parts)
+
+def test_public_api():
+    for name in ("LitCluster", "Paper", "Cluster"):
+        assert hasattr(lc, name)
+
+def test_private_helpers_accessible():
+    for name in ("_tokenise", "_tfidf", "_cosine", "_kmeans"):
+        assert hasattr(lc, name)


### PR DESCRIPTION
## Summary

- **Fix broken entry point** — `pyproject.toml` referenced `litcluster:_cli` which did not exist; now correctly points to `litcluster:main` (and `_cli` alias is defined for safety).
- **Fix `src/litcluster/__init__.py`** — was importing `.cluster` and `.embed` sub-modules that never existed; replaced with re-exports from the actual installed module.
- **Fix BibTeX parser** — replaced fragile single-regex approach with a proper nested-brace parser (`_bibtex_field`), correctly handling `title = {The {BERT} Model}` and similar.
- **K-means++ seeding** — replaced evenly-spaced centroid initialisation with k-means++ for better convergence and more coherent clusters.
- **Input validation** — `LitCluster.__init__` now raises `ValueError` with clear messages for `k < 1`, `max_iter < 1`, `min_term_freq < 1`.
- **Variable naming** — renamed ambiguous loop variable `l` → `lbl` throughout k-means.
- **Error handling** — CLI wraps `fit()` / loader calls in try/except and returns exit code 1 with a readable message.
- **Docstrings** — all public classes, methods, and module-level helpers now have NumPy-style docstrings.
- **`__version__`** — added to module and surfaced in `--version` flag and `summary()` output.
- **Tkinter GUI (`litcluster_gui.py`)** — new standalone GUI with file browser, parameter spinboxes, threaded clustering (UI stays responsive), tabbed results (Summary / Clusters / Papers), cluster-click drill-down to paper list, and one-click CSV / JSON / TXT export. Registered as `litcluster-gui` entry point.
- **Tests** — expanded from 4 smoke tests to **70 tests** covering `_tokenise`, `_tfidf`, `_cosine`, `_kmeans`, `_bibtex_field`, `Paper`, `Cluster`, `LitCluster` (init, all three loaders, fit behaviour, export), and the CLI.
- **README** — full installation guide, CLI reference table, GUI usage, Python API example, input format specs, algorithm description, and citation block.

## Test plan

- [x] All 70 pytest tests pass (`pytest tests/ -v`)
- [x] CLI: `python litcluster.py --help` shows all options
- [x] CLI: `python litcluster.py <file.bib> -k 5` produces summary output
- [x] GUI launches with `python litcluster_gui.py`
- [x] BibTeX nested-brace field extraction verified by dedicated test
- [x] K-means++ seeding verified to separate clearly distinct topic groups

https://claude.ai/code/session_012JgcBBNGeVKA1KSteZQikp

---
_Generated by [Claude Code](https://claude.ai/code/session_012JgcBBNGeVKA1KSteZQikp)_