### PR TITLE
JOSS-level refactor: k-means++, interactive HTML report, Tkinter GUI, 72-test suite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,30 @@
+# Python
+__pycache__/
+*.py[cod]
+*.pyo
+*.pyd
+.Python
+
+# Distribution / packaging
+dist/
+build/
+*.egg-info/
+*.egg
+.eggs/
+
+# Virtual environments
+.venv/
+venv/
+env/
+
+# Testing
+.pytest_cache/
+.coverage
+htmlcov/
+
+# Editor / OS
+.DS_Store
+*.swp
+*.swo
+.idea/
+.vscode/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,45 @@
 # Changelog
 
-## [Unreleased]
-- BERTopic backend for interpretable topic labels (#1)
-- Semantic Scholar API for bulk paper fetching (#2)
-- Per-cluster LLM-generated summaries (#3)
+All notable changes to litcluster are documented here.  
+This project follows [Semantic Versioning](https://semver.org/).
 
-## [0.1.0] - 2026-04-23
+## [Unreleased]
+
+### Planned
+- Embedding-based clustering backend (sentence-transformers + HDBSCAN)
+- UMAP 2D projection for HTML scatter-plot visualisation
+- Semantic Scholar API integration for bulk paper fetching
+- Per-cluster LLM-generated summaries
+
+## [0.1.0] – 2026-04-23
+
 ### Added
-- SPECTER2 sentence-transformer embeddings for scientific literature
-- HDBSCAN, k-means, and agglomerative clustering backends
-- UMAP 2D projection for visualisation
-- Interactive HTML report with cluster explorer
-- BibTeX input support
-- CLI: `litcluster cluster refs.bib`
-- Python API: `LitCluster`, `PaperEmbedder`
+- **Core algorithm**: TF-IDF vectorisation with configurable minimum document
+  frequency, followed by Lloyd's k-means with k-means++ initialisation and
+  cosine-similarity distance.
+- **`Paper`** dataclass: stores `paper_id`, `title`, `abstract`, `authors`,
+  `year`, `venue`, `doi`, `keywords`; includes `from_dict()` classmethod.
+- **`Cluster`** dataclass: groups papers by cluster ID with ranked top-terms
+  and an auto-generated label.
+- **`LitCluster`** class with:
+  - `from_bibtex()` — robust BibTeX parser with proper nested-brace handling
+  - `from_csv()` — CSV reader (flexible column names)
+  - `from_jsonl()` — JSONL reader
+  - `from_list()` — programmatic construction from list of dicts
+  - `fit()` — executes the full clustering pipeline; chainable
+  - `export_csv()` — cluster assignments as CSV
+  - `export_json()` — full cluster metadata as JSON
+  - `export_html()` — self-contained interactive HTML report
+  - `summary()` — Markdown-formatted summary table
+- **Interactive HTML report**: offline-capable, single-file output with
+  collapsible cluster cards, top-term badges, paper tables, real-time search,
+  cluster filter dropdown, and colour-coded cluster pills.
+- **CLI** (`litcluster`): supports `summary`, `csv`, `json`, and `html` output
+  formats; all parameters configurable via flags.
+- **Tkinter GUI** (`litcluster-gui`): file browser, parameter spinboxes,
+  background clustering thread, tabbed results view (Summary / Clusters /
+  Papers), paper search, and export dialogs.
+- **Test suite**: 72 pytest tests covering tokenisation, TF-IDF, cosine
+  similarity, k-means, all input parsers, all export formats, CLI, and BibTeX
+  field extraction.
+- MIT licence, `CITATION.cff`, `pyproject.toml` with correct entry points.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,225 @@
 # litcluster
+
+**Topic-based clustering of scientific literature using TF-IDF and k-means.**
+
+`litcluster` groups a collection of academic papers into thematic clusters automatically, using term frequency–inverse document frequency (TF-IDF) vectorisation and k-means clustering. It accepts BibTeX, CSV, or JSONL input and exports results as CSV, JSON, or an interactive self-contained HTML report. A Tkinter desktop GUI is also included.
+
+All functionality uses the Python standard library only — **no external packages required**.
+
+---
+
+## Features
+
+- **Zero dependencies** — pure Python 3.8+ standard library
+- **Multiple input formats** — BibTeX (`.bib`), CSV, JSONL
+- **Multiple output formats** — Markdown summary, CSV, JSON, interactive HTML
+- **Interactive HTML report** — collapsible cluster cards, search, filter; completely offline
+- **Desktop GUI** — Tkinter interface for interactive use (`litcluster-gui`)
+- **Reproducible** — fixed random seed, deterministic k-means++ initialisation
+
+---
+
+## Installation
+
+```bash
+pip install .
+```
+
+Or directly from source:
+
+```bash
+git clone https://github.com/vdeshmukh203/litcluster.git
+cd litcluster
+pip install -e .
+```
+
+---
+
+## Quick start
+
+### Command-line interface
+
+```bash
+# Cluster a BibTeX file into 5 groups and print a Markdown summary
+litcluster refs.bib -k 5
+
+# Export an interactive HTML report
+litcluster refs.bib -k 6 --format html --output report.html
+
+# Cluster a CSV file, export to JSON
+litcluster papers.csv -k 8 --format json --output clusters.json
+```
+
+**CLI options**
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `-k`, `--clusters` | `5` | Number of clusters |
+| `--format` | `summary` | Output format: `summary`, `csv`, `json`, `html` |
+| `--output`, `-o` | auto | Output file path |
+| `--seed` | `42` | Random seed |
+| `--max-iter` | `100` | Maximum k-means iterations |
+| `--min-freq` | `2` | Minimum document frequency for vocabulary |
+| `--title` | `"Literature Cluster Report"` | Title used in HTML export |
+
+### Desktop GUI
+
+```bash
+litcluster-gui
+```
+
+The GUI lets you browse for an input file, adjust parameters, run clustering, inspect results by cluster, search papers, and export in any format.
+
+### Python API
+
+```python
+from pathlib import Path
+import litcluster as lc
+
+# Load from BibTeX
+model = lc.LitCluster.from_bibtex(Path("refs.bib"), k=6, min_term_freq=2)
+model.fit()
+
+# Inspect results
+print(model.summary())
+for cluster in model.clusters:
+    print(f"\nCluster {cluster.cluster_id}: {cluster.label}")
+    print("Top terms:", cluster.top_terms)
+    for paper in cluster.papers:
+        print(f"  {paper.title} ({paper.year})")
+
+# Export
+model.export_html(Path("report.html"), title="My Literature Survey")
+model.export_csv(Path("clusters.csv"))
+model.export_json(Path("clusters.json"))
+```
+
+**Load from a list of dicts (programmatic use):**
+
+```python
+papers = [
+    {"title": "Deep learning for vision", "abstract": "CNN-based methods...", "year": "2021"},
+    {"title": "Protein folding with AlphaFold", "abstract": "Structure prediction...", "year": "2022"},
+    # ...
+]
+model = lc.LitCluster.from_list(papers, k=4).fit()
+```
+
+---
+
+## Input formats
+
+### BibTeX (`.bib`)
+
+Standard BibTeX files. `litcluster` extracts `title`, `abstract`, `author`,
+`year`, `journal`/`booktitle`, `doi`, and `keywords`. Nested braces and
+multi-line values are handled correctly.
+
+```bibtex
+@article{smith2021,
+  title    = {Deep learning for image recognition},
+  abstract = {We present a convolutional neural network...},
+  author   = {Smith, J. and Jones, A.},
+  year     = {2021},
+  journal  = {CVPR},
+  doi      = {10.1000/xyz123},
+}
+```
+
+### CSV
+
+Any CSV with a header row. Recognised column names:
+`paper_id`, `title`, `abstract`, `authors`, `year`, `venue`, `doi`, `keywords`.
+All columns are optional; at least `title` or `abstract` should be present.
+
+### JSONL
+
+One JSON object per line, with the same field names as CSV.
+
+---
+
+## Output formats
+
+### Markdown summary (default)
+
+```markdown
+# LitCluster Report
+
+**24 papers** — **4 clusters**
+
+| # | Label                         | Papers | Top Terms                          |
+|---|-------------------------------|-------:|------------------------------------|
+| 0 | Cluster 0: neural, image, cnn |      8 | neural, image, cnn, detection, ...  |
+| 1 | Cluster 1: protein, structure |      6 | protein, structure, folding, ...    |
+```
+
+### Interactive HTML report
+
+A single `.html` file with:
+- Header with total paper and cluster counts
+- Search bar that filters papers across all clusters
+- Cluster filter dropdown and colour-coded cluster pills
+- Collapsible cluster cards with top-term badges and paper tables
+
+### CSV
+
+Two-level CSV with columns:
+`cluster_id`, `cluster_label`, `paper_id`, `title`, `authors`, `year`, `venue`, `doi`
+
+### JSON
+
+Array of cluster objects, each with `cluster_id`, `size`, `label`, `top_terms`,
+and a `papers` array of full metadata records.
+
+---
+
+## Algorithm
+
+1. **Tokenisation** — extract alphabetic tokens (≥ 3 characters), lower-cased,
+   with English stopwords and common academic filler words removed.
+2. **TF-IDF vectorisation** — build sparse document vectors using term
+   frequency × smoothed inverse document frequency; terms appearing in fewer
+   than `min_term_freq` documents are discarded.
+3. **k-means++ initialisation** — select initial centroids with probability
+   proportional to squared cosine distance from existing centroids, reducing
+   sensitivity to random initialisation.
+4. **Lloyd's algorithm** — iterate assignment (cosine similarity) and centroid
+   recomputation until convergence or `max_iter` is reached.
+5. **Cluster labelling** — rank terms by mean normalised TF-IDF score across
+   cluster members; top-3 terms form the cluster label.
+
+---
+
+## Running the tests
+
+```bash
+pip install pytest
+pytest tests/ -v
+```
+
+72 tests cover tokenisation, TF-IDF, cosine similarity, k-means, all input
+parsers, all export formats, and the CLI.
+
+---
+
+## Citation
+
+If you use `litcluster` in published research, please cite:
+
+```bibtex
+@software{deshmukh2026litcluster,
+  author  = {Deshmukh, Vaibhav},
+  title   = {litcluster: Topic-based clustering of scientific literature},
+  version = {0.1.0},
+  year    = {2026},
+  url     = {https://github.com/vdeshmukh203/litcluster},
+}
+```
+
+See also `CITATION.cff`.
+
+---
+
+## Licence
+
+MIT — see `LICENSE`.

--- a/litcluster.py
+++ b/litcluster.py
@@ -1,8 +1,14 @@
 #!/usr/bin/env python3
 """
-litcluster.py — Literature Clustering Tool
-Clusters academic papers by topic using TF-IDF + k-means (pure stdlib).
-Stdlib-only. No external dependencies.
+litcluster — Literature Clustering Tool
+
+Clusters academic papers by topic using TF-IDF vectorisation and k-means
+(Lloyd's algorithm with k-means++ initialisation). Supports BibTeX, CSV,
+and JSONL input formats, and exports results as CSV, JSON, or a
+self-contained interactive HTML report.
+
+All functionality uses the Python standard library only; no external
+packages are required.
 """
 
 from __future__ import annotations
@@ -11,6 +17,7 @@ import argparse
 import csv
 import json
 import math
+import random
 import re
 import sys
 from dataclasses import dataclass, field
@@ -23,72 +30,124 @@ from typing import Dict, List, Optional, Tuple
 # ---------------------------------------------------------------------------
 
 _STOPWORDS = {
-    'a','an','the','and','or','but','in','on','at','to','for','of','with',
-    'by','from','is','was','are','were','be','been','being','have','has',
-    'had','do','does','did','will','would','could','should','may','might',
-    'this','that','these','those','it','its','we','our','they','their',
-    'as','if','not','no','nor','so','yet','both','either','whether',
-    'each','few','more','most','other','some','such','than','too','very',
-    'just','also','only','then','here','there','when','where','who','which',
-    'how','all','any','can','into','through','during','before','after',
-    'above','below','between','out','off','over','under','again','further',
-    'once','i','my','me','he','she','his','her','him','you','your',
+    'a', 'an', 'the', 'and', 'or', 'but', 'in', 'on', 'at', 'to', 'for',
+    'of', 'with', 'by', 'from', 'is', 'was', 'are', 'were', 'be', 'been',
+    'being', 'have', 'has', 'had', 'do', 'does', 'did', 'will', 'would',
+    'could', 'should', 'may', 'might', 'this', 'that', 'these', 'those',
+    'it', 'its', 'we', 'our', 'they', 'their', 'as', 'if', 'not', 'no',
+    'nor', 'so', 'yet', 'both', 'either', 'whether', 'each', 'few', 'more',
+    'most', 'other', 'some', 'such', 'than', 'too', 'very', 'just', 'also',
+    'only', 'then', 'here', 'there', 'when', 'where', 'who', 'which', 'how',
+    'all', 'any', 'can', 'into', 'through', 'during', 'before', 'after',
+    'above', 'below', 'between', 'out', 'off', 'over', 'under', 'again',
+    'further', 'once', 'i', 'my', 'me', 'he', 'she', 'his', 'her', 'him',
+    'you', 'your', 'use', 'used', 'using', 'show', 'shows', 'shown',
+    'present', 'propose', 'proposed', 'paper', 'study', 'work', 'based',
+    'approach', 'method', 'results', 'data', 'new', 'two', 'first',
 }
 
 
 def _tokenise(text: str) -> List[str]:
+    """Extract lowercase alphabetic tokens of 3+ characters, excluding stopwords."""
+    if not text:
+        return []
     tokens = re.findall(r"[a-zA-Z]{3,}", text.lower())
     return [t for t in tokens if t not in _STOPWORDS]
 
 
-def _tfidf(documents: List[List[str]]) -> Tuple[List[Dict[str,float]], List[str]]:
-    """Compute TF-IDF vectors. Returns (vectors, vocab)."""
+def _tfidf(
+    documents: List[List[str]],
+    min_freq: int = 1,
+) -> Tuple[List[Dict[str, float]], List[str]]:
+    """Compute TF-IDF sparse vectors for a corpus.
+
+    Parameters
+    ----------
+    documents:
+        Each element is a list of tokens for one document.
+    min_freq:
+        Terms appearing in fewer than this many documents are excluded.
+
+    Returns
+    -------
+    vectors:
+        One sparse TF-IDF dict per document.
+    vocab:
+        Sorted list of terms in the vocabulary.
+    """
     n = len(documents)
     if n == 0:
         return [], []
 
-    # Build vocab
-    vocab_set: set = set()
-    for doc in documents:
-        vocab_set.update(doc)
-    vocab = sorted(vocab_set)
-    term_idx = {t: i for i, t in enumerate(vocab)}
-    V = len(vocab)
-
     # Document frequency
-    df = [0] * V
+    df: Dict[str, int] = {}
     for doc in documents:
-        doc_set = set(doc)
-        for t in doc_set:
-            if t in term_idx:
-                df[term_idx[t]] += 1
+        for t in set(doc):
+            df[t] = df.get(t, 0) + 1
 
-    # TF-IDF
+    vocab = sorted(t for t, count in df.items() if count >= min_freq)
+    if not vocab:
+        return [{} for _ in documents], []
+
+    # TF-IDF vectors
     vectors: List[Dict[str, float]] = []
     for doc in documents:
-        tf: Dict[int, int] = {}
-        for t in doc:
-            if t in term_idx:
-                idx = term_idx[t]
-                tf[idx] = tf.get(idx, 0) + 1
-        vec: Dict[str, float] = {}
         doc_len = len(doc) or 1
-        for idx, count in tf.items():
-            term = vocab[idx]
-            tf_val = count / doc_len
-            idf_val = math.log((n + 1) / (df[idx] + 1)) + 1.0
-            vec[term] = tf_val * idf_val
+        tf: Dict[str, int] = {}
+        for t in doc:
+            if t in df and df[t] >= min_freq:
+                tf[t] = tf.get(t, 0) + 1
+        vec: Dict[str, float] = {}
+        for t, count in tf.items():
+            idf = math.log((n + 1) / (df[t] + 1)) + 1.0
+            vec[t] = (count / doc_len) * idf
         vectors.append(vec)
     return vectors, vocab
 
 
 def _cosine(a: Dict[str, float], b: Dict[str, float]) -> float:
-    dot = sum(a.get(t, 0.0) * b.get(t, 0.0) for t in b)
-    norm_a = math.sqrt(sum(v*v for v in a.values()))
-    norm_b = math.sqrt(sum(v*v for v in b.values()))
-    if norm_a == 0 or norm_b == 0:
+    """Cosine similarity between two sparse vectors."""
+    if not a or not b:
+        return 0.0
+    dot = sum(a.get(t, 0.0) * v for t, v in b.items())
+    norm_a = math.sqrt(sum(v * v for v in a.values()))
+    norm_b = math.sqrt(sum(v * v for v in b.values()))
+    if norm_a == 0.0 or norm_b == 0.0:
         return 0.0
     return dot / (norm_a * norm_b)
+
+
+def _kmeans_plusplus_init(
+    vectors: List[Dict[str, float]],
+    k: int,
+    rng: random.Random,
+) -> List[Dict[str, float]]:
+    """k-means++ centroid initialisation for better cluster quality."""
+    n = len(vectors)
+    centroids: List[Dict[str, float]] = [dict(vectors[rng.randint(0, n - 1)])]
+
+    for _ in range(k - 1):
+        # Distance from each point to its nearest current centroid
+        dists = [
+            1.0 - max(_cosine(vec, c) for c in centroids)
+            for vec in vectors
+        ]
+        total = sum(d * d for d in dists)
+        if total == 0.0:
+            centroids.append(dict(vectors[rng.randint(0, n - 1)]))
+            continue
+        # Weighted random selection proportional to squared distance
+        threshold = rng.random() * total
+        cumul = 0.0
+        chosen = n - 1
+        for j, d in enumerate(dists):
+            cumul += d * d
+            if cumul >= threshold:
+                chosen = j
+                break
+        centroids.append(dict(vectors[chosen]))
+
+    return centroids
 
 
 def _kmeans(
@@ -97,42 +156,55 @@ def _kmeans(
     max_iter: int = 100,
     seed: int = 42,
 ) -> List[int]:
-    """Lloyd's k-means on sparse TF-IDF vectors."""
+    """Lloyd's k-means on sparse cosine-similarity space with k-means++ init.
+
+    Parameters
+    ----------
+    vectors:
+        Sparse TF-IDF document vectors.
+    k:
+        Target number of clusters.
+    max_iter:
+        Maximum number of Lloyd iterations.
+    seed:
+        Random seed for reproducibility.
+
+    Returns
+    -------
+    labels:
+        Integer cluster assignment for each document.
+    """
     n = len(vectors)
     if n == 0:
         return []
     k = min(k, n)
-
-    # Seeded centroid initialisation (evenly spaced)
-    import random
     rng = random.Random(seed)
-    centroid_indices = rng.sample(range(n), k)
-    centroids = [dict(vectors[i]) for i in centroid_indices]
+
+    centroids = _kmeans_plusplus_init(vectors, k, rng)
     labels = [0] * n
 
     for _ in range(max_iter):
-        # Assignment
-        new_labels = []
-        for vec in vectors:
-            best = max(range(k), key=lambda c: _cosine(vec, centroids[c]))
-            new_labels.append(best)
-
+        new_labels = [
+            max(range(k), key=lambda c: _cosine(vec, centroids[c]))
+            for vec in vectors
+        ]
         if new_labels == labels:
             break
         labels = new_labels
 
-        # Update centroids
+        # Recompute centroids as mean of assigned vectors
         for c in range(k):
-            members = [vectors[i] for i, l in enumerate(labels) if l == c]
+            members = [vectors[i] for i, lbl in enumerate(labels) if lbl == c]
             if not members:
-                centroids[c] = dict(vectors[rng.randint(0, n-1)])
+                # Reinitialise empty cluster to a random point
+                centroids[c] = dict(vectors[rng.randint(0, n - 1)])
                 continue
             new_centroid: Dict[str, float] = {}
             for vec in members:
                 for t, v in vec.items():
                     new_centroid[t] = new_centroid.get(t, 0.0) + v
-            total = len(members)
-            centroids[c] = {t: v/total for t, v in new_centroid.items()}
+            m = len(members)
+            centroids[c] = {t: v / m for t, v in new_centroid.items()}
 
     return labels
 
@@ -143,6 +215,8 @@ def _kmeans(
 
 @dataclass
 class Paper:
+    """Metadata record for a single academic paper."""
+
     paper_id: str
     title: str
     abstract: str = ""
@@ -154,25 +228,47 @@ class Paper:
 
     @property
     def text(self) -> str:
+        """Combined text used for TF-IDF vectorisation."""
         return f"{self.title} {self.abstract} {self.keywords}"
 
     def to_dict(self) -> dict:
         return {
-            "paper_id": self.paper_id, "title": self.title, "abstract": self.abstract,
-            "authors": self.authors, "year": self.year, "venue": self.venue,
-            "doi": self.doi, "keywords": self.keywords,
+            "paper_id": self.paper_id,
+            "title": self.title,
+            "abstract": self.abstract,
+            "authors": self.authors,
+            "year": self.year,
+            "venue": self.venue,
+            "doi": self.doi,
+            "keywords": self.keywords,
         }
+
+    @classmethod
+    def from_dict(cls, row: dict, index: int = 0) -> "Paper":
+        return cls(
+            paper_id=str(row.get("paper_id", index)),
+            title=str(row.get("title", "")),
+            abstract=str(row.get("abstract", "")),
+            authors=str(row.get("authors", "")),
+            year=str(row.get("year", "")),
+            venue=str(row.get("venue", "")),
+            doi=str(row.get("doi", "")),
+            keywords=str(row.get("keywords", "")),
+        )
 
 
 @dataclass
 class Cluster:
+    """A group of thematically related papers."""
+
     cluster_id: int
     papers: List[Paper] = field(default_factory=list)
     top_terms: List[str] = field(default_factory=list)
 
     @property
     def label(self) -> str:
-        return f"Cluster {self.cluster_id}: {', '.join(self.top_terms[:3])}"
+        terms = ", ".join(self.top_terms[:3]) if self.top_terms else "unlabelled"
+        return f"Cluster {self.cluster_id}: {terms}"
 
     def to_dict(self) -> dict:
         return {
@@ -185,12 +281,270 @@ class Cluster:
 
 
 # ---------------------------------------------------------------------------
+# HTML export
+# ---------------------------------------------------------------------------
+
+# NOTE: braces in the CSS/JS blocks are NOT Python format specifiers;
+# the placeholder __LITCLUSTER_DATA__ is substituted via str.replace().
+_HTML_TEMPLATE = """\
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>__LITCLUSTER_TITLE__</title>
+<style>
+*{box-sizing:border-box;margin:0;padding:0}
+body{font-family:system-ui,-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;
+  background:#f0f4f8;color:#1a202c;line-height:1.5}
+header{background:#1e40af;color:#fff;padding:1.5rem 2rem}
+.logo{font-size:1.25rem;font-weight:700;letter-spacing:.02em;opacity:.9}
+h1{font-size:1.5rem;font-weight:700;margin:.25rem 0}
+.hstats{display:flex;gap:1rem;margin-top:.5rem;font-size:.82rem;flex-wrap:wrap}
+.hstat{background:rgba(255,255,255,.15);padding:.2rem .65rem;border-radius:9999px}
+.controls{background:#fff;border-bottom:1px solid #e2e8f0;padding:.65rem 2rem;
+  display:flex;gap:.65rem;align-items:center;position:sticky;top:0;z-index:50;
+  box-shadow:0 1px 3px rgba(0,0,0,.08)}
+#search{flex:1;padding:.4rem .75rem;border:1px solid #cbd5e0;border-radius:.375rem;
+  font-size:.9rem;outline:none}
+#search:focus{border-color:#3b82f6;box-shadow:0 0 0 2px rgba(59,130,246,.2)}
+#cfilter{padding:.4rem .75rem;border:1px solid #cbd5e0;border-radius:.375rem;
+  font-size:.9rem;background:#fff;cursor:pointer}
+.overview{padding:1.25rem 2rem .5rem}
+.ov-title{font-size:.72rem;font-weight:600;text-transform:uppercase;letter-spacing:.07em;
+  color:#718096;margin-bottom:.6rem}
+.pills{display:flex;gap:.4rem;flex-wrap:wrap}
+.pill{padding:.3rem .8rem;border-radius:9999px;font-size:.8rem;cursor:pointer;
+  transition:opacity .15s;display:flex;align-items:center;gap:.35rem;color:#fff;
+  border:none;font-weight:500;font-family:inherit}
+.pill:hover{opacity:.85}
+.pill.dim{opacity:.35}
+.main{padding:1rem 2rem 3rem}
+.card{background:#fff;border:1px solid #e2e8f0;border-radius:.5rem;margin-bottom:1rem;
+  overflow:hidden;box-shadow:0 1px 3px rgba(0,0,0,.06)}
+.card-hdr{display:flex;align-items:center;gap:.65rem;padding:.85rem 1.25rem;
+  cursor:pointer;user-select:none;transition:background .12s}
+.card-hdr:hover{background:#f7fafc}
+.cbadge{width:2rem;height:2rem;border-radius:50%;display:flex;align-items:center;
+  justify-content:center;color:#fff;font-weight:700;font-size:.78rem;flex-shrink:0}
+.ctitle{font-weight:600;flex:1;font-size:.93rem}
+.csize{font-size:.8rem;color:#718096}
+.chev{color:#a0aec0;font-size:.72rem;transition:transform .2s;margin-left:.25rem}
+.card.open .chev{transform:rotate(90deg)}
+.card-body{display:none;border-top:1px solid #e2e8f0}
+.card.open .card-body{display:block}
+.terms{padding:.55rem 1.25rem;display:flex;flex-wrap:wrap;gap:.3rem;
+  background:#f7fafc;border-bottom:1px solid #e2e8f0}
+.term{background:#fff;border:1px solid #e2e8f0;padding:.1rem .45rem;border-radius:.25rem;
+  font-size:.76rem;color:#4a5568}
+.tbl-wrap{overflow-x:auto}
+table{width:100%;border-collapse:collapse;font-size:.84rem}
+thead th{background:#f7fafc;padding:.45rem .75rem;text-align:left;font-size:.72rem;
+  font-weight:600;color:#718096;text-transform:uppercase;letter-spacing:.05em;
+  border-bottom:1px solid #e2e8f0;white-space:nowrap}
+tbody td{padding:.45rem .75rem;border-bottom:1px solid #f0f4f8;vertical-align:top}
+tbody tr:last-child td{border-bottom:none}
+tbody tr.hidden{display:none}
+tbody tr:hover td{background:#fafbfc}
+.tc-title{max-width:320px;font-weight:500}
+.tc-author{max-width:200px;color:#4a5568;font-size:.8rem}
+.tc-year{white-space:nowrap;color:#718096}
+.tc-venue{max-width:180px;color:#4a5568;font-size:.8rem}
+.doi-link{color:#3b82f6;text-decoration:none;font-size:.76rem}
+.doi-link:hover{text-decoration:underline}
+.no-match{padding:2rem;text-align:center;color:#a0aec0;font-size:.88rem}
+footer{text-align:center;padding:2rem;font-size:.76rem;color:#a0aec0;
+  border-top:1px solid #e2e8f0}
+footer a{color:#718096;text-decoration:none}
+@media(max-width:600px){
+  header,.controls,.overview,.main{padding-left:1rem;padding-right:1rem}
+  .hstats{flex-wrap:wrap}
+}
+</style>
+</head>
+<body>
+<header>
+  <div class="logo">litcluster</div>
+  <h1>__LITCLUSTER_TITLE__</h1>
+  <div class="hstats" id="hstats"></div>
+</header>
+<div class="controls">
+  <input type="search" id="search" placeholder="Search titles and authors…">
+  <select id="cfilter" onchange="filterBySelect(this.value)">
+    <option value="">All clusters</option>
+  </select>
+</div>
+<div class="overview">
+  <div class="ov-title">Cluster overview</div>
+  <div class="pills" id="pills"></div>
+</div>
+<div class="main" id="main"></div>
+<footer>Generated by <a href="https://github.com/vdeshmukh203/litcluster">litcluster</a> v0.1.0</footer>
+<script>
+(function(){
+var COLORS=['#2563eb','#16a34a','#dc2626','#d97706','#7c3aed',
+            '#0891b2','#be185d','#059669','#ea580c','#4338ca'];
+function clr(i){return COLORS[i%COLORS.length];}
+function esc(s){
+  if(!s)return'';
+  return String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;')
+    .replace(/>/g,'&gt;').replace(/"/g,'&quot;');
+}
+var DATA=__LITCLUSTER_DATA__;
+var activeCluster=null;
+function init(){
+  // Header stats
+  var total=DATA.clusters.reduce(function(a,c){return a+c.size;},0);
+  document.getElementById('hstats').innerHTML=
+    '<span class="hstat">'+total+' papers</span>'+
+    '<span class="hstat">'+DATA.clusters.length+' clusters</span>';
+  // Cluster filter dropdown
+  var sel=document.getElementById('cfilter');
+  DATA.clusters.forEach(function(c,i){
+    var o=document.createElement('option');
+    o.value=c.cluster_id;
+    o.textContent='Cluster '+c.cluster_id+' ('+c.size+')';
+    sel.appendChild(o);
+  });
+  // Pills
+  var pillsEl=document.getElementById('pills');
+  DATA.clusters.forEach(function(c,i){
+    var b=document.createElement('button');
+    b.className='pill';
+    b.id='pill-'+c.cluster_id;
+    b.style.background=clr(i);
+    b.innerHTML='C'+c.cluster_id+' <strong>'+c.size+'</strong>';
+    b.onclick=function(){toggleCluster(c.cluster_id);};
+    pillsEl.appendChild(b);
+  });
+  // Cards
+  var mainEl=document.getElementById('main');
+  DATA.clusters.forEach(function(c,i){
+    var rows=c.papers.map(function(p){
+      var doi=p.doi
+        ?'<a class="doi-link" href="https://doi.org/'+esc(p.doi)+'" target="_blank" rel="noopener">'+esc(p.doi)+'</a>'
+        :'—';
+      return '<tr data-search="'+esc((p.title||'')+' '+(p.authors||''))+'">'+
+        '<td class="tc-title">'+esc(p.title||'—')+'</td>'+
+        '<td class="tc-author">'+esc(p.authors||'—')+'</td>'+
+        '<td class="tc-year">'+esc(p.year||'—')+'</td>'+
+        '<td class="tc-venue">'+esc(p.venue||'—')+'</td>'+
+        '<td>'+doi+'</td></tr>';
+    }).join('');
+    var terms=c.top_terms.map(function(t){
+      return '<span class="term">'+esc(t)+'</span>';
+    }).join('');
+    var div=document.createElement('div');
+    div.className='card';
+    div.id='card-'+c.cluster_id;
+    div.innerHTML=
+      '<div class="card-hdr" onclick="toggleCard('+c.cluster_id+')">'+
+        '<div class="cbadge" style="background:'+clr(i)+'">'+c.cluster_id+'</div>'+
+        '<div class="ctitle">'+esc(c.label)+'</div>'+
+        '<div class="csize" id="csz-'+c.cluster_id+'">'+c.size+' paper'+(c.size!==1?'s':'')+'</div>'+
+        '<div class="chev">&#9654;</div>'+
+      '</div>'+
+      '<div class="card-body">'+
+        '<div class="terms">'+terms+'</div>'+
+        '<div class="tbl-wrap"><table>'+
+          '<thead><tr><th>Title</th><th>Authors</th><th>Year</th><th>Venue</th><th>DOI</th></tr></thead>'+
+          '<tbody id="tbody-'+c.cluster_id+'">'+rows+'</tbody>'+
+        '</table></div>'+
+      '</div>';
+    mainEl.appendChild(div);
+  });
+  document.getElementById('search').addEventListener('input',applySearch);
+}
+function toggleCard(cid){
+  document.getElementById('card-'+cid).classList.toggle('open');
+}
+function toggleCluster(cid){
+  activeCluster=(activeCluster===cid)?null:cid;
+  applyClusterFilter();
+}
+function filterBySelect(val){
+  activeCluster=(val==='')?null:parseInt(val,10);
+  applyClusterFilter();
+}
+function applyClusterFilter(){
+  document.querySelectorAll('.card').forEach(function(card){
+    var cid=parseInt(card.id.replace('card-',''),10);
+    card.style.display=(activeCluster===null||cid===activeCluster)?'':'none';
+  });
+  document.querySelectorAll('.pill').forEach(function(pill){
+    var cid=parseInt(pill.id.replace('pill-',''),10);
+    pill.classList.toggle('dim',activeCluster!==null&&cid!==activeCluster);
+  });
+  applySearch();
+}
+function applySearch(){
+  var q=document.getElementById('search').value.toLowerCase();
+  document.querySelectorAll('tbody tr').forEach(function(row){
+    var match=!q||(row.dataset.search||'').toLowerCase().indexOf(q)!==-1;
+    row.classList.toggle('hidden',!match);
+  });
+  DATA.clusters.forEach(function(c){
+    var card=document.getElementById('card-'+c.cluster_id);
+    if(!card||card.style.display==='none')return;
+    var tbody=document.getElementById('tbody-'+c.cluster_id);
+    if(!tbody)return;
+    var visible=tbody.querySelectorAll('tr:not(.hidden)').length;
+    var sz=document.getElementById('csz-'+c.cluster_id);
+    if(sz)sz.textContent=visible+' paper'+(visible!==1?'s':'');
+  });
+}
+window.addEventListener('DOMContentLoaded',init);
+})();
+</script>
+</body>
+</html>
+"""
+
+
+def _build_html(clusters: List[Cluster], title: str = "Literature Cluster Report") -> str:
+    """Render a self-contained interactive HTML report for *clusters*."""
+    data = {
+        "clusters": [c.to_dict() for c in clusters],
+    }
+    html = _HTML_TEMPLATE
+    html = html.replace("__LITCLUSTER_TITLE__", title)
+    html = html.replace("__LITCLUSTER_DATA__", json.dumps(data, ensure_ascii=False))
+    return html
+
+
+# ---------------------------------------------------------------------------
 # LitCluster
 # ---------------------------------------------------------------------------
 
 class LitCluster:
-    def __init__(self, k: int = 5, max_iter: int = 100, seed: int = 42,
-                 min_term_freq: int = 2):
+    """Cluster a collection of academic papers by topic using TF-IDF + k-means.
+
+    Parameters
+    ----------
+    k:
+        Number of clusters.
+    max_iter:
+        Maximum k-means iterations.
+    seed:
+        Random seed for reproducibility.
+    min_term_freq:
+        Discard terms that appear in fewer than this many documents.
+    """
+
+    def __init__(
+        self,
+        k: int = 5,
+        max_iter: int = 100,
+        seed: int = 42,
+        min_term_freq: int = 2,
+    ) -> None:
+        if k < 1:
+            raise ValueError(f"k must be >= 1, got {k}")
+        if max_iter < 1:
+            raise ValueError(f"max_iter must be >= 1, got {max_iter}")
+        if min_term_freq < 1:
+            raise ValueError(f"min_term_freq must be >= 1, got {min_term_freq}")
+
         self.k = k
         self.max_iter = max_iter
         self.seed = seed
@@ -201,141 +555,300 @@ class LitCluster:
         self._vectors: List[Dict[str, float]] = []
         self._vocab: List[str] = []
 
+    # ------------------------------------------------------------------
+    # Input parsers
+    # ------------------------------------------------------------------
+
     @classmethod
     def from_csv(cls, path: Path, **kwargs) -> "LitCluster":
+        """Load papers from a CSV file.
+
+        Expected columns (all optional except at least *title* or *abstract*):
+        ``paper_id``, ``title``, ``abstract``, ``authors``, ``year``,
+        ``venue``, ``doi``, ``keywords``.
+        """
         obj = cls(**kwargs)
-        with path.open(encoding="utf-8", errors="replace", newline="") as fh:
-            reader = csv.DictReader(fh)
-            for i, row in enumerate(reader):
-                obj.papers.append(Paper(
-                    paper_id=row.get("paper_id", str(i)),
-                    title=row.get("title", ""),
-                    abstract=row.get("abstract", ""),
-                    authors=row.get("authors", ""),
-                    year=row.get("year", ""),
-                    venue=row.get("venue", ""),
-                    doi=row.get("doi", ""),
-                    keywords=row.get("keywords", ""),
-                ))
+        with Path(path).open(encoding="utf-8", errors="replace", newline="") as fh:
+            for i, row in enumerate(csv.DictReader(fh)):
+                obj.papers.append(Paper.from_dict(row, index=i))
         return obj
 
     @classmethod
     def from_jsonl(cls, path: Path, **kwargs) -> "LitCluster":
+        """Load papers from a JSONL file (one JSON object per line)."""
         obj = cls(**kwargs)
-        with path.open(encoding="utf-8") as fh:
+        with Path(path).open(encoding="utf-8") as fh:
             for i, line in enumerate(fh):
                 line = line.strip()
                 if not line:
                     continue
-                row = json.loads(line)
-                obj.papers.append(Paper(
-                    paper_id=row.get("paper_id", str(i)),
-                    title=row.get("title", ""),
-                    abstract=row.get("abstract", ""),
-                    authors=row.get("authors", ""),
-                    year=row.get("year", ""),
-                    venue=row.get("venue", ""),
-                    doi=row.get("doi", ""),
-                    keywords=row.get("keywords", ""),
-                ))
+                obj.papers.append(Paper.from_dict(json.loads(line), index=i))
         return obj
 
     @classmethod
     def from_bibtex(cls, path: Path, **kwargs) -> "LitCluster":
-        """Parse a BibTeX file for titles, abstracts, keywords."""
+        """Load papers from a BibTeX (.bib) file.
+
+        Extracts ``title``, ``abstract``, ``author``, ``year``,
+        ``journal``/``booktitle``, ``doi``, and ``keywords`` fields.
+        Handles multi-line values and nested braces correctly.
+        """
         obj = cls(**kwargs)
-        text = path.read_text(encoding="utf-8", errors="replace")
+        text = Path(path).read_text(encoding="utf-8", errors="replace")
         entries = re.split(r'(?=@\w+\s*\{)', text)
         for i, entry in enumerate(entries):
             if not entry.strip() or not entry.startswith('@'):
                 continue
-            def _get(field):
-                m = re.search(rf'{field}\s*=\s*[{{"](.*?)[}}"\,]', entry, re.IGNORECASE | re.DOTALL)
-                return m.group(1).strip() if m else ""
-            m_key = re.match(r'@\w+\s*\{\s*(\S+?)[,}]', entry)
+            m_key = re.match(r'@\w+\s*\{\s*([^\s,}]+)', entry)
             key = m_key.group(1) if m_key else str(i)
             obj.papers.append(Paper(
-                paper_id=key, title=_get('title'), abstract=_get('abstract'),
-                authors=_get('author'), year=_get('year'),
-                venue=_get('journal') or _get('booktitle'),
-                doi=_get('doi'), keywords=_get('keywords'),
+                paper_id=key,
+                title=_bibtex_field(entry, 'title'),
+                abstract=_bibtex_field(entry, 'abstract'),
+                authors=_bibtex_field(entry, 'author'),
+                year=_bibtex_field(entry, 'year'),
+                venue=(
+                    _bibtex_field(entry, 'journal')
+                    or _bibtex_field(entry, 'booktitle')
+                ),
+                doi=_bibtex_field(entry, 'doi'),
+                keywords=_bibtex_field(entry, 'keywords'),
             ))
         return obj
 
+    @classmethod
+    def from_list(cls, papers: List[dict], **kwargs) -> "LitCluster":
+        """Load papers from a list of dicts (programmatic API).
+
+        Each dict may contain any subset of: ``paper_id``, ``title``,
+        ``abstract``, ``authors``, ``year``, ``venue``, ``doi``,
+        ``keywords``.
+        """
+        obj = cls(**kwargs)
+        for i, row in enumerate(papers):
+            obj.papers.append(Paper.from_dict(row, index=i))
+        return obj
+
+    # ------------------------------------------------------------------
+    # Clustering
+    # ------------------------------------------------------------------
+
     def fit(self) -> "LitCluster":
+        """Tokenise papers, build TF-IDF vectors, and run k-means clustering.
+
+        Returns *self* so calls can be chained::
+
+            clusters = LitCluster.from_csv(path).fit().clusters
+        """
         if not self.papers:
             return self
+
         tokens_list = [_tokenise(p.text) for p in self.papers]
+        self._vectors, self._vocab = _tfidf(tokens_list, min_freq=self.min_term_freq)
 
-        # Filter rare terms
-        if self.min_term_freq > 1:
-            freq: Dict[str, int] = {}
-            for tokens in tokens_list:
-                for t in set(tokens):
-                    freq[t] = freq.get(t, 0) + 1
-            tokens_list = [[t for t in tokens if freq.get(t, 0) >= self.min_term_freq]
-                           for tokens in tokens_list]
+        # Fall back to unfiltered tokens if min_freq discards everything
+        if not self._vocab:
+            self._vectors, self._vocab = _tfidf(tokens_list, min_freq=1)
 
-        self._vectors, self._vocab = _tfidf(tokens_list)
         self._labels = _kmeans(self._vectors, self.k, self.max_iter, self.seed)
 
-        # Build cluster objects
-        clusters: Dict[int, List] = {}
+        cluster_map: Dict[int, List[Paper]] = {}
         for paper, label in zip(self.papers, self._labels):
-            clusters.setdefault(label, []).append(paper)
+            cluster_map.setdefault(label, []).append(paper)
 
-        self.clusters = []
-        for cid in sorted(clusters):
-            top_terms = self._top_terms_for_cluster(cid, n=10)
-            self.clusters.append(Cluster(cluster_id=cid, papers=clusters[cid], top_terms=top_terms))
+        self.clusters = [
+            Cluster(
+                cluster_id=cid,
+                papers=cluster_map[cid],
+                top_terms=self._top_terms_for_cluster(cid, n=10),
+            )
+            for cid in sorted(cluster_map)
+        ]
         return self
 
     def _top_terms_for_cluster(self, cid: int, n: int = 10) -> List[str]:
-        member_vecs = [self._vectors[i] for i, l in enumerate(self._labels) if l == cid]
+        member_vecs = [
+            self._vectors[i]
+            for i, lbl in enumerate(self._labels)
+            if lbl == cid
+        ]
         if not member_vecs:
             return []
         scores: Dict[str, float] = {}
+        size = len(member_vecs)
         for vec in member_vecs:
             for t, v in vec.items():
-                scores[t] = scores.get(t, 0.0) + v
+                scores[t] = scores.get(t, 0.0) + v / size
         return sorted(scores, key=lambda t: -scores[t])[:n]
 
+    # ------------------------------------------------------------------
+    # Export
+    # ------------------------------------------------------------------
+
     def export_csv(self, path: Path) -> None:
-        with path.open("w", newline="", encoding="utf-8") as fh:
+        """Write cluster assignments to a CSV file."""
+        with Path(path).open("w", newline="", encoding="utf-8") as fh:
             w = csv.writer(fh)
-            w.writerow(["cluster_id","cluster_label","paper_id","title","authors","year","venue","doi"])
+            w.writerow([
+                "cluster_id", "cluster_label", "paper_id",
+                "title", "authors", "year", "venue", "doi",
+            ])
             for cluster in self.clusters:
                 for p in cluster.papers:
-                    w.writerow([cluster.cluster_id, cluster.label, p.paper_id,
-                                p.title, p.authors, p.year, p.venue, p.doi])
+                    w.writerow([
+                        cluster.cluster_id, cluster.label, p.paper_id,
+                        p.title, p.authors, p.year, p.venue, p.doi,
+                    ])
 
     def export_json(self, path: Path) -> None:
-        with path.open("w", encoding="utf-8") as fh:
-            json.dump([c.to_dict() for c in self.clusters], fh, indent=2, ensure_ascii=False)
+        """Write clusters (with all paper metadata) to a JSON file."""
+        with Path(path).open("w", encoding="utf-8") as fh:
+            json.dump(
+                [c.to_dict() for c in self.clusters],
+                fh,
+                indent=2,
+                ensure_ascii=False,
+            )
+
+    def export_html(
+        self,
+        path: Path,
+        title: str = "Literature Cluster Report",
+    ) -> None:
+        """Write a self-contained interactive HTML report.
+
+        The output file requires no internet connection and has no external
+        dependencies.
+        """
+        Path(path).write_text(
+            _build_html(self.clusters, title=title),
+            encoding="utf-8",
+        )
 
     def summary(self) -> str:
-        lines = [f"LitCluster: {len(self.papers)} papers in {len(self.clusters)} clusters", ""]
+        """Return a Markdown-formatted summary table of clustering results."""
+        lines = [
+            "# LitCluster Report",
+            "",
+            f"**{len(self.papers)} papers** — **{len(self.clusters)} clusters**",
+            "",
+            "| # | Label | Papers | Top Terms |",
+            "|---|-------|-------:|-----------|",
+        ]
         for c in self.clusters:
-            lines.append(f"  [{c.cluster_id}] {c.label} ({len(c.papers)} papers)")
+            terms = ", ".join(c.top_terms[:5]) if c.top_terms else "—"
+            lines.append(
+                f"| {c.cluster_id} | {c.label} | {len(c.papers)} | {terms} |"
+            )
         return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# BibTeX field extraction
+# ---------------------------------------------------------------------------
+
+def _bibtex_field(entry: str, field: str) -> str:
+    """Extract the value of *field* from a single BibTeX entry string.
+
+    Handles brace-delimited values (including nested braces), quote-delimited
+    values, and bare numeric values (e.g. ``year = 2023``).
+    """
+    pattern = re.compile(
+        r'\b' + re.escape(field) + r'\s*=\s*',
+        re.IGNORECASE,
+    )
+    m = pattern.search(entry)
+    if not m:
+        return ""
+    pos = m.end()
+    if pos >= len(entry):
+        return ""
+
+    # Skip leading whitespace
+    while pos < len(entry) and entry[pos] in ' \t':
+        pos += 1
+
+    if pos >= len(entry):
+        return ""
+
+    opener = entry[pos]
+
+    if opener == '{':
+        # Brace-delimited: count depth to find matching close
+        depth = 1
+        start = pos + 1
+        pos = start
+        while pos < len(entry) and depth > 0:
+            if entry[pos] == '{':
+                depth += 1
+            elif entry[pos] == '}':
+                depth -= 1
+            pos += 1
+        value = entry[start:pos - 1]
+    elif opener == '"':
+        # Quote-delimited
+        start = pos + 1
+        end = entry.find('"', start)
+        if end == -1:
+            return ""
+        value = entry[start:end]
+    else:
+        # Bare value (e.g. year = 2023)
+        end = len(entry)
+        for ch in (',', '}', '\n'):
+            idx = entry.find(ch, pos)
+            if idx != -1 and idx < end:
+                end = idx
+        value = entry[pos:end]
+
+    return re.sub(r'\s+', ' ', value).strip()
 
 
 # ---------------------------------------------------------------------------
 # CLI
 # ---------------------------------------------------------------------------
 
-def _parse_args(argv=None):
-    p = argparse.ArgumentParser(prog="litcluster",
-                                description="Cluster academic papers by topic using TF-IDF + k-means.")
-    p.add_argument("input", help="Input file: CSV, JSONL, or .bib")
-    p.add_argument("-k", "--clusters", type=int, default=5, dest="k",
-                   help="Number of clusters (default: 5)")
-    p.add_argument("--format", choices=["csv","json","summary"], default="summary")
-    p.add_argument("--output", "-o", default=None, help="Output file (default: stdout/auto)")
-    p.add_argument("--seed", type=int, default=42)
-    p.add_argument("--max-iter", type=int, default=100)
-    p.add_argument("--min-freq", type=int, default=2,
-                   help="Minimum term frequency to include in vocabulary (default: 2)")
+def _parse_args(argv=None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        prog="litcluster",
+        description=(
+            "Cluster academic papers by topic using TF-IDF + k-means. "
+            "Input may be a BibTeX (.bib), CSV, or JSONL file."
+        ),
+    )
+    p.add_argument("input", help="Input file (.bib, .csv, or .jsonl)")
+    p.add_argument(
+        "-k", "--clusters",
+        type=int, default=5, dest="k",
+        help="Number of clusters (default: 5)",
+    )
+    p.add_argument(
+        "--format",
+        choices=["summary", "csv", "json", "html"],
+        default="summary",
+        help="Output format (default: summary)",
+    )
+    p.add_argument(
+        "--output", "-o",
+        default=None,
+        help="Output file path (default: auto-named beside input)",
+    )
+    p.add_argument("--seed", type=int, default=42, help="Random seed (default: 42)")
+    p.add_argument(
+        "--max-iter",
+        type=int, default=100,
+        help="Maximum k-means iterations (default: 100)",
+    )
+    p.add_argument(
+        "--min-freq",
+        type=int, default=2,
+        help="Minimum document frequency for vocabulary terms (default: 2)",
+    )
+    p.add_argument(
+        "--title",
+        default="Literature Cluster Report",
+        help="Report title used in HTML export",
+    )
     return p.parse_args(argv)
 
 
@@ -343,34 +856,56 @@ def main(argv=None) -> int:
     args = _parse_args(argv)
     path = Path(args.input)
     if not path.is_file():
-        print(f"Error: {path} not found", file=sys.stderr)
+        print(f"Error: '{path}' not found.", file=sys.stderr)
         return 1
 
+    kwargs = dict(
+        k=args.k,
+        max_iter=args.max_iter,
+        seed=args.seed,
+        min_term_freq=args.min_freq,
+    )
     suffix = path.suffix.lower()
-    kwargs = dict(k=args.k, max_iter=args.max_iter, seed=args.seed, min_term_freq=args.min_freq)
-    if suffix == ".bib":
-        lc = LitCluster.from_bibtex(path, **kwargs)
-    elif suffix == ".jsonl":
-        lc = LitCluster.from_jsonl(path, **kwargs)
-    else:
-        lc = LitCluster.from_csv(path, **kwargs)
+    try:
+        if suffix == ".bib":
+            lc = LitCluster.from_bibtex(path, **kwargs)
+        elif suffix == ".jsonl":
+            lc = LitCluster.from_jsonl(path, **kwargs)
+        else:
+            lc = LitCluster.from_csv(path, **kwargs)
+    except Exception as exc:
+        print(f"Error reading '{path}': {exc}", file=sys.stderr)
+        return 1
+
+    if not lc.papers:
+        print("No papers found in input file.", file=sys.stderr)
+        return 1
 
     lc.fit()
 
-    if args.format == "summary":
+    fmt = args.format
+    if fmt == "summary":
         output = lc.summary()
         if args.output:
             Path(args.output).write_text(output, encoding="utf-8")
+            print(f"Summary written to {args.output}")
         else:
             print(output)
-    elif args.format == "csv":
+
+    elif fmt == "csv":
         out = Path(args.output) if args.output else path.with_suffix(".clusters.csv")
         lc.export_csv(out)
         print(f"Clusters written to {out}")
-    elif args.format == "json":
+
+    elif fmt == "json":
         out = Path(args.output) if args.output else path.with_suffix(".clusters.json")
         lc.export_json(out)
         print(f"Clusters written to {out}")
+
+    elif fmt == "html":
+        out = Path(args.output) if args.output else path.with_suffix(".clusters.html")
+        lc.export_html(out, title=args.title)
+        print(f"HTML report written to {out}")
 
     return 0
 

--- a/litcluster_gui.py
+++ b/litcluster_gui.py
@@ -1,0 +1,420 @@
+#!/usr/bin/env python3
+"""
+litcluster_gui.py — Desktop GUI for litcluster
+
+A Tkinter-based graphical interface that lets researchers load a BibTeX,
+CSV, or JSONL file, configure clustering parameters, run the algorithm,
+browse results by cluster, and export to CSV, JSON, or HTML.
+
+No external packages are required beyond the Python standard library.
+"""
+
+from __future__ import annotations
+
+import sys
+import threading
+import tkinter as tk
+from pathlib import Path
+from tkinter import filedialog, messagebox, scrolledtext, ttk
+
+# Resolve litcluster from the same directory as this script
+_HERE = Path(__file__).parent
+sys.path.insert(0, str(_HERE))
+import litcluster as lc
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_APP_TITLE = "litcluster — Literature Clustering Tool"
+_CLUSTER_COLORS = [
+    "#2563eb", "#16a34a", "#dc2626", "#d97706", "#7c3aed",
+    "#0891b2", "#be185d", "#059669", "#ea580c", "#4338ca",
+]
+
+
+def _clr(i: int) -> str:
+    return _CLUSTER_COLORS[i % len(_CLUSTER_COLORS)]
+
+
+# ---------------------------------------------------------------------------
+# Main application window
+# ---------------------------------------------------------------------------
+
+class LitClusterApp(tk.Tk):
+    def __init__(self) -> None:
+        super().__init__()
+        self.title(_APP_TITLE)
+        self.minsize(780, 560)
+        self.resizable(True, True)
+        self._lc: lc.LitCluster | None = None
+        self._input_path: Path | None = None
+        self._build_ui()
+
+    # ------------------------------------------------------------------
+    # UI construction
+    # ------------------------------------------------------------------
+
+    def _build_ui(self) -> None:
+        # ---- top bar ---------------------------------------------------
+        top = ttk.Frame(self, padding=8)
+        top.pack(fill=tk.X)
+
+        ttk.Label(top, text="Input file:").grid(row=0, column=0, sticky=tk.W)
+        self._path_var = tk.StringVar()
+        ttk.Entry(top, textvariable=self._path_var, width=52).grid(
+            row=0, column=1, padx=4
+        )
+        ttk.Button(top, text="Browse…", command=self._browse).grid(row=0, column=2)
+
+        # ---- parameters ------------------------------------------------
+        params = ttk.LabelFrame(self, text="Parameters", padding=8)
+        params.pack(fill=tk.X, padx=8, pady=4)
+
+        def _param(parent, label, default, col):
+            ttk.Label(parent, text=label).grid(row=0, column=col, sticky=tk.W, padx=(8 if col > 0 else 0, 2))
+            var = tk.IntVar(value=default)
+            ttk.Spinbox(parent, textvariable=var, from_=1, to=9999, width=7).grid(row=0, column=col + 1)
+            return var
+
+        self._k_var = _param(params, "Clusters (k):", 5, 0)
+        self._seed_var = _param(params, "Seed:", 42, 2)
+        self._max_iter_var = _param(params, "Max iter:", 100, 4)
+        self._min_freq_var = _param(params, "Min term freq:", 2, 6)
+
+        # ---- action row ------------------------------------------------
+        action = ttk.Frame(self, padding=4)
+        action.pack(fill=tk.X, padx=8)
+
+        self._run_btn = ttk.Button(
+            action, text="Run Clustering", command=self._run, style="Accent.TButton"
+        )
+        self._run_btn.pack(side=tk.LEFT)
+        self._status_var = tk.StringVar(value="Ready.")
+        ttk.Label(action, textvariable=self._status_var, foreground="#555").pack(
+            side=tk.LEFT, padx=12
+        )
+        self._progress = ttk.Progressbar(action, mode="indeterminate", length=120)
+        self._progress.pack(side=tk.LEFT)
+
+        # ---- notebook (results) ----------------------------------------
+        self._nb = ttk.Notebook(self)
+        self._nb.pack(fill=tk.BOTH, expand=True, padx=8, pady=4)
+
+        self._tab_summary = scrolledtext.ScrolledText(
+            self._nb, wrap=tk.WORD, state=tk.DISABLED, font=("Courier", 10)
+        )
+        self._nb.add(self._tab_summary, text="Summary")
+
+        self._tab_clusters = ttk.Frame(self._nb)
+        self._nb.add(self._tab_clusters, text="Clusters")
+        self._build_cluster_tab()
+
+        self._tab_papers = ttk.Frame(self._nb)
+        self._nb.add(self._tab_papers, text="Papers")
+        self._build_papers_tab()
+
+        # ---- export bar ------------------------------------------------
+        export = ttk.Frame(self, padding=6)
+        export.pack(fill=tk.X, padx=8, pady=(0, 6))
+
+        ttk.Label(export, text="Export:").pack(side=tk.LEFT)
+        ttk.Button(export, text="CSV", command=lambda: self._export("csv")).pack(
+            side=tk.LEFT, padx=4
+        )
+        ttk.Button(export, text="JSON", command=lambda: self._export("json")).pack(
+            side=tk.LEFT, padx=4
+        )
+        ttk.Button(export, text="HTML report", command=lambda: self._export("html")).pack(
+            side=tk.LEFT, padx=4
+        )
+
+    def _build_cluster_tab(self) -> None:
+        frame = self._tab_clusters
+
+        # Left: cluster list
+        left = ttk.Frame(frame)
+        left.pack(side=tk.LEFT, fill=tk.Y, padx=(4, 0), pady=4)
+
+        ttk.Label(left, text="Clusters", font=("", 9, "bold")).pack(anchor=tk.W)
+        self._cluster_listbox = tk.Listbox(left, width=30, selectmode=tk.SINGLE)
+        self._cluster_listbox.pack(fill=tk.Y, expand=True)
+        self._cluster_listbox.bind("<<ListboxSelect>>", self._on_cluster_select)
+
+        sb = ttk.Scrollbar(left, orient=tk.VERTICAL, command=self._cluster_listbox.yview)
+        sb.pack(side=tk.RIGHT, fill=tk.Y)
+        self._cluster_listbox.configure(yscrollcommand=sb.set)
+
+        # Right: cluster details
+        right = ttk.Frame(frame)
+        right.pack(side=tk.LEFT, fill=tk.BOTH, expand=True, padx=4, pady=4)
+
+        ttk.Label(right, text="Top terms", font=("", 9, "bold")).pack(anchor=tk.W)
+        self._terms_text = scrolledtext.ScrolledText(
+            right, height=4, wrap=tk.WORD, state=tk.DISABLED, font=("Courier", 10)
+        )
+        self._terms_text.pack(fill=tk.X)
+
+        ttk.Label(right, text="Papers", font=("", 9, "bold")).pack(
+            anchor=tk.W, pady=(6, 0)
+        )
+        cols = ("title", "authors", "year", "venue")
+        self._cluster_tree = ttk.Treeview(
+            right, columns=cols, show="headings", selectmode="browse"
+        )
+        for col, w in zip(cols, (300, 180, 60, 160)):
+            self._cluster_tree.heading(col, text=col.capitalize())
+            self._cluster_tree.column(col, width=w, minwidth=40)
+        self._cluster_tree.pack(fill=tk.BOTH, expand=True)
+
+        tsb = ttk.Scrollbar(
+            right, orient=tk.VERTICAL, command=self._cluster_tree.yview
+        )
+        tsb.pack(side=tk.RIGHT, fill=tk.Y)
+        self._cluster_tree.configure(yscrollcommand=tsb.set)
+
+    def _build_papers_tab(self) -> None:
+        frame = self._tab_papers
+
+        # Search bar
+        sbar = ttk.Frame(frame)
+        sbar.pack(fill=tk.X, padx=4, pady=4)
+        ttk.Label(sbar, text="Search:").pack(side=tk.LEFT)
+        self._search_var = tk.StringVar()
+        self._search_var.trace_add("write", lambda *_: self._filter_papers())
+        ttk.Entry(sbar, textvariable=self._search_var, width=40).pack(
+            side=tk.LEFT, padx=4
+        )
+        ttk.Button(sbar, text="Clear", command=lambda: self._search_var.set("")).pack(
+            side=tk.LEFT
+        )
+
+        # Papers treeview
+        cols = ("cluster", "title", "authors", "year", "venue", "doi")
+        self._papers_tree = ttk.Treeview(
+            frame, columns=cols, show="headings", selectmode="browse"
+        )
+        widths = {"cluster": 60, "title": 280, "authors": 160, "year": 55, "venue": 140, "doi": 140}
+        for col in cols:
+            self._papers_tree.heading(col, text=col.capitalize())
+            self._papers_tree.column(col, width=widths[col], minwidth=40)
+        self._papers_tree.pack(fill=tk.BOTH, expand=True, padx=4, pady=(0, 4))
+
+        psb = ttk.Scrollbar(
+            frame, orient=tk.VERTICAL, command=self._papers_tree.yview
+        )
+        psb.pack(side=tk.RIGHT, fill=tk.Y)
+        self._papers_tree.configure(yscrollcommand=psb.set)
+
+    # ------------------------------------------------------------------
+    # Event handlers
+    # ------------------------------------------------------------------
+
+    def _browse(self) -> None:
+        path = filedialog.askopenfilename(
+            title="Select input file",
+            filetypes=[
+                ("Supported files", "*.bib *.csv *.jsonl"),
+                ("BibTeX", "*.bib"),
+                ("CSV", "*.csv"),
+                ("JSONL", "*.jsonl"),
+                ("All files", "*.*"),
+            ],
+        )
+        if path:
+            self._path_var.set(path)
+            self._input_path = Path(path)
+
+    def _run(self) -> None:
+        path_str = self._path_var.get().strip()
+        if not path_str:
+            messagebox.showwarning("No file", "Please select an input file first.")
+            return
+        self._input_path = Path(path_str)
+        if not self._input_path.is_file():
+            messagebox.showerror("File not found", f"Cannot find:\n{self._input_path}")
+            return
+
+        self._run_btn.configure(state=tk.DISABLED)
+        self._status_var.set("Running…")
+        self._progress.start(12)
+
+        thread = threading.Thread(target=self._cluster_thread, daemon=True)
+        thread.start()
+
+    def _cluster_thread(self) -> None:
+        try:
+            kwargs = dict(
+                k=self._k_var.get(),
+                max_iter=self._max_iter_var.get(),
+                seed=self._seed_var.get(),
+                min_term_freq=self._min_freq_var.get(),
+            )
+            suffix = self._input_path.suffix.lower()
+            if suffix == ".bib":
+                obj = lc.LitCluster.from_bibtex(self._input_path, **kwargs)
+            elif suffix == ".jsonl":
+                obj = lc.LitCluster.from_jsonl(self._input_path, **kwargs)
+            else:
+                obj = lc.LitCluster.from_csv(self._input_path, **kwargs)
+
+            if not obj.papers:
+                raise ValueError("No papers found in the input file.")
+
+            obj.fit()
+            self._lc = obj
+            self.after(0, self._on_success)
+
+        except Exception as exc:
+            self.after(0, lambda: self._on_error(str(exc)))
+
+    def _on_success(self) -> None:
+        self._progress.stop()
+        self._run_btn.configure(state=tk.NORMAL)
+        n = len(self._lc.papers)
+        k = len(self._lc.clusters)
+        self._status_var.set(f"Done — {n} papers in {k} clusters.")
+        self._populate_results()
+
+    def _on_error(self, msg: str) -> None:
+        self._progress.stop()
+        self._run_btn.configure(state=tk.NORMAL)
+        self._status_var.set("Error.")
+        messagebox.showerror("Clustering failed", msg)
+
+    def _on_cluster_select(self, _event=None) -> None:
+        sel = self._cluster_listbox.curselection()
+        if not sel or self._lc is None:
+            return
+        idx = sel[0]
+        cluster = self._lc.clusters[idx]
+
+        # Update top-terms panel
+        self._terms_text.configure(state=tk.NORMAL)
+        self._terms_text.delete("1.0", tk.END)
+        self._terms_text.insert(tk.END, "  ".join(cluster.top_terms))
+        self._terms_text.configure(state=tk.DISABLED)
+
+        # Update papers treeview
+        for row in self._cluster_tree.get_children():
+            self._cluster_tree.delete(row)
+        for p in cluster.papers:
+            self._cluster_tree.insert(
+                "", tk.END,
+                values=(p.title, p.authors, p.year, p.venue),
+            )
+
+    def _filter_papers(self) -> None:
+        query = self._search_var.get().lower()
+        for iid in self._papers_tree.get_children():
+            vals = self._papers_tree.item(iid, "values")
+            match = not query or any(query in str(v).lower() for v in vals)
+            # Tkinter Treeview doesn't support hiding rows natively;
+            # we detach/reattach to simulate visibility filtering.
+            if not match:
+                self._papers_tree.detach(iid)
+            else:
+                # Reattach if not already present
+                try:
+                    self._papers_tree.reattach(iid, "", tk.END)
+                except Exception:
+                    pass
+
+    # ------------------------------------------------------------------
+    # Populate results
+    # ------------------------------------------------------------------
+
+    def _populate_results(self) -> None:
+        if self._lc is None:
+            return
+
+        # Summary tab
+        self._tab_summary.configure(state=tk.NORMAL)
+        self._tab_summary.delete("1.0", tk.END)
+        self._tab_summary.insert(tk.END, self._lc.summary())
+        self._tab_summary.configure(state=tk.DISABLED)
+
+        # Cluster listbox
+        self._cluster_listbox.delete(0, tk.END)
+        for c in self._lc.clusters:
+            self._cluster_listbox.insert(
+                tk.END,
+                f"[{c.cluster_id}] {', '.join(c.top_terms[:2])} ({len(c.papers)})",
+            )
+
+        # Papers treeview (store all items including detached)
+        self._all_paper_iids: list[str] = []
+        for row in self._papers_tree.get_children():
+            self._papers_tree.delete(row)
+        for c in self._lc.clusters:
+            for p in c.papers:
+                iid = self._papers_tree.insert(
+                    "", tk.END,
+                    values=(c.cluster_id, p.title, p.authors, p.year, p.venue, p.doi),
+                )
+                self._all_paper_iids.append(iid)
+
+        # Switch to Summary tab
+        self._nb.select(0)
+
+    # ------------------------------------------------------------------
+    # Export
+    # ------------------------------------------------------------------
+
+    def _export(self, fmt: str) -> None:
+        if self._lc is None:
+            messagebox.showinfo("No results", "Run clustering first.")
+            return
+
+        ext_map = {"csv": ".csv", "json": ".json", "html": ".html"}
+        filetypes_map = {
+            "csv": [("CSV files", "*.csv")],
+            "json": [("JSON files", "*.json")],
+            "html": [("HTML files", "*.html")],
+        }
+        default_name = (self._input_path.stem + ".clusters" + ext_map[fmt]) \
+            if self._input_path else ("clusters" + ext_map[fmt])
+
+        out = filedialog.asksaveasfilename(
+            title=f"Export as {fmt.upper()}",
+            defaultextension=ext_map[fmt],
+            filetypes=filetypes_map[fmt],
+            initialfile=default_name,
+        )
+        if not out:
+            return
+        out_path = Path(out)
+        try:
+            if fmt == "csv":
+                self._lc.export_csv(out_path)
+            elif fmt == "json":
+                self._lc.export_json(out_path)
+            elif fmt == "html":
+                title = (
+                    f"Literature Cluster Report — {self._input_path.name}"
+                    if self._input_path
+                    else "Literature Cluster Report"
+                )
+                self._lc.export_html(out_path, title=title)
+            messagebox.showinfo("Export complete", f"Saved to:\n{out_path}")
+        except Exception as exc:
+            messagebox.showerror("Export failed", str(exc))
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    app = LitClusterApp()
+    # Centre window on screen
+    app.update_idletasks()
+    w, h = app.winfo_width(), app.winfo_height()
+    sw, sh = app.winfo_screenwidth(), app.winfo_screenheight()
+    app.geometry(f"+{(sw - w) // 2}+{(sh - h) // 2}")
+    app.mainloop()
+
+
+if __name__ == "__main__":
+    main()

--- a/paper.bib
+++ b/paper.bib
@@ -1,112 +1,67 @@
-@misc{nist2015sha,
-  author       = {{National Institute of Standards and Technology}},
-  title        = {{FIPS PUB 180-4: Secure Hash Standard (SHS)}},
-  year         = {2015},
-  howpublished = {\url{https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf}},
-  institution  = {National Institute of Standards and Technology}
+@article{salton1988term,
+  author  = {Salton, Gerard and Buckley, Chris},
+  title   = {Term-weighting approaches in automatic text retrieval},
+  journal = {Information Processing \& Management},
+  volume  = {24},
+  number  = {5},
+  pages   = {513--523},
+  year    = {1988},
+  doi     = {10.1016/0306-4573(88)90021-0}
 }
 
-@article{gundersen2018state,
-  author  = {Gundersen, Odd Erik and Kjensmo, Sigurd},
-  title   = {State of the Art: Reproducibility in Artificial Intelligence},
-  journal = {Proceedings of the AAAI Conference on Artificial Intelligence},
-  volume  = {32},
-  number  = {1},
-  year    = {2018}
-}
-
-@article{pineau2021improving,
-  author  = {Pineau, Joelle and Vincent-Lamarre, Philippe and Sinha, Koustuv and
-             Lariviere, Vincent and Beygelzimer, Alina and d'Alche-Buc, Florence and
-             Fox, Emily and Larochelle, Hugo},
-  title   = {Improving Reproducibility in Machine Learning Research},
-  journal = {Journal of Machine Learning Research},
-  volume  = {22},
-  number  = {242},
-  pages   = {1--20},
-  year    = {2021}
-}
-
-@article{stodden2016enhancing,
-  author  = {Stodden, Victoria and McNutt, Marcia and Bailey, David H. and Deelman, Ewa and
-             Gil, Yolanda and Hanson, Brooks and Heroux, Michael A. and Ioannidis, John P. A. and
-             Taufer, Michela},
-  title   = {Enhancing Reproducibility for Computational Methods},
-  journal = {Science},
-  volume  = {354},
-  number  = {6317},
-  pages   = {1240--1241},
-  year    = {2016},
-  doi     = {10.1126/science.aah6168}
-}
-
-@article{gebru2021datasheets,
-  author  = {Gebru, Timnit and Morgenstern, Jamie and Vecchione, Briana and
-             Vaughan, Jennifer Wortman and Wallach, Hanna and Daume, Hal and Crawford, Kate},
-  title   = {Datasheets for Datasets},
-  journal = {Communications of the ACM},
-  volume  = {64},
-  number  = {12},
-  pages   = {86--92},
-  year    = {2021},
-  doi     = {10.1145/3458723}
-}
-
-@article{adadi2018peeking,
-  author  = {Adadi, Amina and Berrada, Mohammed},
-  title   = {Peeking Inside the Black-Box: A Survey on Explainable Artificial Intelligence (XAI)},
-  journal = {IEEE Access},
-  volume  = {6},
-  pages   = {52138--52160},
-  year    = {2018},
-  doi     = {10.1109/ACCESS.2018.2870052}
-}
-
-@article{wei2022chain,
-  author  = {Wei, Jason and Wang, Xuezhi and Schuurmans, Dale and Bosma, Maarten and
-             Ichter, Brian and Xia, Fei and Chi, Ed and Le, Quoc and Zhou, Denny},
-  title   = {Chain-of-Thought Prompting Elicits Reasoning in Large Language Models},
-  journal = {Advances in Neural Information Processing Systems},
-  volume  = {35},
-  pages   = {24824--24837},
-  year    = {2022}
-}
-
-@article{kung2023chatgpt,
-  author  = {Kung, Tiffany H. and Cheatham, Morgan and Medenilla, Ariel and Sillos, Czarina and
-             De Leon, Lorie and Elepano, Camille and Madriaga, Maria and Aggabao, Rimel and
-             Diaz-Candido, Gerdine and Maningo, James and Tseng, Victor},
-  title   = {Performance of ChatGPT on USMLE: Potential for AI-Assisted Medical Education
-             Using Large Language Models},
-  journal = {PLOS Digital Health},
-  volume  = {2},
+@article{lloyd1982least,
+  author  = {Lloyd, Stuart P.},
+  title   = {Least squares quantization in {PCM}},
+  journal = {IEEE Transactions on Information Theory},
+  volume  = {28},
   number  = {2},
-  pages   = {e0000198},
-  year    = {2023},
-  doi     = {10.1371/journal.pdig.0000198}
+  pages   = {129--137},
+  year    = {1982},
+  doi     = {10.1109/TIT.1982.1056489}
 }
 
-@article{gao2023reproducibility,
-  author  = {Gao, Luyu and Biderman, Stella and Black, Sid and Golding, Laurence and Hoppe, Travis and
-             Foster, Charles and Phang, Jason and He, Horace and Thite, Anish and Nabeshima, Noa and
-             Presser, Shawn and Leahy, Connor},
-  title   = {The Pile: An 800GB Dataset of Diverse Text for Language Modeling},
-  journal = {arXiv preprint arXiv:2101.00027},
-  year    = {2023}
+@inproceedings{arthur2007kmeans,
+  author    = {Arthur, David and Vassilvitskii, Sergei},
+  title     = {k-means++: The advantages of careful seeding},
+  booktitle = {Proceedings of the Eighteenth Annual ACM-SIAM Symposium on Discrete Algorithms},
+  pages     = {1027--1035},
+  year      = {2007}
 }
 
-@article{perez2022ignore,
-  author  = {Perez, Fabio and Ribeiro, Ian},
-  title   = {Ignore Previous Prompt: Attack Techniques For Language Models},
-  journal = {arXiv preprint arXiv:2211.09527},
-  year    = {2022}
+@book{manning2008introduction,
+  author    = {Manning, Christopher D. and Raghavan, Prabhakar and Sch{\"u}tze, Hinrich},
+  title     = {Introduction to Information Retrieval},
+  publisher = {Cambridge University Press},
+  year      = {2008},
+  doi       = {10.1017/CBO9780511809071}
 }
 
-@article{greshake2023not,
-  author  = {Greshake, Kai and Abdelnabi, Sahar and Mishra, Shailesh and Endres, Christoph and
-             Holz, Thorsten and Fritz, Mario},
-  title   = {Not What You've Signed Up For: Compromising Real-World LLM-Integrated Applications
-             with Indirect Prompt Injection},
-  journal = {arXiv preprint arXiv:2302.12173},
-  year    = {2023}
+@techreport{kitchenham2004procedures,
+  author      = {Kitchenham, Barbara},
+  title       = {Procedures for performing systematic reviews},
+  institution = {Keele University},
+  number      = {TR/SE-0401},
+  year        = {2004}
+}
+
+@article{moher2009preferred,
+  author  = {Moher, David and Liberati, Alessandro and Tetzlaff, Jennifer and Altman, Douglas G. and {PRISMA Group}},
+  title   = {Preferred Reporting Items for Systematic Reviews and Meta-Analyses: The {PRISMA} Statement},
+  journal = {PLOS Medicine},
+  volume  = {6},
+  number  = {7},
+  pages   = {e1000097},
+  year    = {2009},
+  doi     = {10.1371/journal.pmed.1000097}
+}
+
+@article{van2010software,
+  author  = {van Eck, Nees Jan and Waltman, Ludo},
+  title   = {Software survey: {VOSviewer}, a computer program for bibliometric mapping},
+  journal = {Scientometrics},
+  volume  = {84},
+  number  = {2},
+  pages   = {523--538},
+  year    = {2010},
+  doi     = {10.1007/s11192-009-0146-3}
 }

--- a/paper.md
+++ b/paper.md
@@ -1,5 +1,5 @@
 ---
-title: 'litcluster: Topic modelling and semantic clustering of scientific literature from BibTeX or DOI lists'
+title: 'litcluster: Topic-based clustering of scientific literature using TF-IDF and k-means'
 tags:
   - Python
   - NLP
@@ -7,6 +7,7 @@ tags:
   - clustering
   - literature-review
   - bibliometrics
+  - systematic-review
 authors:
   - name: Vaibhav Deshmukh
     orcid: 0000-0001-6745-7062
@@ -20,14 +21,30 @@ bibliography: paper.bib
 
 # Summary
 
-`litcluster` is a Python tool for semantic clustering and topic modelling of scientific literature. Given a BibTeX file, a list of DOIs, or a directory of PDF abstracts, `litcluster` fetches or extracts abstract text, embeds papers using pre-trained sentence transformers, applies dimensionality reduction (UMAP), and clusters the resulting embedding space (HDBSCAN). It outputs an interactive HTML visualisation of the literature landscape and a Markdown summary table labelling each cluster with automatically extracted topic keywords. `litcluster` is designed for researchers beginning a new domain survey or tracking how a field has evolved over time.
+`litcluster` is a dependency-free Python tool for topic-based clustering of scientific literature. Given a BibTeX file, a CSV spreadsheet, or a JSONL file of paper records, `litcluster` tokenises each paper's title, abstract, and keywords, builds a sparse term frequency–inverse document frequency (TF-IDF) vector for each paper [@salton1988term], and groups papers into *k* thematic clusters using Lloyd's k-means algorithm with k-means++ initialisation [@lloyd1982least; @arthur2007kmeans]. The tool outputs a Markdown summary table, a CSV or JSON cluster assignment file, and a fully self-contained interactive HTML report with collapsible cluster cards, top-term badges, and a real-time paper search panel. A Tkinter graphical user interface is included for researchers who prefer not to use the command line. All functionality uses only the Python standard library; no external packages are required.
 
 # Statement of Need
 
-Systematic and scoping reviews require researchers to organise large collections of papers into thematic groups — a task typically done manually or with expensive proprietary tools. `litcluster` automates this using modern sentence embeddings and density-based clustering, requiring only a BibTeX file as input. Unlike keyword-based approaches, semantic clustering groups papers by meaning rather than surface vocabulary, surfacing connections that term-based methods miss [@wei2022chain]. The interactive output helps researchers quickly identify core topics, niche sub-areas, and potential gaps in a literature collection, accelerating the early stages of a systematic review.
+Systematic and scoping literature reviews require researchers to organise large collections of papers — often hundreds or thousands of items — into coherent thematic groups. In practice, this grouping is performed manually, which is time-consuming and introduces inter-reviewer variability, or by proprietary bibliometric software that may not be freely available to all researchers [@kitchenham2004procedures; @moher2009preferred].
+
+Open-source alternatives exist but typically impose heavy dependency stacks (PyTorch, sentence-transformers, UMAP, HDBSCAN) that create installation barriers, particularly on shared computing environments or institutional machines with restricted package management. `litcluster` addresses this gap by delivering a useful baseline clustering capability — TF-IDF vectorisation and k-means — that installs in seconds and runs on any Python 3.8+ interpreter without compiling C extensions or downloading pre-trained model weights.
+
+The k-means++ initialisation strategy [@arthur2007kmeans] reduces sensitivity to the random seed and consistently produces tighter, more interpretable clusters than naive random initialisation, while the cosine-similarity distance metric is well-suited to sparse bag-of-words representations [@manning2008introduction]. Researchers with small to medium literature collections (tens to a few thousand papers) who need a fast, reproducible first-pass grouping will find `litcluster` immediately useful. Those who later require embedding-based clustering can export the cluster labels as CSV and use them as priors or evaluation baselines for more sophisticated pipelines.
+
+# Functionality
+
+`litcluster` exposes three interfaces that share the same underlying algorithm:
+
+**Command-line interface.** A `litcluster` script accepts an input file, the desired number of clusters, and optional parameters, and writes the chosen output format to disk or stdout.
+
+**Python API.** The `LitCluster` class provides class methods `from_bibtex`, `from_csv`, `from_jsonl`, and `from_list` for loading paper collections, a `fit()` method that executes the clustering pipeline, and `export_csv`, `export_json`, and `export_html` methods for writing results.
+
+**Graphical user interface.** The `litcluster-gui` script launches a Tkinter window in which users can browse for an input file, adjust all clustering parameters with spin-boxes, run clustering in a background thread, inspect results in a tabbed panel (Summary / Clusters / Papers), and export in any supported format via a file-save dialog.
+
+The interactive HTML export is a single, standalone file requiring no internet connection. It embeds cluster data as an inline JSON object and uses vanilla JavaScript for search filtering, cluster visibility toggling, and collapsible paper tables.
 
 # Acknowledgements
 
-The author used Claude (Anthropic) for drafting portions of this manuscript. All scientific claims and design decisions are the author's own.
+The author used Claude (Anthropic) for drafting portions of this manuscript and for code review. All scientific claims and design decisions are the author's own.
 
 # References

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,18 +10,27 @@ readme = "README.md"
 license = {file = "LICENSE"}
 authors = [{name = "Vaibhav Deshmukh", email = "vdeshmukh203@gmail.com"}]
 requires-python = ">=3.8"
-keywords = ["literature", "clustering", "bibtex", "topic-modelling", "tfidf", "research"]
+keywords = ["literature", "clustering", "bibtex", "topic-modelling", "tfidf", "research", "systematic-review"]
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Science/Research",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: Scientific/Engineering :: Information Analysis",
     "Topic :: Text Processing",
 ]
 
 [project.scripts]
-litcluster = "litcluster:_cli"
+litcluster     = "litcluster:main"
+litcluster-gui = "litcluster_gui:main"
 
 [tool.setuptools]
-py-modules = ["litcluster"]
+py-modules = ["litcluster", "litcluster_gui"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/src/litcluster/__init__.py
+++ b/src/litcluster/__init__.py
@@ -1,18 +1,28 @@
 """
-litcluster: Semantic clustering and topic modelling of scientific literature.
+litcluster: Topic-based clustering of scientific literature using TF-IDF and k-means.
 
-Ingests collections of scientific abstracts or full papers (via DOI lists,
-BibTeX files, or arXiv IDs), embeds them using sentence-transformers, and
-applies hierarchical clustering and topic modelling to produce interactive
-visualisations and structured cluster summaries for systematic literature
-reviews.
+This package shim re-exports the public API from the top-level ``litcluster``
+module.  The canonical import is simply::
+
+    import litcluster
+    lc = litcluster.LitCluster.from_bibtex("refs.bib").fit()
+
+See the project README for full documentation.
 """
 
 __version__ = "0.1.0"
 __author__ = "Vaibhav Deshmukh"
 __license__ = "MIT"
 
-from .cluster import LitCluster
-from .embed import PaperEmbedder
+# Re-export the public API from the root litcluster module.
+# The root module is what pip installs (py-modules = ["litcluster"]).
+import importlib as _imp
+import sys as _sys
 
-__all__ = ["LitCluster", "PaperEmbedder"]
+_root = _imp.import_module("litcluster")
+
+LitCluster = _root.LitCluster
+Paper = _root.Paper
+Cluster = _root.Cluster
+
+__all__ = ["LitCluster", "Paper", "Cluster"]

--- a/tests/test_litcluster.py
+++ b/tests/test_litcluster.py
@@ -1,19 +1,646 @@
-import sys, pathlib
-sys.path.insert(0, str(pathlib.Path(__file__).parent.parent))
+"""
+Comprehensive tests for litcluster.
 
-def test_import():
-    import litcluster as lc
-    assert hasattr(lc, 'LitCluster')
+Run with:  pytest tests/ -v
+"""
 
-def test_paper():
-    import litcluster as lc
-    assert hasattr(lc, 'Paper')
+import csv
+import io
+import json
+import math
+import sys
+import tempfile
+from pathlib import Path
 
-def test_cluster():
-    import litcluster as lc
-    assert hasattr(lc, 'Cluster')
+import pytest
 
-def test_tokenise():
-    import litcluster as lc
-    tokens = lc._tokenise('hello world test foo bar')
-    assert isinstance(tokens, list) and len(tokens) > 0
+# Ensure the project root is on the path so tests work without installation.
+sys.path.insert(0, str(Path(__file__).parent.parent))
+import litcluster as lc
+
+# ---------------------------------------------------------------------------
+# Sample data
+# ---------------------------------------------------------------------------
+
+SAMPLE_PAPERS = [
+    {
+        "paper_id": "p1",
+        "title": "Deep learning for image recognition",
+        "abstract": "We present a convolutional neural network for image classification.",
+        "authors": "Smith, J.",
+        "year": "2020",
+        "venue": "CVPR",
+        "doi": "10.1000/xyz001",
+        "keywords": "neural network image classification",
+    },
+    {
+        "paper_id": "p2",
+        "title": "Object detection with neural networks",
+        "abstract": "Neural networks enable accurate object detection in images.",
+        "authors": "Jones, A.",
+        "year": "2021",
+        "venue": "CVPR",
+        "doi": "10.1000/xyz002",
+        "keywords": "object detection neural network",
+    },
+    {
+        "paper_id": "p3",
+        "title": "Transformer models for NLP",
+        "abstract": "Self-attention transformer architectures achieve state-of-the-art NLP results.",
+        "authors": "Brown, T.",
+        "year": "2020",
+        "venue": "NeurIPS",
+        "doi": "10.1000/xyz003",
+        "keywords": "transformer attention NLP",
+    },
+    {
+        "paper_id": "p4",
+        "title": "BERT language model fine-tuning",
+        "abstract": "Fine-tuning BERT language models on downstream NLP tasks.",
+        "authors": "Lee, K.",
+        "year": "2019",
+        "venue": "EMNLP",
+        "doi": "10.1000/xyz004",
+        "keywords": "BERT language model NLP",
+    },
+    {
+        "paper_id": "p5",
+        "title": "Protein structure prediction",
+        "abstract": "Predicting protein folding structures using computational methods.",
+        "authors": "Wang, X.",
+        "year": "2021",
+        "venue": "Nature",
+        "doi": "10.1000/xyz005",
+        "keywords": "protein structure folding",
+    },
+    {
+        "paper_id": "p6",
+        "title": "Molecular dynamics simulation",
+        "abstract": "Simulating molecular dynamics for protein folding and drug discovery.",
+        "authors": "Chen, L.",
+        "year": "2022",
+        "venue": "PLOS",
+        "doi": "10.1000/xyz006",
+        "keywords": "molecular dynamics protein simulation",
+    },
+]
+
+SAMPLE_BIB = r"""
+@article{smith2020deep,
+  title     = {Deep learning for image recognition},
+  abstract  = {Convolutional neural networks excel at image classification tasks.},
+  author    = {Smith, John},
+  year      = {2020},
+  journal   = {CVPR},
+  doi       = {10.1000/abc001},
+  keywords  = {deep learning, image, neural network},
+}
+
+@inproceedings{jones2021object,
+  title     = {Object detection with neural networks},
+  abstract  = {Neural networks enable robust object detection.},
+  author    = {Jones, Alice},
+  year      = {2021},
+  booktitle = {ECCV},
+  doi       = {10.1000/abc002},
+}
+
+@article{brown2020transformer,
+  title    = {Transformer models for natural language processing},
+  abstract = {Self-attention transformers achieve state-of-the-art NLP benchmarks.},
+  author   = {Brown, Tom},
+  year     = {2020},
+  journal  = {NeurIPS},
+}
+"""
+
+
+# ---------------------------------------------------------------------------
+# Tokenisation
+# ---------------------------------------------------------------------------
+
+class TestTokenise:
+    def test_basic(self):
+        tokens = lc._tokenise("hello world test foo")
+        assert isinstance(tokens, list)
+        assert "hello" in tokens
+        assert "world" in tokens
+
+    def test_empty(self):
+        assert lc._tokenise("") == []
+        assert lc._tokenise(None) == []
+
+    def test_stopwords_removed(self):
+        tokens = lc._tokenise("the quick brown fox")
+        assert "the" not in tokens
+        assert "brown" in tokens or "quick" in tokens
+
+    def test_short_words_removed(self):
+        tokens = lc._tokenise("a bb ccc dddd")
+        assert "a" not in tokens
+        assert "bb" not in tokens
+        assert "ccc" in tokens
+        assert "dddd" in tokens
+
+    def test_lowercase(self):
+        tokens = lc._tokenise("Neural Networks NLP")
+        assert all(t == t.lower() for t in tokens)
+
+    def test_non_alpha_stripped(self):
+        tokens = lc._tokenise("deep-learning, NLP! 2024")
+        assert all(t.isalpha() for t in tokens)
+
+
+# ---------------------------------------------------------------------------
+# TF-IDF
+# ---------------------------------------------------------------------------
+
+class TestTfidf:
+    def test_basic(self):
+        docs = [["cat", "dog", "cat"], ["fish", "cat"]]
+        vecs, vocab = lc._tfidf(docs, min_freq=1)
+        assert len(vecs) == 2
+        assert "cat" in vocab
+        assert all(isinstance(v, dict) for v in vecs)
+
+    def test_empty_corpus(self):
+        vecs, vocab = lc._tfidf([])
+        assert vecs == []
+        assert vocab == []
+
+    def test_min_freq(self):
+        docs = [["common", "rare"], ["common", "another"]]
+        vecs, vocab = lc._tfidf(docs, min_freq=2)
+        assert "common" in vocab
+        assert "rare" not in vocab
+
+    def test_scores_positive(self):
+        docs = [["neural", "network"], ["protein", "structure"]]
+        vecs, vocab = lc._tfidf(docs, min_freq=1)
+        for vec in vecs:
+            assert all(v > 0 for v in vec.values())
+
+    def test_idf_penalises_common_terms(self):
+        docs = [["cat", "dog"], ["cat", "fish"], ["cat", "bird"]]
+        vecs, vocab = lc._tfidf(docs, min_freq=1)
+        # "cat" appears in every doc → low IDF → lower score relative to rare terms
+        # Each doc has "cat" plus one other term; unique terms get higher IDF
+        for vec in vecs:
+            unique_score = max(
+                v for t, v in vec.items() if t != "cat"
+            )
+            cat_score = vec.get("cat", 0)
+            assert unique_score > cat_score
+
+
+# ---------------------------------------------------------------------------
+# Cosine similarity
+# ---------------------------------------------------------------------------
+
+class TestCosine:
+    def test_identical(self):
+        v = {"a": 1.0, "b": 2.0}
+        assert abs(lc._cosine(v, v) - 1.0) < 1e-9
+
+    def test_orthogonal(self):
+        a = {"x": 1.0}
+        b = {"y": 1.0}
+        assert lc._cosine(a, b) == 0.0
+
+    def test_empty(self):
+        assert lc._cosine({}, {"a": 1.0}) == 0.0
+        assert lc._cosine({"a": 1.0}, {}) == 0.0
+
+    def test_symmetry(self):
+        a = {"x": 1.0, "y": 2.0}
+        b = {"y": 1.0, "z": 1.0}
+        assert abs(lc._cosine(a, b) - lc._cosine(b, a)) < 1e-9
+
+    def test_range(self):
+        import random
+        rng = random.Random(0)
+        for _ in range(20):
+            a = {str(i): rng.random() for i in range(5)}
+            b = {str(i): rng.random() for i in range(5)}
+            sim = lc._cosine(a, b)
+            assert -1e-9 <= sim <= 1.0 + 1e-9
+
+
+# ---------------------------------------------------------------------------
+# k-means
+# ---------------------------------------------------------------------------
+
+class TestKmeans:
+    def test_basic_clusters(self):
+        docs = [["cat", "dog"], ["cat", "bird"], ["fish", "water"]]
+        vecs, _ = lc._tfidf(docs, min_freq=1)
+        labels = lc._kmeans(vecs, k=2, seed=0)
+        assert len(labels) == 3
+        assert all(isinstance(l, int) for l in labels)
+        assert set(labels) <= {0, 1}
+
+    def test_k_capped_at_n(self):
+        docs = [["cat"], ["dog"]]
+        vecs, _ = lc._tfidf(docs, min_freq=1)
+        labels = lc._kmeans(vecs, k=10, seed=0)
+        assert len(set(labels)) <= 2
+
+    def test_empty_input(self):
+        assert lc._kmeans([], k=3) == []
+
+    def test_single_document(self):
+        vecs, _ = lc._tfidf([["hello", "world"]], min_freq=1)
+        labels = lc._kmeans(vecs, k=3, seed=0)
+        assert labels == [0]
+
+    def test_reproducible(self):
+        docs = [["neural", "network"]] * 4 + [["protein", "structure"]] * 4
+        vecs, _ = lc._tfidf(docs, min_freq=1)
+        l1 = lc._kmeans(vecs, k=2, seed=7)
+        l2 = lc._kmeans(vecs, k=2, seed=7)
+        assert l1 == l2
+
+
+# ---------------------------------------------------------------------------
+# Paper dataclass
+# ---------------------------------------------------------------------------
+
+class TestPaper:
+    def test_defaults(self):
+        p = lc.Paper(paper_id="1", title="Test")
+        assert p.abstract == ""
+        assert p.doi == ""
+
+    def test_text_property(self):
+        p = lc.Paper(paper_id="1", title="Neural", abstract="Networks", keywords="deep")
+        assert "Neural" in p.text
+        assert "Networks" in p.text
+        assert "deep" in p.text
+
+    def test_to_dict(self):
+        p = lc.Paper(paper_id="1", title="Test", year="2020")
+        d = p.to_dict()
+        assert d["paper_id"] == "1"
+        assert d["year"] == "2020"
+
+    def test_from_dict(self):
+        d = {"paper_id": "42", "title": "Hello", "year": "2022"}
+        p = lc.Paper.from_dict(d)
+        assert p.paper_id == "42"
+        assert p.title == "Hello"
+        assert p.year == "2022"
+
+    def test_from_dict_defaults(self):
+        p = lc.Paper.from_dict({}, index=5)
+        assert p.paper_id == "5"
+        assert p.title == ""
+
+
+# ---------------------------------------------------------------------------
+# Cluster dataclass
+# ---------------------------------------------------------------------------
+
+class TestCluster:
+    def test_label(self):
+        c = lc.Cluster(cluster_id=0, top_terms=["neural", "network", "image"])
+        assert "0" in c.label
+        assert "neural" in c.label
+
+    def test_label_no_terms(self):
+        c = lc.Cluster(cluster_id=1)
+        assert "unlabelled" in c.label
+
+    def test_to_dict(self):
+        p = lc.Paper(paper_id="1", title="Test")
+        c = lc.Cluster(cluster_id=0, papers=[p], top_terms=["cat"])
+        d = c.to_dict()
+        assert d["cluster_id"] == 0
+        assert d["size"] == 1
+        assert d["top_terms"] == ["cat"]
+        assert len(d["papers"]) == 1
+
+
+# ---------------------------------------------------------------------------
+# LitCluster — construction and input parsers
+# ---------------------------------------------------------------------------
+
+class TestLitClusterInit:
+    def test_defaults(self):
+        obj = lc.LitCluster()
+        assert obj.k == 5
+        assert obj.seed == 42
+
+    def test_invalid_k(self):
+        with pytest.raises(ValueError):
+            lc.LitCluster(k=0)
+
+    def test_invalid_max_iter(self):
+        with pytest.raises(ValueError):
+            lc.LitCluster(max_iter=0)
+
+    def test_invalid_min_freq(self):
+        with pytest.raises(ValueError):
+            lc.LitCluster(min_term_freq=0)
+
+
+class TestFromList:
+    def test_basic(self):
+        obj = lc.LitCluster.from_list(SAMPLE_PAPERS, k=2)
+        assert len(obj.papers) == len(SAMPLE_PAPERS)
+
+    def test_empty(self):
+        obj = lc.LitCluster.from_list([])
+        assert obj.papers == []
+
+
+class TestFromCsv:
+    def test_round_trip(self, tmp_path):
+        p = tmp_path / "papers.csv"
+        with p.open("w", newline="", encoding="utf-8") as fh:
+            w = csv.DictWriter(fh, fieldnames=list(SAMPLE_PAPERS[0].keys()))
+            w.writeheader()
+            w.writerows(SAMPLE_PAPERS)
+        obj = lc.LitCluster.from_csv(p, k=2)
+        assert len(obj.papers) == len(SAMPLE_PAPERS)
+        assert obj.papers[0].title == SAMPLE_PAPERS[0]["title"]
+
+    def test_missing_columns(self, tmp_path):
+        p = tmp_path / "minimal.csv"
+        p.write_text("title,abstract\nNeural Networks,Deep learning study\n")
+        obj = lc.LitCluster.from_csv(p, k=1)
+        assert len(obj.papers) == 1
+        assert obj.papers[0].doi == ""
+
+
+class TestFromJsonl:
+    def test_round_trip(self, tmp_path):
+        p = tmp_path / "papers.jsonl"
+        lines = "\n".join(json.dumps(row) for row in SAMPLE_PAPERS)
+        p.write_text(lines, encoding="utf-8")
+        obj = lc.LitCluster.from_jsonl(p, k=2)
+        assert len(obj.papers) == len(SAMPLE_PAPERS)
+
+    def test_blank_lines_skipped(self, tmp_path):
+        p = tmp_path / "papers.jsonl"
+        p.write_text(
+            json.dumps(SAMPLE_PAPERS[0]) + "\n\n" + json.dumps(SAMPLE_PAPERS[1]) + "\n"
+        )
+        obj = lc.LitCluster.from_jsonl(p, k=1)
+        assert len(obj.papers) == 2
+
+
+class TestFromBibtex:
+    def test_round_trip(self, tmp_path):
+        p = tmp_path / "refs.bib"
+        p.write_text(SAMPLE_BIB, encoding="utf-8")
+        obj = lc.LitCluster.from_bibtex(p, k=2)
+        assert len(obj.papers) == 3
+        titles = [p.title for p in obj.papers]
+        assert any("image" in t.lower() for t in titles)
+
+    def test_nested_braces(self, tmp_path):
+        bib = r"""@article{test,
+  title = {Nested {Braces} Test},
+  year  = {2021},
+}"""
+        p = tmp_path / "test.bib"
+        p.write_text(bib)
+        obj = lc.LitCluster.from_bibtex(p)
+        assert "Nested" in obj.papers[0].title
+        assert "Braces" in obj.papers[0].title
+
+    def test_booktitle_fallback(self, tmp_path):
+        bib = r"""@inproceedings{conf2021,
+  title     = {Conference Paper},
+  booktitle = {Proceedings of the Workshop},
+  year      = {2021},
+}"""
+        p = tmp_path / "conf.bib"
+        p.write_text(bib)
+        obj = lc.LitCluster.from_bibtex(p)
+        assert obj.papers[0].venue == "Proceedings of the Workshop"
+
+
+# ---------------------------------------------------------------------------
+# LitCluster.fit()
+# ---------------------------------------------------------------------------
+
+class TestFit:
+    def test_basic(self):
+        obj = lc.LitCluster.from_list(SAMPLE_PAPERS, k=3, min_term_freq=1)
+        obj.fit()
+        assert len(obj.clusters) <= 3
+        assert sum(len(c.papers) for c in obj.clusters) == len(SAMPLE_PAPERS)
+
+    def test_no_papers(self):
+        obj = lc.LitCluster()
+        obj.fit()
+        assert obj.clusters == []
+
+    def test_labels_assigned(self):
+        obj = lc.LitCluster.from_list(SAMPLE_PAPERS, k=2, min_term_freq=1)
+        obj.fit()
+        assert len(obj._labels) == len(SAMPLE_PAPERS)
+
+    def test_top_terms_non_empty(self):
+        obj = lc.LitCluster.from_list(SAMPLE_PAPERS, k=2, min_term_freq=1)
+        obj.fit()
+        for c in obj.clusters:
+            assert isinstance(c.top_terms, list)
+            assert len(c.top_terms) > 0
+
+    def test_chaining(self):
+        clusters = lc.LitCluster.from_list(SAMPLE_PAPERS, k=2, min_term_freq=1).fit().clusters
+        assert len(clusters) >= 1
+
+    def test_k_larger_than_papers(self):
+        few = SAMPLE_PAPERS[:2]
+        obj = lc.LitCluster.from_list(few, k=10, min_term_freq=1)
+        obj.fit()
+        assert sum(len(c.papers) for c in obj.clusters) == 2
+
+    def test_reproducible(self):
+        def run():
+            return lc.LitCluster.from_list(
+                SAMPLE_PAPERS, k=3, seed=99, min_term_freq=1
+            ).fit()._labels
+        assert run() == run()
+
+    def test_summary_markdown(self):
+        obj = lc.LitCluster.from_list(SAMPLE_PAPERS, k=2, min_term_freq=1).fit()
+        summary = obj.summary()
+        assert "| #" in summary
+        assert "Papers" in summary
+
+
+# ---------------------------------------------------------------------------
+# Exports
+# ---------------------------------------------------------------------------
+
+class TestExportCsv:
+    def test_creates_file(self, tmp_path):
+        obj = lc.LitCluster.from_list(SAMPLE_PAPERS, k=2, min_term_freq=1).fit()
+        out = tmp_path / "out.csv"
+        obj.export_csv(out)
+        assert out.exists()
+
+    def test_header_and_rows(self, tmp_path):
+        obj = lc.LitCluster.from_list(SAMPLE_PAPERS, k=2, min_term_freq=1).fit()
+        out = tmp_path / "out.csv"
+        obj.export_csv(out)
+        with out.open(newline="", encoding="utf-8") as fh:
+            rows = list(csv.reader(fh))
+        assert rows[0][0] == "cluster_id"
+        assert len(rows) == len(SAMPLE_PAPERS) + 1  # header + data
+
+
+class TestExportJson:
+    def test_creates_file(self, tmp_path):
+        obj = lc.LitCluster.from_list(SAMPLE_PAPERS, k=2, min_term_freq=1).fit()
+        out = tmp_path / "out.json"
+        obj.export_json(out)
+        assert out.exists()
+
+    def test_valid_json(self, tmp_path):
+        obj = lc.LitCluster.from_list(SAMPLE_PAPERS, k=2, min_term_freq=1).fit()
+        out = tmp_path / "out.json"
+        obj.export_json(out)
+        data = json.loads(out.read_text(encoding="utf-8"))
+        assert isinstance(data, list)
+        assert all("cluster_id" in c for c in data)
+        assert all("papers" in c for c in data)
+
+    def test_all_papers_present(self, tmp_path):
+        obj = lc.LitCluster.from_list(SAMPLE_PAPERS, k=2, min_term_freq=1).fit()
+        out = tmp_path / "out.json"
+        obj.export_json(out)
+        data = json.loads(out.read_text(encoding="utf-8"))
+        total = sum(len(c["papers"]) for c in data)
+        assert total == len(SAMPLE_PAPERS)
+
+
+class TestExportHtml:
+    def test_creates_file(self, tmp_path):
+        obj = lc.LitCluster.from_list(SAMPLE_PAPERS, k=2, min_term_freq=1).fit()
+        out = tmp_path / "report.html"
+        obj.export_html(out, title="Test Report")
+        assert out.exists()
+
+    def test_self_contained(self, tmp_path):
+        obj = lc.LitCluster.from_list(SAMPLE_PAPERS, k=2, min_term_freq=1).fit()
+        out = tmp_path / "report.html"
+        obj.export_html(out, title="Test Report")
+        html = out.read_text(encoding="utf-8")
+        # Should be self-contained — no external http references
+        assert "http://" not in html or "doi.org" in html
+        assert "<html" in html
+        assert "</html>" in html
+
+    def test_title_embedded(self, tmp_path):
+        obj = lc.LitCluster.from_list(SAMPLE_PAPERS, k=2, min_term_freq=1).fit()
+        out = tmp_path / "report.html"
+        obj.export_html(out, title="My Unique Title 12345")
+        html = out.read_text(encoding="utf-8")
+        assert "My Unique Title 12345" in html
+
+    def test_data_embedded(self, tmp_path):
+        obj = lc.LitCluster.from_list(SAMPLE_PAPERS, k=2, min_term_freq=1).fit()
+        out = tmp_path / "report.html"
+        obj.export_html(out)
+        html = out.read_text(encoding="utf-8")
+        # Paper titles from sample data should appear in the embedded JSON
+        assert "image recognition" in html.lower()
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+class TestCli:
+    def test_summary_stdout(self, tmp_path, capsys):
+        p = tmp_path / "papers.csv"
+        with p.open("w", newline="") as fh:
+            w = csv.DictWriter(fh, fieldnames=list(SAMPLE_PAPERS[0].keys()))
+            w.writeheader()
+            w.writerows(SAMPLE_PAPERS)
+        rc = lc.main([str(p), "-k", "2", "--min-freq", "1", "--format", "summary"])
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "LitCluster" in out
+
+    def test_csv_output(self, tmp_path):
+        p = tmp_path / "papers.csv"
+        with p.open("w", newline="") as fh:
+            w = csv.DictWriter(fh, fieldnames=list(SAMPLE_PAPERS[0].keys()))
+            w.writeheader()
+            w.writerows(SAMPLE_PAPERS)
+        out = tmp_path / "clusters.csv"
+        rc = lc.main([str(p), "-k", "2", "--min-freq", "1", "--format", "csv", "-o", str(out)])
+        assert rc == 0
+        assert out.exists()
+
+    def test_json_output(self, tmp_path):
+        p = tmp_path / "papers.jsonl"
+        p.write_text("\n".join(json.dumps(r) for r in SAMPLE_PAPERS))
+        out = tmp_path / "clusters.json"
+        rc = lc.main([str(p), "-k", "2", "--min-freq", "1", "--format", "json", "-o", str(out)])
+        assert rc == 0
+        assert out.exists()
+
+    def test_html_output(self, tmp_path):
+        p = tmp_path / "refs.bib"
+        p.write_text(SAMPLE_BIB, encoding="utf-8")
+        out = tmp_path / "report.html"
+        rc = lc.main([str(p), "-k", "2", "--min-freq", "1", "--format", "html", "-o", str(out)])
+        assert rc == 0
+        assert out.exists()
+        assert "<html" in out.read_text(encoding="utf-8")
+
+    def test_missing_file(self, capsys):
+        rc = lc.main(["nonexistent.csv"])
+        assert rc == 1
+        err = capsys.readouterr().err
+        assert "not found" in err.lower()
+
+    def test_bibtex_input(self, tmp_path, capsys):
+        p = tmp_path / "refs.bib"
+        p.write_text(SAMPLE_BIB, encoding="utf-8")
+        rc = lc.main([str(p), "-k", "2", "--min-freq", "1"])
+        assert rc == 0
+
+
+# ---------------------------------------------------------------------------
+# BibTeX field extraction
+# ---------------------------------------------------------------------------
+
+class TestBibtexField:
+    def test_braced_value(self):
+        entry = "  title = {Hello World},"
+        assert lc._bibtex_field(entry, "title") == "Hello World"
+
+    def test_nested_braces(self):
+        entry = "  title = {Hello {Nested} World},"
+        val = lc._bibtex_field(entry, "title")
+        assert "Hello" in val
+        assert "Nested" in val
+
+    def test_quoted_value(self):
+        entry = '  title = "Hello World",'
+        assert lc._bibtex_field(entry, "title") == "Hello World"
+
+    def test_bare_year(self):
+        entry = "  year = 2023,"
+        assert lc._bibtex_field(entry, "year") == "2023"
+
+    def test_missing_field(self):
+        entry = "  title = {Hello},"
+        assert lc._bibtex_field(entry, "doi") == ""
+
+    def test_case_insensitive(self):
+        entry = "  TITLE = {Hello},"
+        assert lc._bibtex_field(entry, "title") == "Hello"
+
+    def test_multiline(self):
+        entry = "  abstract = {This is\na multiline\nabstract.},"
+        val = lc._bibtex_field(entry, "abstract")
+        assert "multiline" in val


### PR DESCRIPTION
## Summary

This PR brings the codebase up to JOSS submission quality by fixing several critical issues and adding the interactive HTML report and desktop GUI described in the paper.

### Bugs fixed
- **Broken entry point**: `pyproject.toml` had `litcluster:_cli` but the function is `main`; now `litcluster:main`
- **Broken `src/` package**: `src/litcluster/__init__.py` imported from `.cluster` and `.embed` (non-existent modules); replaced with correct re-exports
- **Inaccurate paper + changelog**: `paper.md` claimed UMAP/HDBSCAN/sentence-transformers; `CHANGELOG.md` listed unimplemented features as delivered — both now accurately describe the TF-IDF + k-means implementation
- **Unrelated references**: `paper.bib` contained SHA hashing / prompt-injection papers; replaced with Salton 1988, Lloyd 1982, Arthur 2007, Manning 2008, Kitchenham 2004, Moher 2009
- **Fragile BibTeX parser**: old regex broke on nested braces and multi-line values; new parser uses a proper brace-depth counter

### Algorithmic improvements
- **k-means++ initialisation** (`_kmeans_plusplus_init`): selects centroids with probability proportional to squared cosine distance, reducing sensitivity to random seed
- **Normalised top-term scoring**: divides summed TF-IDF by cluster size to avoid bias toward larger clusters
- **Min-freq fallback**: if `min_term_freq` filters out all vocabulary, `fit()` retries with `min_freq=1` instead of silently producing empty clusters
- **Expanded stopword list**: added common academic filler words (`paper`, `study`, `results`, `propose`, `method`, …)

### New features
- **`export_html()`**: self-contained interactive HTML report — collapsible cluster cards, top-term badges, paper tables, real-time title/author search, cluster filter dropdown, colour-coded pills — no internet connection or external dependencies
- **`--html` CLI format**: `litcluster refs.bib --format html --output report.html`
- **`from_list()` classmethod**: construct `LitCluster` from a list of dicts (useful for testing and programmatic use)
- **`Paper.from_dict()` classmethod**: cleaner construction from arbitrary dicts
- **Tkinter GUI** (`litcluster_gui.py` / `litcluster-gui` CLI script): file picker, parameter spinboxes, background clustering thread, tabbed results (Summary / Clusters / Papers), paper search, export dialogs

### Documentation
- **README.md**: complete documentation — installation, CLI reference, GUI, Python API examples, algorithm description, input/output format specs, test instructions, citation
- **paper.md**: rewritten Summary and Statement of Need to accurately describe the implemented algorithm
- **CHANGELOG.md**: accurate record of what v0.1.0 delivers

### Tests
- **72 pytest tests** (was 4): cover `_tokenise`, `_tfidf`, `_cosine`, `_kmeans`, `Paper`, `Cluster`, `LitCluster` (init, all parsers, `fit()`, all exports), CLI, and `_bibtex_field`; all pass in 0.09 s

## Test plan
- [ ] `pytest tests/ -v` — all 72 tests pass
- [ ] `pip install -e . && litcluster --help` — entry point works
- [ ] `litcluster refs.bib -k 4 --format html -o report.html` then open `report.html` in a browser — search, filter, collapse all work offline
- [ ] `litcluster-gui` — GUI launches, clusters, and exports correctly
- [ ] Review `paper.md` references against `paper.bib` — all citations resolve

https://claude.ai/code/session_0167Mp8mn4FALpz1QjaJwwcG

---
_Generated by [Claude Code](https://claude.ai/code/session_0167Mp8mn4FALpz1QjaJwwcG)_