### PR TITLE
feat: JOSS-quality debug pass, interactive HTML export, and tkinter GUI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,23 @@
+# Python bytecode
+__pycache__/
+*.py[cod]
+*.pyo
+
+# Distribution / packaging
+*.egg-info/
+dist/
+build/
+*.egg
+
+# Virtual environments
+.venv/
+venv/
+env/
+
+# pytest cache
+.pytest_cache/
+
+# Editor / OS
+.DS_Store
+*.swp
+*.swo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,31 @@
 # Changelog
 
+All notable changes to litcluster are documented in this file.
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
 ## [Unreleased]
-- BERTopic backend for interpretable topic labels (#1)
-- Semantic Scholar API for bulk paper fetching (#2)
-- Per-cluster LLM-generated summaries (#3)
+
+### Planned
+- BERTopic backend for richer topic labels
+- Semantic Scholar API integration for bulk paper fetching
+- Per-cluster LLM-generated summaries
+- UMAP 2-D projection for scatter-plot visualisation
 
 ## [0.1.0] - 2026-04-23
+
 ### Added
-- SPECTER2 sentence-transformer embeddings for scientific literature
-- HDBSCAN, k-means, and agglomerative clustering backends
-- UMAP 2D projection for visualisation
-- Interactive HTML report with cluster explorer
-- BibTeX input support
-- CLI: `litcluster cluster refs.bib`
-- Python API: `LitCluster`, `PaperEmbedder`
+- TF-IDF vectorisation with smoothed IDF (`log((N+1)/(df+1)) + 1`)
+- Lloyd's k-means clustering using cosine similarity on sparse vectors
+- `Paper` and `Cluster` dataclasses
+- `LitCluster` class with `from_bibtex`, `from_csv`, `from_jsonl` loaders
+- Automatic top-term extraction per cluster
+- `export_csv`, `export_json`, `export_html` output methods
+- Self-contained interactive HTML report with collapsible cluster cards,
+  click-to-reveal abstracts, and a real-time search filter
+- `litcluster_gui.py`: tkinter GUI with file picker, parameter controls,
+  treeview results browser, and export buttons
+- CLI: `litcluster <file> [-k K] [--format summary|csv|json|html]`
+- Robust BibTeX field parser handling nested curly braces
+- Extended stop-word list covering common academic filler words
+- 63 pytest unit and integration tests (100 % passing)
+- MIT licence

--- a/README.md
+++ b/README.md
@@ -1,1 +1,193 @@
 # litcluster
+
+[![CI](https://github.com/vdeshmukh203/litcluster/actions/workflows/ci.yml/badge.svg)](https://github.com/vdeshmukh203/litcluster/actions/workflows/ci.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+[![Python 3.8+](https://img.shields.io/badge/python-3.8%2B-blue.svg)](https://python.org)
+
+**litcluster** is a pure-Python tool for automatically clustering academic papers by topic using TF-IDF and k-means.  Given a BibTeX file, a CSV, or a JSONL collection of paper metadata, it groups papers into thematic clusters and labels each cluster with its most distinctive terms.
+
+Results can be exported as:
+
+- **Interactive HTML** — collapsible cluster cards, click-to-reveal abstracts, real-time search filter
+- **CSV** — flat table with cluster assignments for use in spreadsheets
+- **JSON** — full structured output including top terms and abstracts
+
+An optional **GUI** (built with `tkinter`, standard-library only) provides a point-and-click interface.
+
+**No external dependencies** — only Python ≥ 3.8 standard library required.
+
+---
+
+## Installation
+
+```bash
+# From PyPI (once published)
+pip install litcluster
+
+# Or directly from source
+git clone https://github.com/vdeshmukh203/litcluster.git
+cd litcluster
+pip install -e .
+```
+
+---
+
+## Quick start
+
+### Command line
+
+```bash
+# Cluster a BibTeX file into 5 groups and print a summary
+litcluster refs.bib
+
+# Choose the number of clusters and export to HTML
+litcluster refs.bib -k 8 --format html -o report.html
+
+# Export to CSV
+litcluster papers.csv -k 6 --format csv -o clusters.csv
+
+# Export to JSON
+litcluster papers.jsonl -k 4 --format json
+```
+
+### Python API
+
+```python
+from pathlib import Path
+from litcluster import LitCluster
+
+# Load from BibTeX
+lc = LitCluster.from_bibtex(Path("refs.bib"), k=6, seed=42)
+lc.fit()
+
+# Print a plain-text summary
+print(lc.summary())
+
+# Export formats
+lc.export_html(Path("report.html"))   # interactive HTML
+lc.export_csv(Path("clusters.csv"))   # flat CSV
+lc.export_json(Path("clusters.json")) # structured JSON
+
+# Iterate over clusters programmatically
+for cluster in lc.clusters:
+    print(cluster.label, "—", len(cluster.papers), "papers")
+    for paper in cluster.papers:
+        print(" ", paper.title, f"({paper.year})")
+```
+
+### GUI
+
+```bash
+litcluster-gui
+# or, without installation:
+python litcluster_gui.py
+```
+
+The GUI lets you browse for a file, tune parameters with spin-boxes, run clustering in a background thread, browse results in a tree view, and export to CSV / JSON / HTML — all without touching the command line.
+
+---
+
+## Input formats
+
+| Format | Extension | Required columns / fields |
+|--------|-----------|--------------------------|
+| CSV | `.csv` | `title` (all others optional: `paper_id`, `abstract`, `authors`, `year`, `venue`, `doi`, `keywords`) |
+| JSONL | `.jsonl` | Same field names as CSV, one JSON object per line |
+| BibTeX | `.bib` | Standard BibTeX fields: `title`, `abstract`, `author`, `year`, `journal`/`booktitle`, `doi`, `keywords` |
+
+---
+
+## CLI reference
+
+```
+usage: litcluster [-h] [-k K] [--format {csv,json,html,summary}]
+                  [--output OUTPUT] [--seed SEED] [--max-iter MAX_ITER]
+                  [--min-freq MIN_FREQ]
+                  input
+
+positional arguments:
+  input                 Input file (.csv, .jsonl, or .bib)
+
+options:
+  -k, --clusters K      Number of clusters (default: 5)
+  --format              Output format: summary | csv | json | html (default: summary)
+  -o, --output          Output file path (default: derived from input name)
+  --seed                Random seed for reproducibility (default: 42)
+  --max-iter            Maximum k-means iterations (default: 100)
+  --min-freq            Minimum document-frequency for vocabulary terms (default: 2)
+```
+
+---
+
+## Python API reference
+
+### `LitCluster(k=5, max_iter=100, seed=42, min_term_freq=2)`
+
+Main class.
+
+| Method | Description |
+|--------|-------------|
+| `from_csv(path, **kwargs)` | Load papers from a CSV file |
+| `from_jsonl(path, **kwargs)` | Load papers from a JSONL file |
+| `from_bibtex(path, **kwargs)` | Load papers from a BibTeX `.bib` file |
+| `fit()` | Run TF-IDF + k-means; populates `.clusters`; returns `self` |
+| `summary()` | Return a plain-text summary string |
+| `export_csv(path)` | Write cluster assignments to CSV |
+| `export_json(path)` | Write full cluster data to JSON |
+| `export_html(path)` | Write an interactive self-contained HTML report |
+
+### `Paper`
+
+Dataclass with fields: `paper_id`, `title`, `abstract`, `authors`, `year`, `venue`, `doi`, `keywords`.  The `.text` property returns the concatenation of `title`, `abstract`, and `keywords` used for vectorisation.
+
+### `Cluster`
+
+Dataclass with fields: `cluster_id` (int), `papers` (list of `Paper`), `top_terms` (list of str).  The `.label` property returns a short human-readable label.
+
+---
+
+## How it works
+
+1. **Tokenisation** — titles, abstracts, and keywords are lowercased and split into alphabetic tokens (≥ 3 chars); stop-words and common academic filler words are removed.
+2. **TF-IDF** — a sparse term-frequency × inverse-document-frequency matrix is built using the smoothed sklearn-style IDF formula `log((N+1)/(df+1)) + 1`.
+3. **k-means** — Lloyd's algorithm is run on the TF-IDF vectors using cosine similarity.  Centroids are initialised by random sampling (seeded for reproducibility).
+4. **Top terms** — each cluster is labelled with its highest aggregate-weight terms across member papers.
+
+---
+
+## Running the tests
+
+```bash
+pip install pytest
+pytest tests/ -v
+```
+
+All 63 tests should pass on Python 3.8 – 3.12 with no additional dependencies.
+
+---
+
+## Contributing
+
+Bug reports and pull requests are welcome.  Please open an issue before submitting large changes.
+
+---
+
+## Citation
+
+If you use litcluster in published research, please cite:
+
+```bibtex
+@software{deshmukh2026litcluster,
+  author    = {Deshmukh, Vaibhav},
+  title     = {litcluster: Topic modelling and semantic clustering of scientific literature},
+  year      = {2026},
+  url       = {https://github.com/vdeshmukh203/litcluster},
+  version   = {0.1.0}
+}
+```
+
+---
+
+## License
+
+MIT — see [LICENSE](LICENSE).

--- a/litcluster.py
+++ b/litcluster.py
@@ -1,8 +1,16 @@
 #!/usr/bin/env python3
 """
-litcluster.py — Literature Clustering Tool
-Clusters academic papers by topic using TF-IDF + k-means (pure stdlib).
-Stdlib-only. No external dependencies.
+litcluster — Literature Clustering Tool
+
+Clusters academic papers by topic using TF-IDF + k-means.
+Pure standard-library implementation; zero external dependencies.
+
+Typical usage::
+
+    lc = LitCluster.from_bibtex(Path("refs.bib"), k=6)
+    lc.fit()
+    lc.export_html(Path("clusters.html"))
+    print(lc.summary())
 """
 
 from __future__ import annotations
@@ -17,37 +25,76 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
+__version__ = "0.1.0"
+__author__ = "Vaibhav Deshmukh"
+__license__ = "MIT"
+
 
 # ---------------------------------------------------------------------------
 # Text processing
 # ---------------------------------------------------------------------------
 
 _STOPWORDS = {
-    'a','an','the','and','or','but','in','on','at','to','for','of','with',
-    'by','from','is','was','are','were','be','been','being','have','has',
-    'had','do','does','did','will','would','could','should','may','might',
-    'this','that','these','those','it','its','we','our','they','their',
-    'as','if','not','no','nor','so','yet','both','either','whether',
-    'each','few','more','most','other','some','such','than','too','very',
-    'just','also','only','then','here','there','when','where','who','which',
-    'how','all','any','can','into','through','during','before','after',
-    'above','below','between','out','off','over','under','again','further',
-    'once','i','my','me','he','she','his','her','him','you','your',
+    # Articles / conjunctions / prepositions
+    'a', 'an', 'the', 'and', 'or', 'but', 'in', 'on', 'at', 'to', 'for',
+    'of', 'with', 'by', 'from', 'is', 'was', 'are', 'were', 'be', 'been',
+    'being', 'have', 'has', 'had', 'do', 'does', 'did', 'will', 'would',
+    'could', 'should', 'may', 'might', 'this', 'that', 'these', 'those',
+    'it', 'its', 'we', 'our', 'they', 'their', 'as', 'if', 'not', 'no',
+    'nor', 'so', 'yet', 'both', 'either', 'whether', 'each', 'few', 'more',
+    'most', 'other', 'some', 'such', 'than', 'too', 'very', 'just', 'also',
+    'only', 'then', 'here', 'there', 'when', 'where', 'who', 'which', 'how',
+    'all', 'any', 'can', 'into', 'through', 'during', 'before', 'after',
+    'above', 'below', 'between', 'out', 'off', 'over', 'under', 'again',
+    'further', 'once', 'i', 'my', 'me', 'he', 'she', 'his', 'her', 'him',
+    'you', 'your',
+    # Common academic filler words (suppress them so clusters contain
+    # domain-meaningful terms only)
+    'paper', 'study', 'work', 'approach', 'method', 'methods', 'technique',
+    'techniques', 'propose', 'proposed', 'present', 'show', 'shows',
+    'shown', 'demonstrate', 'demonstrates', 'find', 'found', 'results',
+    'result', 'data', 'new', 'use', 'used', 'using', 'based', 'two',
+    'three', 'four', 'five', 'one', 'first', 'second', 'third', 'also',
+    'thus', 'however', 'therefore', 'while', 'whereas', 'since', 'due',
+    'via', 'within', 'without', 'across', 'per', 'well', 'large', 'high',
+    'low', 'good', 'different', 'various', 'several', 'many',
 }
 
 
 def _tokenise(text: str) -> List[str]:
+    """Lowercase and tokenise *text*, removing stop-words and short tokens.
+
+    Only alphabetic tokens of three or more characters are kept.
+    """
     tokens = re.findall(r"[a-zA-Z]{3,}", text.lower())
     return [t for t in tokens if t not in _STOPWORDS]
 
 
-def _tfidf(documents: List[List[str]]) -> Tuple[List[Dict[str,float]], List[str]]:
-    """Compute TF-IDF vectors. Returns (vectors, vocab)."""
+def _tfidf(
+    documents: List[List[str]],
+) -> Tuple[List[Dict[str, float]], List[str]]:
+    """Compute TF-IDF vectors for a list of tokenised documents.
+
+    Uses the *sklearn*-style smoothed IDF formula
+    ``idf = log((N+1)/(df+1)) + 1`` so that terms appearing in every
+    document still receive a non-zero weight.
+
+    Parameters
+    ----------
+    documents:
+        List of token lists, one per document.
+
+    Returns
+    -------
+    vectors:
+        Sparse ``{term: weight}`` dicts, one per document.
+    vocab:
+        Sorted list of all unique terms across the corpus.
+    """
     n = len(documents)
     if n == 0:
         return [], []
 
-    # Build vocab
     vocab_set: set = set()
     for doc in documents:
         vocab_set.update(doc)
@@ -55,15 +102,12 @@ def _tfidf(documents: List[List[str]]) -> Tuple[List[Dict[str,float]], List[str]
     term_idx = {t: i for i, t in enumerate(vocab)}
     V = len(vocab)
 
-    # Document frequency
     df = [0] * V
     for doc in documents:
-        doc_set = set(doc)
-        for t in doc_set:
+        for t in set(doc):
             if t in term_idx:
                 df[term_idx[t]] += 1
 
-    # TF-IDF
     vectors: List[Dict[str, float]] = []
     for doc in documents:
         tf: Dict[int, int] = {}
@@ -83,10 +127,16 @@ def _tfidf(documents: List[List[str]]) -> Tuple[List[Dict[str,float]], List[str]
 
 
 def _cosine(a: Dict[str, float], b: Dict[str, float]) -> float:
-    dot = sum(a.get(t, 0.0) * b.get(t, 0.0) for t in b)
-    norm_a = math.sqrt(sum(v*v for v in a.values()))
-    norm_b = math.sqrt(sum(v*v for v in b.values()))
-    if norm_a == 0 or norm_b == 0:
+    """Cosine similarity between two sparse TF-IDF vectors.
+
+    Returns 0.0 when either vector is empty or has zero norm.
+    """
+    if not a or not b:
+        return 0.0
+    dot = sum(a.get(t, 0.0) * v for t, v in b.items())
+    norm_a = math.sqrt(sum(v * v for v in a.values()))
+    norm_b = math.sqrt(sum(v * v for v in b.values()))
+    if norm_a == 0.0 or norm_b == 0.0:
         return 0.0
     return dot / (norm_a * norm_b)
 
@@ -97,44 +147,92 @@ def _kmeans(
     max_iter: int = 100,
     seed: int = 42,
 ) -> List[int]:
-    """Lloyd's k-means on sparse TF-IDF vectors."""
+    """Lloyd's k-means clustering on sparse cosine-similarity vectors.
+
+    Parameters
+    ----------
+    vectors:
+        Sparse TF-IDF vectors as ``{term: weight}`` dicts.
+    k:
+        Target number of clusters (clamped to ``len(vectors)``).
+    max_iter:
+        Maximum Lloyd iterations before forced convergence.
+    seed:
+        Random seed for reproducible centroid initialisation.
+
+    Returns
+    -------
+    List[int]
+        Integer cluster label (0-indexed) for every input vector.
+    """
+    import random
+
     n = len(vectors)
     if n == 0:
         return []
     k = min(k, n)
 
-    # Seeded centroid initialisation (evenly spaced)
-    import random
     rng = random.Random(seed)
     centroid_indices = rng.sample(range(n), k)
     centroids = [dict(vectors[i]) for i in centroid_indices]
-    labels = [0] * n
+    labels: List[int] = [-1] * n
 
     for _ in range(max_iter):
-        # Assignment
-        new_labels = []
+        new_labels: List[int] = []
         for vec in vectors:
-            best = max(range(k), key=lambda c: _cosine(vec, centroids[c]))
-            new_labels.append(best)
+            sims = [_cosine(vec, centroids[c]) for c in range(k)]
+            new_labels.append(sims.index(max(sims)))
 
         if new_labels == labels:
             break
         labels = new_labels
 
-        # Update centroids
         for c in range(k):
-            members = [vectors[i] for i, l in enumerate(labels) if l == c]
+            members = [vectors[i] for i, lbl in enumerate(labels) if lbl == c]
             if not members:
-                centroids[c] = dict(vectors[rng.randint(0, n-1)])
+                # Reinitialise empty cluster from a random document
+                centroids[c] = dict(vectors[rng.randint(0, n - 1)])
                 continue
             new_centroid: Dict[str, float] = {}
             for vec in members:
                 for t, v in vec.items():
                     new_centroid[t] = new_centroid.get(t, 0.0) + v
-            total = len(members)
-            centroids[c] = {t: v/total for t, v in new_centroid.items()}
+            m = len(members)
+            centroids[c] = {t: v / m for t, v in new_centroid.items()}
 
     return labels
+
+
+def _bibtex_field(entry: str, field_name: str) -> str:
+    """Extract the value of *field_name* from a single BibTeX entry string.
+
+    Correctly handles both ``{...}`` and ``"..."`` delimiters and tracks
+    nested curly braces so titles like ``{Advances in {Machine Learning}}``
+    are extracted in full.
+    """
+    pattern = re.compile(
+        r'(?i)\b' + re.escape(field_name) + r'\s*=\s*'
+    )
+    m = pattern.search(entry)
+    if not m:
+        return ""
+    rest = entry[m.end():].lstrip()
+    if rest.startswith('{'):
+        depth = 0
+        for i, ch in enumerate(rest):
+            if ch == '{':
+                depth += 1
+            elif ch == '}':
+                depth -= 1
+                if depth == 0:
+                    return rest[1:i].strip()
+        return ""
+    if rest.startswith('"'):
+        end = rest.find('"', 1)
+        return rest[1:end].strip() if end >= 0 else ""
+    # Numeric / unquoted value
+    m2 = re.match(r'[^\s,}\n]+', rest)
+    return m2.group(0) if m2 else ""
 
 
 # ---------------------------------------------------------------------------
@@ -143,6 +241,28 @@ def _kmeans(
 
 @dataclass
 class Paper:
+    """A single academic paper with standard bibliographic metadata.
+
+    Attributes
+    ----------
+    paper_id:
+        Unique identifier (BibTeX cite-key, row index, or DOI).
+    title:
+        Paper title.
+    abstract:
+        Full abstract text.
+    authors:
+        Author string (free-form, e.g. ``"Smith, J. and Doe, A."``).
+    year:
+        Publication year as a string.
+    venue:
+        Journal or conference name.
+    doi:
+        Digital Object Identifier.
+    keywords:
+        Author-supplied keywords.
+    """
+
     paper_id: str
     title: str
     abstract: str = ""
@@ -154,25 +274,46 @@ class Paper:
 
     @property
     def text(self) -> str:
-        return f"{self.title} {self.abstract} {self.keywords}"
+        """Concatenated text used for vectorisation (title + abstract + keywords)."""
+        return " ".join(filter(None, [self.title, self.abstract, self.keywords]))
 
     def to_dict(self) -> dict:
         return {
-            "paper_id": self.paper_id, "title": self.title, "abstract": self.abstract,
-            "authors": self.authors, "year": self.year, "venue": self.venue,
-            "doi": self.doi, "keywords": self.keywords,
+            "paper_id": self.paper_id,
+            "title": self.title,
+            "abstract": self.abstract,
+            "authors": self.authors,
+            "year": self.year,
+            "venue": self.venue,
+            "doi": self.doi,
+            "keywords": self.keywords,
         }
 
 
 @dataclass
 class Cluster:
+    """A group of thematically related papers.
+
+    Attributes
+    ----------
+    cluster_id:
+        Zero-based integer identifier assigned by k-means.
+    papers:
+        All :class:`Paper` objects assigned to this cluster.
+    top_terms:
+        Top-N TF-IDF terms that characterise the cluster, ranked by
+        aggregate weight.
+    """
+
     cluster_id: int
     papers: List[Paper] = field(default_factory=list)
     top_terms: List[str] = field(default_factory=list)
 
     @property
     def label(self) -> str:
-        return f"Cluster {self.cluster_id}: {', '.join(self.top_terms[:3])}"
+        """Short human-readable label built from the top three terms."""
+        terms = ", ".join(self.top_terms[:3]) if self.top_terms else "—"
+        return f"Cluster {self.cluster_id}: {terms}"
 
     def to_dict(self) -> dict:
         return {
@@ -189,8 +330,38 @@ class Cluster:
 # ---------------------------------------------------------------------------
 
 class LitCluster:
-    def __init__(self, k: int = 5, max_iter: int = 100, seed: int = 42,
-                 min_term_freq: int = 2):
+    """Orchestrates loading, clustering, and exporting paper collections.
+
+    Parameters
+    ----------
+    k:
+        Number of clusters (default 5).
+    max_iter:
+        Maximum k-means iterations (default 100).
+    seed:
+        Random seed for reproducible results (default 42).
+    min_term_freq:
+        Minimum document-frequency (number of papers a term must appear
+        in) to be included in the vocabulary.  Setting this higher speeds
+        up computation on large corpora and removes rare noise terms
+        (default 2).
+
+    Examples
+    --------
+    >>> from pathlib import Path
+    >>> lc = LitCluster.from_bibtex(Path("refs.bib"), k=5)
+    >>> lc.fit()
+    >>> print(lc.summary())
+    >>> lc.export_html(Path("report.html"))
+    """
+
+    def __init__(
+        self,
+        k: int = 5,
+        max_iter: int = 100,
+        seed: int = 42,
+        min_term_freq: int = 2,
+    ) -> None:
         self.k = k
         self.max_iter = max_iter
         self.seed = seed
@@ -201,8 +372,20 @@ class LitCluster:
         self._vectors: List[Dict[str, float]] = []
         self._vocab: List[str] = []
 
+    # ------------------------------------------------------------------
+    # Loaders
+    # ------------------------------------------------------------------
+
     @classmethod
     def from_csv(cls, path: Path, **kwargs) -> "LitCluster":
+        """Load papers from a CSV file.
+
+        Expected columns (all optional except ``title``):
+        ``paper_id``, ``title``, ``abstract``, ``authors``, ``year``,
+        ``venue``, ``doi``, ``keywords``.
+
+        Extra columns are silently ignored.
+        """
         obj = cls(**kwargs)
         with path.open(encoding="utf-8", errors="replace", newline="") as fh:
             reader = csv.DictReader(fh)
@@ -221,6 +404,11 @@ class LitCluster:
 
     @classmethod
     def from_jsonl(cls, path: Path, **kwargs) -> "LitCluster":
+        """Load papers from a JSONL file (one JSON object per line).
+
+        The same field names as :meth:`from_csv` are recognised.
+        Blank lines are skipped.
+        """
         obj = cls(**kwargs)
         with path.open(encoding="utf-8") as fh:
             for i, line in enumerate(fh):
@@ -242,56 +430,87 @@ class LitCluster:
 
     @classmethod
     def from_bibtex(cls, path: Path, **kwargs) -> "LitCluster":
-        """Parse a BibTeX file for titles, abstracts, keywords."""
+        """Load papers from a BibTeX (``.bib``) file.
+
+        Extracts ``title``, ``abstract``, ``author``, ``year``,
+        ``journal``/``booktitle``, ``doi``, and ``keywords`` fields.
+        Nested curly braces in field values are handled correctly.
+        Entries without a ``@`` marker are skipped.
+        """
         obj = cls(**kwargs)
         text = path.read_text(encoding="utf-8", errors="replace")
         entries = re.split(r'(?=@\w+\s*\{)', text)
         for i, entry in enumerate(entries):
-            if not entry.strip() or not entry.startswith('@'):
+            entry = entry.strip()
+            if not entry or not entry.startswith('@'):
                 continue
-            def _get(field):
-                m = re.search(rf'{field}\s*=\s*[{{"](.*?)[}}"\,]', entry, re.IGNORECASE | re.DOTALL)
-                return m.group(1).strip() if m else ""
             m_key = re.match(r'@\w+\s*\{\s*(\S+?)[,}]', entry)
             key = m_key.group(1) if m_key else str(i)
             obj.papers.append(Paper(
-                paper_id=key, title=_get('title'), abstract=_get('abstract'),
-                authors=_get('author'), year=_get('year'),
-                venue=_get('journal') or _get('booktitle'),
-                doi=_get('doi'), keywords=_get('keywords'),
+                paper_id=key,
+                title=_bibtex_field(entry, 'title'),
+                abstract=_bibtex_field(entry, 'abstract'),
+                authors=_bibtex_field(entry, 'author'),
+                year=_bibtex_field(entry, 'year'),
+                venue=(
+                    _bibtex_field(entry, 'journal')
+                    or _bibtex_field(entry, 'booktitle')
+                ),
+                doi=_bibtex_field(entry, 'doi'),
+                keywords=_bibtex_field(entry, 'keywords'),
             ))
         return obj
 
+    # ------------------------------------------------------------------
+    # Clustering
+    # ------------------------------------------------------------------
+
     def fit(self) -> "LitCluster":
+        """Run the TF-IDF + k-means clustering pipeline.
+
+        Tokenises each paper's text (title + abstract + keywords),
+        builds a TF-IDF matrix, applies k-means, and populates
+        :attr:`clusters`.
+
+        Returns *self* for method chaining.
+        """
         if not self.papers:
             return self
+
         tokens_list = [_tokenise(p.text) for p in self.papers]
 
-        # Filter rare terms
         if self.min_term_freq > 1:
             freq: Dict[str, int] = {}
             for tokens in tokens_list:
                 for t in set(tokens):
                     freq[t] = freq.get(t, 0) + 1
-            tokens_list = [[t for t in tokens if freq.get(t, 0) >= self.min_term_freq]
-                           for tokens in tokens_list]
+            tokens_list = [
+                [t for t in tokens if freq.get(t, 0) >= self.min_term_freq]
+                for tokens in tokens_list
+            ]
 
         self._vectors, self._vocab = _tfidf(tokens_list)
         self._labels = _kmeans(self._vectors, self.k, self.max_iter, self.seed)
 
-        # Build cluster objects
-        clusters: Dict[int, List] = {}
-        for paper, label in zip(self.papers, self._labels):
-            clusters.setdefault(label, []).append(paper)
+        cluster_map: Dict[int, List[Paper]] = {}
+        for paper, lbl in zip(self.papers, self._labels):
+            cluster_map.setdefault(lbl, []).append(paper)
 
         self.clusters = []
-        for cid in sorted(clusters):
+        for cid in sorted(cluster_map):
             top_terms = self._top_terms_for_cluster(cid, n=10)
-            self.clusters.append(Cluster(cluster_id=cid, papers=clusters[cid], top_terms=top_terms))
+            self.clusters.append(
+                Cluster(cluster_id=cid, papers=cluster_map[cid], top_terms=top_terms)
+            )
         return self
 
     def _top_terms_for_cluster(self, cid: int, n: int = 10) -> List[str]:
-        member_vecs = [self._vectors[i] for i, l in enumerate(self._labels) if l == cid]
+        """Return the top-*n* terms for cluster *cid* by aggregate TF-IDF weight."""
+        member_vecs = [
+            self._vectors[i]
+            for i, lbl in enumerate(self._labels)
+            if lbl == cid
+        ]
         if not member_vecs:
             return []
         scores: Dict[str, float] = {}
@@ -300,24 +519,261 @@ class LitCluster:
                 scores[t] = scores.get(t, 0.0) + v
         return sorted(scores, key=lambda t: -scores[t])[:n]
 
+    # ------------------------------------------------------------------
+    # Export
+    # ------------------------------------------------------------------
+
     def export_csv(self, path: Path) -> None:
+        """Write cluster assignments to *path* as a flat CSV file.
+
+        Columns: ``cluster_id``, ``cluster_label``, ``paper_id``,
+        ``title``, ``authors``, ``year``, ``venue``, ``doi``.
+        """
         with path.open("w", newline="", encoding="utf-8") as fh:
             w = csv.writer(fh)
-            w.writerow(["cluster_id","cluster_label","paper_id","title","authors","year","venue","doi"])
+            w.writerow([
+                "cluster_id", "cluster_label", "paper_id",
+                "title", "authors", "year", "venue", "doi",
+            ])
             for cluster in self.clusters:
                 for p in cluster.papers:
-                    w.writerow([cluster.cluster_id, cluster.label, p.paper_id,
-                                p.title, p.authors, p.year, p.venue, p.doi])
+                    w.writerow([
+                        cluster.cluster_id, cluster.label,
+                        p.paper_id, p.title, p.authors,
+                        p.year, p.venue, p.doi,
+                    ])
 
     def export_json(self, path: Path) -> None:
+        """Write full cluster data (including abstracts) to *path* as JSON."""
         with path.open("w", encoding="utf-8") as fh:
-            json.dump([c.to_dict() for c in self.clusters], fh, indent=2, ensure_ascii=False)
+            json.dump(
+                [c.to_dict() for c in self.clusters],
+                fh,
+                indent=2,
+                ensure_ascii=False,
+            )
+
+    def export_html(self, path: Path) -> None:
+        """Write a self-contained interactive HTML report to *path*.
+
+        The report lists every cluster as a collapsible card showing its
+        top terms and a table of member papers.  Clicking a paper row
+        reveals its abstract.  A search box filters papers in real-time.
+        """
+        path.write_text(_render_html(self), encoding="utf-8")
 
     def summary(self) -> str:
-        lines = [f"LitCluster: {len(self.papers)} papers in {len(self.clusters)} clusters", ""]
+        """Return a human-readable plain-text overview of the clusters.
+
+        Includes the top three terms per cluster and a sample of up to
+        three paper titles.  If :meth:`fit` has not been called, returns
+        a reminder.
+        """
+        if not self.clusters:
+            return (
+                f"LitCluster: {len(self.papers)} papers loaded — "
+                "call fit() to run clustering."
+            )
+        lines = [
+            f"LitCluster: {len(self.papers)} papers in {len(self.clusters)} clusters",
+            "",
+        ]
         for c in self.clusters:
-            lines.append(f"  [{c.cluster_id}] {c.label} ({len(c.papers)} papers)")
+            lines.append(f"  [{c.cluster_id}] {c.label}  ({len(c.papers)} papers)")
+            for p in c.papers[:3]:
+                snippet = (p.title or "(no title)")[:72]
+                lines.append(f"      • {snippet}")
+            if len(c.papers) > 3:
+                lines.append(f"        … and {len(c.papers) - 3} more")
+            lines.append("")
         return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# HTML renderer
+# ---------------------------------------------------------------------------
+
+_CLUSTER_COLOURS = [
+    "#4e79a7", "#f28e2b", "#e15759", "#76b7b2", "#59a14f",
+    "#edc948", "#b07aa1", "#ff9da7", "#9c755f", "#bab0ac",
+]
+
+
+def _html_escape(text: str) -> str:
+    return (
+        text.replace("&", "&amp;")
+            .replace("<", "&lt;")
+            .replace(">", "&gt;")
+            .replace('"', "&quot;")
+    )
+
+
+def _render_html(lc: LitCluster) -> str:
+    """Build and return a self-contained interactive HTML string for *lc*."""
+    clusters_json = json.dumps(
+        [c.to_dict() for c in lc.clusters], ensure_ascii=False
+    )
+    n_papers = len(lc.papers)
+    n_clusters = len(lc.clusters)
+
+    cards_html_parts: List[str] = []
+    for idx, cluster in enumerate(lc.clusters):
+        colour = _CLUSTER_COLOURS[idx % len(_CLUSTER_COLOURS)]
+        terms_html = " ".join(
+            f'<span class="term">{_html_escape(t)}</span>'
+            for t in cluster.top_terms[:8]
+        )
+        paper_rows: List[str] = []
+        for p in cluster.papers:
+            title_esc = _html_escape(p.title or "(no title)")
+            authors_esc = _html_escape(p.authors or "")
+            year = _html_escape(p.year or "")
+            doi_link = (
+                f'<a href="https://doi.org/{_html_escape(p.doi)}" '
+                f'target="_blank">{_html_escape(p.doi)}</a>'
+                if p.doi else ""
+            )
+            abstract_text = p.abstract or ""
+            abstract_short = _html_escape(abstract_text[:300])
+            if len(abstract_text) > 300:
+                abstract_short += "…"
+            paper_rows.append(
+                f'<tr class="paper-row">'
+                f'<td class="paper-title">{title_esc}</td>'
+                f'<td>{authors_esc}</td>'
+                f'<td class="paper-year">{year}</td>'
+                f'<td>{doi_link}</td>'
+                f'</tr>'
+                f'<tr class="abstract-row" style="display:none">'
+                f'<td colspan="4" class="abstract-cell">{abstract_short}</td>'
+                f'</tr>'
+            )
+
+        papers_html = "\n".join(paper_rows)
+        cards_html_parts.append(f"""
+  <div class="cluster-card" data-cluster="{cluster.cluster_id}" style="border-left:5px solid {colour}">
+    <div class="cluster-header" onclick="toggleCluster(this)">
+      <span class="cluster-badge" style="background:{colour}">{cluster.cluster_id}</span>
+      <span class="cluster-title">{_html_escape(cluster.label)}</span>
+      <span class="cluster-count">{len(cluster.papers)} paper{"s" if len(cluster.papers) != 1 else ""}</span>
+      <span class="toggle-icon">&#9660;</span>
+    </div>
+    <div class="cluster-terms">{terms_html}</div>
+    <div class="cluster-body" style="display:none">
+      <table class="paper-table">
+        <thead><tr><th>Title</th><th>Authors</th><th>Year</th><th>DOI</th></tr></thead>
+        <tbody>{papers_html}</tbody>
+      </table>
+    </div>
+  </div>""")
+
+    cards_html = "\n".join(cards_html_parts)
+
+    return f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>litcluster &mdash; {n_papers} papers, {n_clusters} clusters</title>
+<style>
+*,*::before,*::after{{box-sizing:border-box}}
+body{{font-family:system-ui,sans-serif;margin:0;background:#f5f5f5;color:#333}}
+header{{background:#2c3e50;color:#fff;padding:.9rem 2rem;display:flex;align-items:center;gap:1rem}}
+header h1{{margin:0;font-size:1.4rem}}
+.meta{{font-size:.85rem;opacity:.75}}
+.controls{{padding:.75rem 2rem;background:#fff;border-bottom:1px solid #ddd;display:flex;gap:.6rem;flex-wrap:wrap;align-items:center}}
+.controls input{{flex:1;min-width:200px;padding:.4rem .7rem;border:1px solid #ccc;border-radius:4px;font-size:.9rem}}
+.controls button{{padding:.4rem .9rem;border:none;border-radius:4px;cursor:pointer;font-size:.85rem}}
+.btn-expand{{background:#4e79a7;color:#fff}}
+.btn-collapse{{background:#e0e0e0;color:#333}}
+main{{max-width:1100px;margin:1.2rem auto;padding:0 1rem}}
+.cluster-card{{background:#fff;border-radius:6px;margin-bottom:.9rem;box-shadow:0 1px 3px rgba(0,0,0,.1);overflow:hidden}}
+.cluster-header{{display:flex;align-items:center;gap:.7rem;padding:.7rem 1rem;cursor:pointer;user-select:none}}
+.cluster-header:hover{{background:#f9f9f9}}
+.cluster-badge{{width:26px;height:26px;border-radius:50%;color:#fff;display:flex;align-items:center;justify-content:center;font-weight:bold;font-size:.8rem;flex-shrink:0}}
+.cluster-title{{flex:1;font-weight:600}}
+.cluster-count{{font-size:.8rem;color:#777}}
+.toggle-icon{{font-size:.75rem;color:#aaa;transition:transform .2s}}
+.cluster-terms{{padding:.2rem 1rem .5rem 3.5rem;display:flex;flex-wrap:wrap;gap:.3rem}}
+.term{{background:#eef2ff;color:#3b4cb8;padding:.12rem .45rem;border-radius:999px;font-size:.78rem}}
+.cluster-body{{padding:0 1rem 1rem}}
+.paper-table{{width:100%;border-collapse:collapse;font-size:.85rem}}
+.paper-table th{{text-align:left;padding:.35rem .5rem;border-bottom:2px solid #eee;color:#555;font-weight:600}}
+.paper-row td{{padding:.35rem .5rem;border-bottom:1px solid #f0f0f0;vertical-align:top;cursor:pointer}}
+.paper-row:hover td{{background:#fafafa}}
+.paper-title{{font-weight:500}}
+.paper-year{{width:50px;text-align:center}}
+.abstract-cell{{padding:.5rem 1rem .7rem;font-size:.82rem;color:#555;background:#fafbff}}
+.no-results{{text-align:center;color:#999;padding:2rem}}
+footer{{text-align:center;padding:1.5rem;font-size:.8rem;color:#aaa}}
+</style>
+</head>
+<body>
+<header>
+  <h1>&#128218; litcluster</h1>
+  <div class="meta">{n_papers} papers &nbsp;&middot;&nbsp; {n_clusters} clusters</div>
+</header>
+<div class="controls">
+  <input type="text" id="search" placeholder="Filter by title, author or year&hellip;"
+         oninput="filterPapers(this.value)">
+  <button class="btn-expand" onclick="expandAll()">Expand all</button>
+  <button class="btn-collapse" onclick="collapseAll()">Collapse all</button>
+</div>
+<main id="main">
+{cards_html}
+  <p class="no-results" id="no-results" style="display:none">No papers match your filter.</p>
+</main>
+<footer>Generated by <a href="https://github.com/vdeshmukh203/litcluster">litcluster</a> {__version__}</footer>
+<script>
+function toggleCluster(hdr){{
+  var card=hdr.closest('.cluster-card');
+  var body=card.querySelector('.cluster-body');
+  var icon=hdr.querySelector('.toggle-icon');
+  var open=body.style.display!=='none';
+  body.style.display=open?'none':'block';
+  icon.style.transform=open?'':'rotate(180deg)';
+}}
+function expandAll(){{
+  document.querySelectorAll('.cluster-body').forEach(function(b){{b.style.display='block';}});
+  document.querySelectorAll('.toggle-icon').forEach(function(i){{i.style.transform='rotate(180deg)';}});
+}}
+function collapseAll(){{
+  document.querySelectorAll('.cluster-body').forEach(function(b){{b.style.display='none';}});
+  document.querySelectorAll('.toggle-icon').forEach(function(i){{i.style.transform='';}});
+}}
+document.querySelectorAll('.paper-row').forEach(function(row){{
+  row.addEventListener('click',function(){{
+    var next=row.nextElementSibling;
+    if(next&&next.classList.contains('abstract-row')){{
+      next.style.display=next.style.display==='none'?'table-row':'none';
+    }}
+  }});
+}});
+function filterPapers(q){{
+  q=q.toLowerCase();
+  var anyVisible=false;
+  document.querySelectorAll('.cluster-card').forEach(function(card){{
+    var rows=card.querySelectorAll('.paper-row');
+    var cardHit=false;
+    rows.forEach(function(row){{
+      var match=!q||row.textContent.toLowerCase().includes(q);
+      row.style.display=match?'':'none';
+      var abs=row.nextElementSibling;
+      if(abs&&abs.classList.contains('abstract-row')&&!match)abs.style.display='none';
+      if(match)cardHit=true;
+    }});
+    card.style.display=cardHit?'':'none';
+    if(cardHit)anyVisible=true;
+    if(cardHit&&q){{
+      card.querySelector('.cluster-body').style.display='block';
+      card.querySelector('.toggle-icon').style.transform='rotate(180deg)';
+    }}
+  }});
+  document.getElementById('no-results').style.display=anyVisible?'none':'block';
+}}
+</script>
+</body>
+</html>"""
 
 
 # ---------------------------------------------------------------------------
@@ -325,29 +781,50 @@ class LitCluster:
 # ---------------------------------------------------------------------------
 
 def _parse_args(argv=None):
-    p = argparse.ArgumentParser(prog="litcluster",
-                                description="Cluster academic papers by topic using TF-IDF + k-means.")
-    p.add_argument("input", help="Input file: CSV, JSONL, or .bib")
-    p.add_argument("-k", "--clusters", type=int, default=5, dest="k",
-                   help="Number of clusters (default: 5)")
-    p.add_argument("--format", choices=["csv","json","summary"], default="summary")
-    p.add_argument("--output", "-o", default=None, help="Output file (default: stdout/auto)")
-    p.add_argument("--seed", type=int, default=42)
-    p.add_argument("--max-iter", type=int, default=100)
-    p.add_argument("--min-freq", type=int, default=2,
-                   help="Minimum term frequency to include in vocabulary (default: 2)")
+    p = argparse.ArgumentParser(
+        prog="litcluster",
+        description="Cluster academic papers by topic using TF-IDF + k-means.",
+    )
+    p.add_argument("input", help="Input file (.csv, .jsonl, or .bib)")
+    p.add_argument(
+        "-k", "--clusters", type=int, default=5, dest="k",
+        metavar="K",
+        help="Number of clusters (default: 5)",
+    )
+    p.add_argument(
+        "--format", choices=["csv", "json", "html", "summary"],
+        default="summary",
+        help="Output format (default: summary)",
+    )
+    p.add_argument(
+        "--output", "-o", default=None,
+        help="Output file path (default: derived from input filename)",
+    )
+    p.add_argument("--seed", type=int, default=42, help="Random seed (default: 42)")
+    p.add_argument("--max-iter", type=int, default=100,
+                   help="Max k-means iterations (default: 100)")
+    p.add_argument(
+        "--min-freq", type=int, default=2,
+        help="Minimum document-frequency for vocabulary terms (default: 2)",
+    )
     return p.parse_args(argv)
 
 
 def main(argv=None) -> int:
+    """Command-line entry point for the ``litcluster`` command."""
     args = _parse_args(argv)
     path = Path(args.input)
     if not path.is_file():
-        print(f"Error: {path} not found", file=sys.stderr)
+        print(f"Error: file not found: {path}", file=sys.stderr)
         return 1
 
     suffix = path.suffix.lower()
-    kwargs = dict(k=args.k, max_iter=args.max_iter, seed=args.seed, min_term_freq=args.min_freq)
+    kwargs = dict(
+        k=args.k,
+        max_iter=args.max_iter,
+        seed=args.seed,
+        min_term_freq=args.min_freq,
+    )
     if suffix == ".bib":
         lc = LitCluster.from_bibtex(path, **kwargs)
     elif suffix == ".jsonl":
@@ -357,20 +834,25 @@ def main(argv=None) -> int:
 
     lc.fit()
 
-    if args.format == "summary":
+    fmt = args.format
+    if fmt == "summary":
         output = lc.summary()
         if args.output:
             Path(args.output).write_text(output, encoding="utf-8")
         else:
             print(output)
-    elif args.format == "csv":
+    elif fmt == "csv":
         out = Path(args.output) if args.output else path.with_suffix(".clusters.csv")
         lc.export_csv(out)
         print(f"Clusters written to {out}")
-    elif args.format == "json":
+    elif fmt == "json":
         out = Path(args.output) if args.output else path.with_suffix(".clusters.json")
         lc.export_json(out)
         print(f"Clusters written to {out}")
+    elif fmt == "html":
+        out = Path(args.output) if args.output else path.with_suffix(".clusters.html")
+        lc.export_html(out)
+        print(f"Interactive HTML written to {out}")
 
     return 0
 

--- a/litcluster_gui.py
+++ b/litcluster_gui.py
@@ -1,0 +1,445 @@
+#!/usr/bin/env python3
+"""
+litcluster_gui.py — Tkinter GUI for the litcluster tool.
+
+Launch with::
+
+    python litcluster_gui.py
+    # or, after installation:
+    litcluster-gui
+"""
+
+from __future__ import annotations
+
+import pathlib
+import sys
+import threading
+import tkinter as tk
+from tkinter import filedialog, messagebox, ttk
+
+# Resolve litcluster.py from the same directory as this file
+sys.path.insert(0, str(pathlib.Path(__file__).parent))
+from litcluster import LitCluster, Cluster, Paper, __version__
+
+
+class _AboutDialog(tk.Toplevel):
+    """Simple modal About dialog."""
+
+    def __init__(self, parent: tk.Tk) -> None:
+        super().__init__(parent)
+        self.title("About litcluster")
+        self.resizable(False, False)
+        self.grab_set()
+        tk.Label(
+            self,
+            text="litcluster",
+            font=("TkDefaultFont", 16, "bold"),
+            pady=10,
+        ).pack()
+        tk.Label(
+            self,
+            text=(
+                f"Version {__version__}\n\n"
+                "Topic-based clustering of scientific literature\n"
+                "using TF-IDF + k-means.\n\n"
+                "Pure Python — zero external dependencies.\n"
+            ),
+            justify="center",
+            pady=4,
+        ).pack()
+        ttk.Button(self, text="Close", command=self.destroy).pack(pady=(0, 12))
+        self.update_idletasks()
+        x = parent.winfo_x() + (parent.winfo_width() - self.winfo_width()) // 2
+        y = parent.winfo_y() + (parent.winfo_height() - self.winfo_height()) // 2
+        self.geometry(f"+{x}+{y}")
+
+
+class LitClusterApp(tk.Tk):
+    """Main application window."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.title("litcluster — Literature Clustering Tool")
+        self.geometry("960x680")
+        self.minsize(700, 520)
+
+        self._lc: LitCluster | None = None
+        self._build_menu()
+        self._build_ui()
+
+    # ------------------------------------------------------------------
+    # Menu bar
+    # ------------------------------------------------------------------
+
+    def _build_menu(self) -> None:
+        menubar = tk.Menu(self)
+        self.configure(menu=menubar)
+
+        file_menu = tk.Menu(menubar, tearoff=False)
+        file_menu.add_command(label="Open…", accelerator="Ctrl+O", command=self._browse)
+        file_menu.add_separator()
+        file_menu.add_command(label="Export CSV…", command=self._export_csv)
+        file_menu.add_command(label="Export JSON…", command=self._export_json)
+        file_menu.add_command(label="Export HTML…", command=self._export_html)
+        file_menu.add_separator()
+        file_menu.add_command(label="Quit", accelerator="Ctrl+Q", command=self.quit)
+        menubar.add_cascade(label="File", menu=file_menu)
+
+        help_menu = tk.Menu(menubar, tearoff=False)
+        help_menu.add_command(label="About", command=lambda: _AboutDialog(self))
+        menubar.add_cascade(label="Help", menu=help_menu)
+
+        self.bind_all("<Control-o>", lambda _e: self._browse())
+        self.bind_all("<Control-q>", lambda _e: self.quit())
+
+    # ------------------------------------------------------------------
+    # Main UI
+    # ------------------------------------------------------------------
+
+    def _build_ui(self) -> None:
+        # ---- Input / parameters frame ----
+        top = ttk.LabelFrame(self, text="Input & Parameters", padding=8)
+        top.pack(fill="x", padx=10, pady=(8, 4))
+
+        # File row
+        ttk.Label(top, text="File:").grid(row=0, column=0, sticky="w")
+        self._file_var = tk.StringVar()
+        ttk.Entry(top, textvariable=self._file_var, width=60).grid(
+            row=0, column=1, columnspan=4, padx=(4, 4), sticky="ew"
+        )
+        ttk.Button(top, text="Browse…", command=self._browse).grid(
+            row=0, column=5, padx=(0, 4)
+        )
+        top.columnconfigure(1, weight=1)
+
+        # Parameters row
+        params: list[tuple[str, str, int, int, int]] = [
+            ("k (clusters):", "_k_var", 5, 2, 99),
+            ("Seed:", "_seed_var", 42, 0, 9999),
+            ("Max iter:", "_maxiter_var", 100, 10, 9999),
+            ("Min freq:", "_minfreq_var", 2, 1, 50),
+        ]
+        for col, (lbl, attr, default, lo, hi) in enumerate(params):
+            ttk.Label(top, text=lbl).grid(
+                row=1, column=col, sticky="e", padx=(8 if col else 0, 2), pady=(6, 0)
+            )
+            var = tk.IntVar(value=default)
+            setattr(self, attr, var)
+            ttk.Spinbox(top, from_=lo, to=hi, textvariable=var, width=7).grid(
+                row=1, column=col, sticky="w", padx=(70, 0), pady=(6, 0)
+            )
+
+        self._run_btn = ttk.Button(
+            top, text="▶  Run Clustering", command=self._run
+        )
+        self._run_btn.grid(row=1, column=5, pady=(6, 0))
+
+        # ---- Paned area: tree + detail ----
+        pane = ttk.PanedWindow(self, orient="horizontal")
+        pane.pack(fill="both", expand=True, padx=10, pady=4)
+
+        # Left: cluster / paper tree
+        left = ttk.LabelFrame(pane, text="Clusters & Papers", padding=4)
+        pane.add(left, weight=3)
+
+        self._tree = ttk.Treeview(
+            left,
+            columns=("info",),
+            show="tree headings",
+            selectmode="browse",
+        )
+        self._tree.heading("#0", text="Cluster / Paper title")
+        self._tree.heading("info", text="Year / Size")
+        self._tree.column("#0", width=320, minwidth=180)
+        self._tree.column("info", width=90, minwidth=60, anchor="center")
+        ysb = ttk.Scrollbar(left, orient="vertical", command=self._tree.yview)
+        xsb = ttk.Scrollbar(left, orient="horizontal", command=self._tree.xview)
+        self._tree.configure(yscrollcommand=ysb.set, xscrollcommand=xsb.set)
+        self._tree.grid(row=0, column=0, sticky="nsew")
+        ysb.grid(row=0, column=1, sticky="ns")
+        xsb.grid(row=1, column=0, sticky="ew")
+        left.rowconfigure(0, weight=1)
+        left.columnconfigure(0, weight=1)
+        self._tree.bind("<<TreeviewSelect>>", self._on_select)
+
+        # Right: detail panel
+        right = ttk.LabelFrame(pane, text="Paper Details", padding=6)
+        pane.add(right, weight=2)
+
+        self._detail = tk.Text(
+            right,
+            wrap="word",
+            state="disabled",
+            font=("TkDefaultFont", 9),
+            bg="#fdfdfd",
+            relief="flat",
+            cursor="arrow",
+        )
+        det_sb = ttk.Scrollbar(right, orient="vertical", command=self._detail.yview)
+        self._detail.configure(yscrollcommand=det_sb.set)
+        self._detail.grid(row=0, column=0, sticky="nsew")
+        det_sb.grid(row=0, column=1, sticky="ns")
+        right.rowconfigure(0, weight=1)
+        right.columnconfigure(0, weight=1)
+
+        # Configure text tags for detail panel
+        self._detail.tag_configure("heading", font=("TkDefaultFont", 10, "bold"))
+        self._detail.tag_configure("label", foreground="#555555")
+        self._detail.tag_configure("value", foreground="#111111")
+
+        # ---- Bottom: export buttons + status bar ----
+        bot = ttk.Frame(self)
+        bot.pack(fill="x", padx=10, pady=(0, 8))
+
+        ttk.Button(bot, text="Export CSV…", command=self._export_csv).pack(
+            side="left", padx=(0, 4)
+        )
+        ttk.Button(bot, text="Export JSON…", command=self._export_json).pack(
+            side="left", padx=4
+        )
+        ttk.Button(bot, text="Export HTML…", command=self._export_html).pack(
+            side="left", padx=4
+        )
+
+        self._status_var = tk.StringVar(value="Ready. Open a file to begin.")
+        ttk.Label(
+            bot, textvariable=self._status_var, foreground="#555", anchor="e"
+        ).pack(side="right", padx=6)
+
+        self._progress = ttk.Progressbar(bot, mode="indeterminate", length=80)
+
+    # ------------------------------------------------------------------
+    # Actions
+    # ------------------------------------------------------------------
+
+    def _browse(self) -> None:
+        path = filedialog.askopenfilename(
+            title="Open literature file",
+            filetypes=[
+                ("All supported", "*.csv *.jsonl *.bib"),
+                ("CSV files", "*.csv"),
+                ("JSONL files", "*.jsonl"),
+                ("BibTeX files", "*.bib"),
+                ("All files", "*"),
+            ],
+        )
+        if path:
+            self._file_var.set(path)
+
+    def _run(self) -> None:
+        path_str = self._file_var.get().strip()
+        if not path_str:
+            messagebox.showerror("No file selected", "Please select an input file first.")
+            return
+        path = pathlib.Path(path_str)
+        if not path.is_file():
+            messagebox.showerror("File not found", f"Cannot find:\n{path}")
+            return
+
+        self._run_btn.configure(state="disabled")
+        self._status("Clustering…")
+        self._progress.pack(side="left", padx=8)
+        self._progress.start(12)
+        self._tree.delete(*self._tree.get_children())
+        self._clear_detail()
+
+        def _worker() -> None:
+            try:
+                suffix = path.suffix.lower()
+                kwargs: dict = dict(
+                    k=self._k_var.get(),
+                    seed=self._seed_var.get(),
+                    max_iter=self._maxiter_var.get(),
+                    min_term_freq=self._minfreq_var.get(),
+                )
+                if suffix == ".bib":
+                    lc = LitCluster.from_bibtex(path, **kwargs)
+                elif suffix == ".jsonl":
+                    lc = LitCluster.from_jsonl(path, **kwargs)
+                else:
+                    lc = LitCluster.from_csv(path, **kwargs)
+                lc.fit()
+                self._lc = lc
+                self.after(0, self._populate_tree)
+            except Exception as exc:
+                msg = str(exc)
+                self.after(0, lambda: (
+                    messagebox.showerror("Clustering failed", msg),
+                    self._status(f"Error: {msg}"),
+                    self._stop_progress(),
+                    self._run_btn.configure(state="normal"),
+                ))
+
+        threading.Thread(target=_worker, daemon=True).start()
+
+    def _stop_progress(self) -> None:
+        self._progress.stop()
+        self._progress.pack_forget()
+
+    def _populate_tree(self) -> None:
+        lc = self._lc
+        self._tree.delete(*self._tree.get_children())
+        for c in lc.clusters:
+            cid = self._tree.insert(
+                "",
+                "end",
+                iid=f"c{c.cluster_id}",
+                text=c.label,
+                values=(f"{len(c.papers)} papers",),
+                open=False,
+                tags=("cluster",),
+            )
+            for p in c.papers:
+                # Use a safe iid: prefix with 'p' and cluster id to avoid collisions
+                iid = f"p{c.cluster_id}_{p.paper_id}"
+                self._tree.insert(
+                    cid,
+                    "end",
+                    iid=iid,
+                    text=(p.title or "(no title)")[:100],
+                    values=(p.year or "",),
+                    tags=("paper",),
+                )
+        self._tree.tag_configure("cluster", font=("TkDefaultFont", 9, "bold"))
+        self._tree.tag_configure("paper", font=("TkDefaultFont", 9))
+        self._stop_progress()
+        self._status(
+            f"Done — {len(lc.papers)} papers in {len(lc.clusters)} clusters."
+        )
+        self._run_btn.configure(state="normal")
+
+    def _on_select(self, _event=None) -> None:
+        sel = self._tree.selection()
+        if not sel or not self._lc:
+            return
+        iid = sel[0]
+        if iid.startswith("c"):
+            try:
+                cid = int(iid[1:])
+            except ValueError:
+                return
+            cluster = next(
+                (c for c in self._lc.clusters if c.cluster_id == cid), None
+            )
+            if cluster:
+                self._show_cluster(cluster)
+        elif iid.startswith("p"):
+            # iid format: p{cluster_id}_{paper_id}
+            rest = iid[1:]
+            parts = rest.split("_", 1)
+            if len(parts) == 2:
+                paper_id = parts[1]
+                paper = next(
+                    (p for p in self._lc.papers if p.paper_id == paper_id), None
+                )
+                if paper:
+                    self._show_paper(paper)
+
+    # ------------------------------------------------------------------
+    # Detail panel helpers
+    # ------------------------------------------------------------------
+
+    def _clear_detail(self) -> None:
+        self._detail.configure(state="normal")
+        self._detail.delete("1.0", "end")
+        self._detail.configure(state="disabled")
+
+    def _show_paper(self, paper: Paper) -> None:
+        self._detail.configure(state="normal")
+        self._detail.delete("1.0", "end")
+        fields = [
+            ("Title", paper.title or "—"),
+            ("Authors", paper.authors or "—"),
+            ("Year", paper.year or "—"),
+            ("Venue", paper.venue or "—"),
+            ("DOI", paper.doi or "—"),
+            ("Keywords", paper.keywords or "—"),
+        ]
+        for label, value in fields:
+            self._detail.insert("end", f"{label}:  ", "label")
+            self._detail.insert("end", f"{value}\n", "value")
+        self._detail.insert("end", "\nAbstract\n", "heading")
+        self._detail.insert("end", paper.abstract or "(no abstract)", "value")
+        self._detail.configure(state="disabled")
+
+    def _show_cluster(self, cluster: Cluster) -> None:
+        self._detail.configure(state="normal")
+        self._detail.delete("1.0", "end")
+        self._detail.insert("end", f"{cluster.label}\n", "heading")
+        self._detail.insert("end", f"\nPapers:    ", "label")
+        self._detail.insert("end", f"{len(cluster.papers)}\n", "value")
+        self._detail.insert("end", "Top terms: ", "label")
+        self._detail.insert("end", ", ".join(cluster.top_terms) + "\n", "value")
+        self._detail.configure(state="disabled")
+
+    def _status(self, msg: str) -> None:
+        self._status_var.set(msg)
+
+    # ------------------------------------------------------------------
+    # Export helpers
+    # ------------------------------------------------------------------
+
+    def _check_lc(self) -> bool:
+        if not self._lc or not self._lc.clusters:
+            messagebox.showinfo("No results", "Run clustering first.")
+            return False
+        return True
+
+    def _export_csv(self) -> None:
+        if not self._check_lc():
+            return
+        path = filedialog.asksaveasfilename(
+            title="Save CSV",
+            defaultextension=".csv",
+            filetypes=[("CSV files", "*.csv"), ("All files", "*")],
+        )
+        if path:
+            try:
+                self._lc.export_csv(pathlib.Path(path))
+                self._status(f"Saved: {path}")
+            except Exception as exc:
+                messagebox.showerror("Export failed", str(exc))
+
+    def _export_json(self) -> None:
+        if not self._check_lc():
+            return
+        path = filedialog.asksaveasfilename(
+            title="Save JSON",
+            defaultextension=".json",
+            filetypes=[("JSON files", "*.json"), ("All files", "*")],
+        )
+        if path:
+            try:
+                self._lc.export_json(pathlib.Path(path))
+                self._status(f"Saved: {path}")
+            except Exception as exc:
+                messagebox.showerror("Export failed", str(exc))
+
+    def _export_html(self) -> None:
+        if not self._check_lc():
+            return
+        path = filedialog.asksaveasfilename(
+            title="Save interactive HTML report",
+            defaultextension=".html",
+            filetypes=[("HTML files", "*.html"), ("All files", "*")],
+        )
+        if path:
+            try:
+                self._lc.export_html(pathlib.Path(path))
+                self._status(f"Saved: {path}")
+            except Exception as exc:
+                messagebox.showerror("Export failed", str(exc))
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    """Launch the litcluster GUI application."""
+    app = LitClusterApp()
+    app.mainloop()
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,8 @@ classifiers = [
 ]
 
 [project.scripts]
-litcluster = "litcluster:_cli"
+litcluster = "litcluster:main"
+litcluster-gui = "litcluster_gui:main"
 
 [tool.setuptools]
-py-modules = ["litcluster"]
+py-modules = ["litcluster", "litcluster_gui"]

--- a/src/litcluster/__init__.py
+++ b/src/litcluster/__init__.py
@@ -1,18 +1,32 @@
 """
 litcluster: Semantic clustering and topic modelling of scientific literature.
 
-Ingests collections of scientific abstracts or full papers (via DOI lists,
-BibTeX files, or arXiv IDs), embeds them using sentence-transformers, and
-applies hierarchical clustering and topic modelling to produce interactive
-visualisations and structured cluster summaries for systematic literature
-reviews.
+Ingests collections of academic papers (BibTeX, CSV, or JSONL), builds
+TF-IDF vectors from titles and abstracts, and applies k-means clustering
+to group papers by topic.  Results can be exported as CSV, JSON, or an
+interactive self-contained HTML report.
 """
 
 __version__ = "0.1.0"
 __author__ = "Vaibhav Deshmukh"
 __license__ = "MIT"
 
-from .cluster import LitCluster
-from .embed import PaperEmbedder
+import sys as _sys
+from pathlib import Path as _Path
 
-__all__ = ["LitCluster", "PaperEmbedder"]
+# The canonical implementation lives in litcluster.py at the repository root.
+# When the package is used in-development (editable install or direct clone)
+# we ensure the root is on sys.path so the import resolves correctly.
+_root = str(_Path(__file__).parent.parent.parent)
+if _root not in _sys.path:
+    _sys.path.insert(0, _root)
+
+from litcluster import (  # noqa: E402
+    LitCluster,
+    Paper,
+    Cluster,
+    _tokenise,
+    _bibtex_field,
+)
+
+__all__ = ["LitCluster", "Paper", "Cluster"]

--- a/tests/test_litcluster.py
+++ b/tests/test_litcluster.py
@@ -1,19 +1,602 @@
-import sys, pathlib
+"""
+Tests for litcluster — covers text processing, data structures, I/O,
+the full clustering pipeline, and all export formats.
+"""
+
+import csv
+import json
+import pathlib
+import sys
+
+import pytest
+
+# Resolve litcluster.py from the repository root
 sys.path.insert(0, str(pathlib.Path(__file__).parent.parent))
 
-def test_import():
-    import litcluster as lc
-    assert hasattr(lc, 'LitCluster')
+import litcluster as lc_module
+from litcluster import (
+    Cluster,
+    LitCluster,
+    Paper,
+    _bibtex_field,
+    _cosine,
+    _kmeans,
+    _tfidf,
+    _tokenise,
+)
 
-def test_paper():
-    import litcluster as lc
-    assert hasattr(lc, 'Paper')
 
-def test_cluster():
-    import litcluster as lc
-    assert hasattr(lc, 'Cluster')
+# ---------------------------------------------------------------------------
+# _tokenise
+# ---------------------------------------------------------------------------
 
-def test_tokenise():
-    import litcluster as lc
-    tokens = lc._tokenise('hello world test foo bar')
-    assert isinstance(tokens, list) and len(tokens) > 0
+def test_tokenise_returns_list():
+    assert isinstance(_tokenise("hello world test"), list)
+
+
+def test_tokenise_lowercases():
+    tokens = _tokenise("Machine Learning Neural")
+    assert all(t == t.lower() for t in tokens)
+
+
+def test_tokenise_removes_stopwords():
+    tokens = _tokenise("the quick brown fox")
+    assert "the" not in tokens
+
+
+def test_tokenise_min_length_three():
+    tokens = _tokenise("a ab abc abcd")
+    assert "a" not in tokens
+    assert "ab" not in tokens
+    assert "abc" in tokens
+    assert "abcd" in tokens
+
+
+def test_tokenise_empty_string():
+    assert _tokenise("") == []
+
+
+def test_tokenise_non_alpha_ignored():
+    tokens = _tokenise("123 !@# hello")
+    assert "123" not in tokens
+    assert "hello" in tokens
+
+
+# ---------------------------------------------------------------------------
+# _tfidf
+# ---------------------------------------------------------------------------
+
+def test_tfidf_empty_input():
+    vectors, vocab = _tfidf([])
+    assert vectors == []
+    assert vocab == []
+
+
+def test_tfidf_single_doc():
+    vectors, vocab = _tfidf([["machine", "learning"]])
+    assert len(vectors) == 1
+    assert "machine" in vectors[0]
+    assert "learning" in vectors[0]
+
+
+def test_tfidf_two_docs():
+    docs = [["machine", "learning", "neural"], ["biology", "protein", "cell"]]
+    vectors, vocab = _tfidf(docs)
+    assert len(vectors) == 2
+    assert len(vocab) == 6
+
+
+def test_tfidf_weights_positive():
+    vectors, _ = _tfidf([["deep", "learning"], ["protein", "folding"]])
+    for vec in vectors:
+        assert all(v > 0 for v in vec.values())
+
+
+def test_tfidf_rare_terms_get_high_idf():
+    # Both terms appear once in doc[0] (equal TF), but "unique" is absent
+    # from all other docs so IDF drives its score higher than "common".
+    docs = [["unique", "common"]] + [["common", "other"]] * 9
+    vectors, _ = _tfidf(docs)
+    assert vectors[0].get("unique", 0) > vectors[0].get("common", 0)
+
+
+def test_tfidf_empty_doc_gives_empty_vector():
+    vectors, vocab = _tfidf([["alpha", "beta"], []])
+    assert vectors[1] == {}
+
+
+# ---------------------------------------------------------------------------
+# _cosine
+# ---------------------------------------------------------------------------
+
+def test_cosine_identical_vectors():
+    v = {"a": 1.0, "b": 2.0}
+    assert abs(_cosine(v, v) - 1.0) < 1e-9
+
+
+def test_cosine_orthogonal_vectors():
+    assert _cosine({"x": 1.0}, {"y": 1.0}) == 0.0
+
+
+def test_cosine_empty_first():
+    assert _cosine({}, {"a": 1.0}) == 0.0
+
+
+def test_cosine_empty_second():
+    assert _cosine({"a": 1.0}, {}) == 0.0
+
+
+def test_cosine_both_empty():
+    assert _cosine({}, {}) == 0.0
+
+
+def test_cosine_range():
+    a = {"a": 1.0, "b": 0.5}
+    b = {"a": 0.5, "c": 1.0}
+    sim = _cosine(a, b)
+    assert 0.0 <= sim <= 1.0
+
+
+# ---------------------------------------------------------------------------
+# _kmeans
+# ---------------------------------------------------------------------------
+
+def test_kmeans_empty_input():
+    assert _kmeans([], k=3) == []
+
+
+def test_kmeans_single_vector():
+    labels = _kmeans([{"a": 1.0}], k=3)
+    assert labels == [0]
+
+
+def test_kmeans_k_clamped_to_n():
+    vecs = [{"a": float(i)} for i in range(3)]
+    labels = _kmeans(vecs, k=100)
+    assert len(labels) == 3
+    assert all(0 <= l < 3 for l in labels)
+
+
+def test_kmeans_reproducible():
+    vecs = [{"a": float(i), "b": float(i % 3)} for i in range(10)]
+    l1 = _kmeans(vecs, k=3, seed=0)
+    l2 = _kmeans(vecs, k=3, seed=0)
+    assert l1 == l2
+
+
+def test_kmeans_different_seeds_may_differ():
+    vecs = [{"a": float(i)} for i in range(10)]
+    l1 = _kmeans(vecs, k=3, seed=0)
+    l2 = _kmeans(vecs, k=3, seed=99)
+    # Not guaranteed but highly likely with different seeds
+    # (just ensure they run without error)
+    assert len(l1) == len(l2) == 10
+
+
+def test_kmeans_covers_all_indices():
+    vecs = [{"a": float(i)} for i in range(6)]
+    labels = _kmeans(vecs, k=3, seed=42)
+    assert len(labels) == 6
+    assert all(isinstance(l, int) for l in labels)
+
+
+# ---------------------------------------------------------------------------
+# _bibtex_field
+# ---------------------------------------------------------------------------
+
+def test_bibtex_field_braces():
+    entry = "@article{key, title = {Hello World}, year = {2023}}"
+    assert _bibtex_field(entry, "title") == "Hello World"
+    assert _bibtex_field(entry, "year") == "2023"
+
+
+def test_bibtex_field_double_quotes():
+    entry = '@article{key, title = "Quoted Title"}'
+    assert _bibtex_field(entry, "title") == "Quoted Title"
+
+
+def test_bibtex_field_nested_braces():
+    entry = "@article{key, title = {Advances in {Machine Learning}}}"
+    result = _bibtex_field(entry, "title")
+    # Should include the inner braces content
+    assert "Machine Learning" in result
+    assert "Advances" in result
+
+
+def test_bibtex_field_numeric():
+    entry = "@article{key, year = 2024}"
+    assert _bibtex_field(entry, "year") == "2024"
+
+
+def test_bibtex_field_missing_returns_empty():
+    entry = "@article{key, title = {Test}}"
+    assert _bibtex_field(entry, "abstract") == ""
+
+
+def test_bibtex_field_case_insensitive():
+    entry = "@article{key, TITLE = {Upper}}"
+    assert _bibtex_field(entry, "title") == "Upper"
+
+
+# ---------------------------------------------------------------------------
+# Paper dataclass
+# ---------------------------------------------------------------------------
+
+def test_paper_text_combines_fields():
+    p = Paper(paper_id="1", title="Neural Networks", abstract="Deep learning.", keywords="ML")
+    assert "Neural Networks" in p.text
+    assert "Deep learning." in p.text
+    assert "ML" in p.text
+
+
+def test_paper_text_skips_empty_fields():
+    p = Paper(paper_id="1", title="Title", abstract="", keywords="")
+    assert p.text == "Title"
+
+
+def test_paper_to_dict_keys():
+    p = Paper(paper_id="x", title="T", abstract="A")
+    d = p.to_dict()
+    for key in ("paper_id", "title", "abstract", "authors", "year", "venue", "doi", "keywords"):
+        assert key in d
+
+
+# ---------------------------------------------------------------------------
+# Cluster dataclass
+# ---------------------------------------------------------------------------
+
+def test_cluster_label_includes_top_terms():
+    c = Cluster(cluster_id=0, top_terms=["neural", "network", "deep"])
+    assert "neural" in c.label
+    assert "0" in c.label
+
+
+def test_cluster_label_no_terms():
+    c = Cluster(cluster_id=1)
+    assert "1" in c.label
+    assert "—" in c.label
+
+
+def test_cluster_to_dict_structure():
+    c = Cluster(cluster_id=2, papers=[], top_terms=["alpha", "beta"])
+    d = c.to_dict()
+    assert d["cluster_id"] == 2
+    assert d["size"] == 0
+    assert d["top_terms"] == ["alpha", "beta"]
+    assert "label" in d
+    assert "papers" in d
+
+
+# ---------------------------------------------------------------------------
+# Helpers for integration tests
+# ---------------------------------------------------------------------------
+
+def _make_papers(n: int = 10) -> list[Paper]:
+    """Return a list of synthetic papers with distinct topic vocabulary."""
+    corpus = [
+        ("Neural networks for image classification using deep learning "
+         "convolutional architectures and backpropagation training",
+         "deep learning neural convolutional"),
+        ("Protein folding prediction using molecular dynamics simulation "
+         "and energy minimization algorithms",
+         "protein folding biology molecular"),
+        ("Climate change impact on biodiversity and ecosystem services "
+         "in tropical rainforests",
+         "climate ecosystem biodiversity ecology"),
+        ("Quantum computing algorithms for combinatorial optimization "
+         "using variational circuits",
+         "quantum computing algorithm optimization"),
+        ("Genome sequencing analysis using bioinformatics pipelines "
+         "and variant calling workflows",
+         "genome sequencing bioinformatics variant"),
+        ("Autonomous robot navigation using reinforcement learning "
+         "and sensor fusion techniques",
+         "robot navigation reinforcement sensor"),
+        ("Solar energy photovoltaic cell efficiency improvements "
+         "using perovskite materials",
+         "solar photovoltaic energy efficiency"),
+        ("Cancer detection using convolutional neural networks "
+         "on histopathology images",
+         "cancer detection neural histopathology"),
+        ("Natural language processing for abstractive summarization "
+         "using transformer architectures",
+         "language processing transformer summarization"),
+        ("Novel battery materials for energy storage applications "
+         "using lithium-ion chemistry",
+         "battery energy storage materials lithium"),
+    ]
+    papers = []
+    for i, (text, kw) in enumerate(corpus[:n]):
+        papers.append(Paper(
+            paper_id=str(i),
+            title=text[:60],
+            abstract=text,
+            keywords=kw,
+            authors=f"Author {i}",
+            year=str(2020 + i % 5),
+        ))
+    return papers
+
+
+def _make_lc(n: int = 10, k: int = 3) -> LitCluster:
+    obj = LitCluster(k=k, min_term_freq=1, seed=0)
+    obj.papers = _make_papers(n)
+    return obj
+
+
+# ---------------------------------------------------------------------------
+# LitCluster — fit()
+# ---------------------------------------------------------------------------
+
+def test_fit_populates_clusters():
+    lc = _make_lc()
+    lc.fit()
+    assert len(lc.clusters) > 0
+
+
+def test_fit_all_papers_assigned():
+    lc = _make_lc()
+    lc.fit()
+    total = sum(len(c.papers) for c in lc.clusters)
+    assert total == len(lc.papers)
+
+
+def test_fit_clusters_have_top_terms():
+    lc = _make_lc()
+    lc.fit()
+    for c in lc.clusters:
+        assert len(c.top_terms) > 0
+
+
+def test_fit_returns_self():
+    lc = _make_lc()
+    assert lc.fit() is lc
+
+
+def test_fit_empty_corpus_returns_self():
+    lc = LitCluster()
+    result = lc.fit()
+    assert result is lc
+    assert lc.clusters == []
+
+
+def test_fit_k_greater_than_papers():
+    lc = LitCluster(k=100, min_term_freq=1, seed=0)
+    lc.papers = _make_papers(3)
+    lc.fit()
+    # k is clamped to n; all papers assigned
+    assert sum(len(c.papers) for c in lc.clusters) == 3
+
+
+def test_fit_min_term_freq_filters_vocabulary():
+    lc = LitCluster(k=2, min_term_freq=5, seed=0)
+    lc.papers = _make_papers(10)
+    lc.fit()
+    # With high min_term_freq some rare terms may be absent from top_terms
+    # but clustering should still complete
+    assert len(lc.clusters) > 0
+
+
+# ---------------------------------------------------------------------------
+# LitCluster — summary()
+# ---------------------------------------------------------------------------
+
+def test_summary_before_fit():
+    lc = _make_lc()
+    s = lc.summary()
+    assert "fit()" in s
+
+
+def test_summary_after_fit():
+    lc = _make_lc()
+    lc.fit()
+    s = lc.summary()
+    assert "papers" in s
+    assert "clusters" in s
+
+
+def test_summary_lists_cluster_ids():
+    lc = _make_lc(k=2)
+    lc.fit()
+    s = lc.summary()
+    assert "[0]" in s or "[1]" in s
+
+
+# ---------------------------------------------------------------------------
+# LitCluster — loaders
+# ---------------------------------------------------------------------------
+
+def test_from_csv(tmp_path):
+    p = tmp_path / "papers.csv"
+    with p.open("w", newline="") as fh:
+        w = csv.writer(fh)
+        w.writerow(["paper_id", "title", "abstract", "authors",
+                    "year", "venue", "doi", "keywords"])
+        w.writerow(["1", "Deep Learning", "Neural networks.", "Smith", "2020",
+                    "NeurIPS", "10.1/ex", "ML"])
+        w.writerow(["2", "Protein Folding", "Biology methods.", "Jones", "2021",
+                    "Nature", "", "bio"])
+    obj = LitCluster.from_csv(p, k=2, min_term_freq=1)
+    assert len(obj.papers) == 2
+    assert obj.papers[0].paper_id == "1"
+    assert obj.papers[0].doi == "10.1/ex"
+
+
+def test_from_csv_missing_columns_default_empty(tmp_path):
+    p = tmp_path / "minimal.csv"
+    with p.open("w", newline="") as fh:
+        csv.writer(fh).writerows([["title"], ["Only Title"]])
+    obj = LitCluster.from_csv(p, k=2, min_term_freq=1)
+    assert len(obj.papers) == 1
+    assert obj.papers[0].abstract == ""
+
+
+def test_from_jsonl(tmp_path):
+    p = tmp_path / "papers.jsonl"
+    with p.open("w") as fh:
+        fh.write(json.dumps({"title": "Test paper", "abstract": "Abstract text."}) + "\n")
+        fh.write("\n")  # blank line should be skipped
+        fh.write(json.dumps({"title": "Another paper", "abstract": "More text."}) + "\n")
+    obj = LitCluster.from_jsonl(p, k=2, min_term_freq=1)
+    assert len(obj.papers) == 2
+
+
+def test_from_bibtex(tmp_path):
+    bib = tmp_path / "refs.bib"
+    bib.write_text(
+        "@article{smith2020,\n"
+        "  title = {Deep Learning for Vision},\n"
+        "  abstract = {Neural network architecture.},\n"
+        "  author = {Smith, John},\n"
+        "  year = {2020},\n"
+        "  journal = {CVPR},\n"
+        "}\n"
+        "@inproceedings{jones2021,\n"
+        "  title = {Protein Structure Prediction},\n"
+        "  abstract = {Biological sequence analysis.},\n"
+        "  author = {Jones, Alice},\n"
+        "  year = {2021},\n"
+        "  booktitle = {NeurIPS},\n"
+        "}\n",
+        encoding="utf-8",
+    )
+    obj = LitCluster.from_bibtex(bib, k=2, min_term_freq=1)
+    assert len(obj.papers) == 2
+    assert obj.papers[0].title == "Deep Learning for Vision"
+    assert obj.papers[1].authors == "Jones, Alice"
+    assert obj.papers[1].venue == "NeurIPS"
+
+
+def test_from_bibtex_nested_braces(tmp_path):
+    bib = tmp_path / "nested.bib"
+    bib.write_text(
+        "@article{k1,\n"
+        "  title = {Advances in {Machine Learning}},\n"
+        "  year = {2023},\n"
+        "}\n",
+        encoding="utf-8",
+    )
+    obj = LitCluster.from_bibtex(bib, k=1, min_term_freq=1)
+    assert len(obj.papers) == 1
+    assert "Machine Learning" in obj.papers[0].title
+
+
+def test_from_bibtex_booktitle_fallback(tmp_path):
+    bib = tmp_path / "conf.bib"
+    bib.write_text(
+        "@inproceedings{conf1,\n"
+        "  title = {Conference Paper},\n"
+        "  booktitle = {ICML 2024},\n"
+        "  year = {2024},\n"
+        "}\n",
+        encoding="utf-8",
+    )
+    obj = LitCluster.from_bibtex(bib, k=1, min_term_freq=1)
+    assert obj.papers[0].venue == "ICML 2024"
+
+
+# ---------------------------------------------------------------------------
+# LitCluster — exports
+# ---------------------------------------------------------------------------
+
+def test_export_csv(tmp_path):
+    lc = _make_lc()
+    lc.fit()
+    out = tmp_path / "out.csv"
+    lc.export_csv(out)
+    assert out.exists()
+    with out.open() as fh:
+        rows = list(csv.reader(fh))
+    assert rows[0][0] == "cluster_id"
+    assert len(rows) == len(lc.papers) + 1  # header + one row per paper
+
+
+def test_export_csv_contains_all_papers(tmp_path):
+    lc = _make_lc()
+    lc.fit()
+    out = tmp_path / "all.csv"
+    lc.export_csv(out)
+    with out.open() as fh:
+        data_rows = list(csv.DictReader(fh))
+    paper_ids_out = {r["paper_id"] for r in data_rows}
+    paper_ids_in = {p.paper_id for p in lc.papers}
+    assert paper_ids_out == paper_ids_in
+
+
+def test_export_json(tmp_path):
+    lc = _make_lc()
+    lc.fit()
+    out = tmp_path / "out.json"
+    lc.export_json(out)
+    assert out.exists()
+    data = json.loads(out.read_text())
+    assert isinstance(data, list)
+    assert len(data) == len(lc.clusters)
+    for entry in data:
+        assert "cluster_id" in entry
+        assert "papers" in entry
+        assert "top_terms" in entry
+
+
+def test_export_html(tmp_path):
+    lc = _make_lc()
+    lc.fit()
+    out = tmp_path / "out.html"
+    lc.export_html(out)
+    assert out.exists()
+    content = out.read_text(encoding="utf-8")
+    assert "<!DOCTYPE html>" in content
+    assert "litcluster" in content
+    # Each cluster should appear
+    for c in lc.clusters:
+        assert str(c.cluster_id) in content
+
+
+def test_export_html_contains_paper_titles(tmp_path):
+    lc = _make_lc(n=5)
+    lc.fit()
+    out = tmp_path / "titles.html"
+    lc.export_html(out)
+    content = out.read_text(encoding="utf-8")
+    for p in lc.papers:
+        assert p.title[:20] in content
+
+
+def test_export_html_special_chars_escaped(tmp_path):
+    lc = LitCluster(k=1, min_term_freq=1, seed=0)
+    lc.papers = [Paper(
+        paper_id="x",
+        title='<script>alert("xss")</script>',
+        abstract="Safe abstract content here.",
+    )]
+    lc.fit()
+    out = tmp_path / "xss.html"
+    lc.export_html(out)
+    content = out.read_text(encoding="utf-8")
+    assert "<script>alert" not in content
+    assert "&lt;script&gt;" in content
+
+
+# ---------------------------------------------------------------------------
+# Module-level attributes (JOSS requirement: importable public API)
+# ---------------------------------------------------------------------------
+
+def test_module_version():
+    assert hasattr(lc_module, "__version__")
+    assert isinstance(lc_module.__version__, str)
+
+
+def test_module_exports_litcluster():
+    assert hasattr(lc_module, "LitCluster")
+
+
+def test_module_exports_paper():
+    assert hasattr(lc_module, "Paper")
+
+
+def test_module_exports_cluster():
+    assert hasattr(lc_module, "Cluster")
+
+
+def test_module_exports_tokenise():
+    assert hasattr(lc_module, "_tokenise")


### PR DESCRIPTION
## Summary

- **Bug fixes**: corrected broken BibTeX parser (nested brace handling), wrong CLI entry point (`_cli` → `main`), broken `src/litcluster/__init__.py` imports, variable shadowing (`l` → `lbl`), empty-vector guard in `_cosine()`
- **New feature — HTML export**: `export_html()` generates a self-contained interactive HTML report with collapsible cluster cards, click-to-reveal abstracts, and a real-time search filter
- **New feature — GUI**: `litcluster_gui.py` is a full tkinter GUI (file browser, parameter spinboxes, background clustering thread, Treeview results panel, detail pane, CSV/JSON/HTML export)
- **Test suite**: expanded from 4 to 63 tests (100 % passing) covering all functions, loaders, exporters, edge cases, and XSS escaping
- **Docs**: README rewritten with installation, quick-start, CLI reference, and API table; CHANGELOG corrected to remove false claims about SPECTER2/UMAP/HDBSCAN

## Test plan

- [ ] `pytest tests/ -v` — all 63 tests pass
- [ ] `python litcluster.py <file>` — CLI summary output works
- [ ] `python litcluster.py <file> --format html -o report.html` — opens in browser with working search and expand/collapse
- [ ] `python litcluster_gui.py` — GUI launches, file loads, clustering runs, export buttons save files

https://claude.ai/code/session_01U12sUUQCEytuS9NA6XJGT1

---
_Generated by [Claude Code](https://claude.ai/code/session_01U12sUUQCEytuS9NA6XJGT1)_