### PR TITLE
Debug, refine to JOSS quality, and add tkinter GUI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+__pycache__/
+*.py[cod]
+*.egg-info/
+dist/
+build/
+.eggs/
+*.egg
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+*.so

--- a/README.md
+++ b/README.md
@@ -1,1 +1,187 @@
 # litcluster
+
+[![CI](https://github.com/vdeshmukh203/litcluster/actions/workflows/ci.yml/badge.svg)](https://github.com/vdeshmukh203/litcluster/actions/workflows/ci.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+[![Python](https://img.shields.io/badge/python-3.8%2B-blue)](https://python.org)
+
+**litcluster** clusters academic papers into thematic groups using TF-IDF vectorisation and k-means — zero external dependencies, pure Python standard library.
+
+It is designed to help researchers organise large literature collections at the start of a systematic or scoping review, surfacing thematic clusters and their top discriminative terms automatically.
+
+---
+
+## Features
+
+- Ingest papers from **BibTeX** (`.bib`), **CSV**, or **JSONL** files
+- TF-IDF vectorisation with configurable rare-term filtering
+- k-means clustering using cosine similarity
+- Per-cluster top-term extraction for interpretable labels
+- Export results as **CSV** or **JSON**
+- Interactive **GUI** (tkinter, stdlib — no install required)
+- **CLI** with summary, CSV, and JSON output modes
+- Fully reproducible: seeded random initialisation
+
+---
+
+## Installation
+
+```bash
+pip install litcluster
+```
+
+Or from source:
+
+```bash
+git clone https://github.com/vdeshmukh203/litcluster.git
+cd litcluster
+pip install -e .
+```
+
+No external packages are required — litcluster depends only on the Python standard library.
+
+---
+
+## Quick Start
+
+### GUI
+
+```bash
+litcluster-gui
+# or
+litcluster --gui
+```
+
+The GUI lets you browse for a file, tune parameters with spinboxes, run clustering, inspect cluster contents and individual paper metadata, and export results.
+
+### CLI
+
+```bash
+# Print a summary to stdout
+litcluster refs.bib -k 5
+
+# Export cluster assignments as CSV
+litcluster refs.bib -k 8 --format csv -o clusters.csv
+
+# Export full cluster data (papers + top terms) as JSON
+litcluster refs.bib -k 8 --format json -o clusters.json
+```
+
+### Python API
+
+```python
+from pathlib import Path
+from litcluster import LitCluster
+
+lc = LitCluster.from_bibtex(Path("refs.bib"), k=6)
+lc.fit()
+
+print(lc.summary())
+lc.export_csv(Path("clusters.csv"))
+lc.export_json(Path("clusters.json"))
+```
+
+---
+
+## Input Formats
+
+### BibTeX (`.bib`)
+
+Standard BibTeX files exported from reference managers (Zotero, Mendeley, etc.).
+litcluster reads the `title`, `abstract`, `author`, `year`, `journal`/`booktitle`,
+`doi`, and `keywords` fields. Multi-line values and nested braces are handled.
+
+### CSV (`.csv`)
+
+Column names: `paper_id`, `title`, `abstract`, `authors`, `year`, `venue`, `doi`,
+`keywords`. All columns except `title` are optional.
+
+### JSONL (`.jsonl`)
+
+One JSON object per line, using the same field names as CSV.
+
+---
+
+## Parameters
+
+| Parameter | CLI flag | Default | Description |
+|-----------|----------|---------|-------------|
+| `k` | `-k` / `--clusters` | `5` | Number of clusters |
+| `seed` | `--seed` | `42` | Random seed for reproducibility |
+| `max_iter` | `--max-iter` | `100` | Maximum k-means iterations |
+| `min_term_freq` | `--min-freq` | `2` | Minimum document frequency for a term to enter the vocabulary |
+
+---
+
+## Output
+
+### Summary (default)
+
+```
+LitCluster: 42 papers in 5 clusters
+
+  [0] Cluster 0: deep, learning, neural  (9 papers)
+  [1] Cluster 1: climate, temperature, carbon  (8 papers)
+  [2] Cluster 2: genome, protein, sequence  (10 papers)
+  [3] Cluster 3: quantum, circuit, gate  (7 papers)
+  [4] Cluster 4: polymer, synthesis, catalyst  (8 papers)
+```
+
+### CSV
+
+Columns: `cluster_id`, `cluster_label`, `paper_id`, `title`, `authors`, `year`,
+`venue`, `doi`.
+
+### JSON
+
+Array of cluster objects, each containing `cluster_id`, `size`, `top_terms`,
+`label`, and a `papers` array with full metadata.
+
+---
+
+## Development
+
+```bash
+git clone https://github.com/vdeshmukh203/litcluster.git
+cd litcluster
+pip install -e ".[dev]"
+pytest tests/ -v
+```
+
+---
+
+## How It Works
+
+1. **Load** — papers are ingested from BibTeX, CSV, or JSONL.
+2. **Tokenise** — title, abstract, and keywords are lower-cased; alphabetic tokens
+   of length >= 3 are retained after stopword removal.
+3. **Filter** — terms appearing in fewer than `min_term_freq` documents are dropped,
+   reducing noise from highly specialised or misspelled tokens.
+4. **Vectorise** — each paper is represented as a sparse TF-IDF vector using
+   smoothed IDF: `idf(t) = log((N+1)/(df(t)+1)) + 1`.
+5. **Cluster** — Lloyd's k-means algorithm iterates assignment and centroid update
+   steps using cosine similarity until convergence or `max_iter` is reached.
+   Empty clusters are re-seeded to a random document.
+6. **Label** — the top-`n` terms by aggregate TF-IDF score across cluster members
+   are extracted as interpretable cluster labels.
+
+---
+
+## Citation
+
+If you use litcluster in published work, please cite:
+
+```bibtex
+@software{deshmukh2026litcluster,
+  author  = {Deshmukh, Vaibhav},
+  title   = {litcluster: Topic-based clustering of scientific literature},
+  year    = {2026},
+  url     = {https://github.com/vdeshmukh203/litcluster},
+  license = {MIT}
+}
+```
+
+---
+
+## License
+
+MIT — see [LICENSE](LICENSE).

--- a/litcluster.py
+++ b/litcluster.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
 """
-litcluster.py — Literature Clustering Tool
-Clusters academic papers by topic using TF-IDF + k-means (pure stdlib).
-Stdlib-only. No external dependencies.
+litcluster — Literature Clustering Tool
+
+Clusters academic papers by topic using TF-IDF and k-means.
+Pure Python standard library; no external dependencies required.
 """
 
 from __future__ import annotations
@@ -17,6 +18,11 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
+__version__ = "0.1.0"
+__all__ = [
+    "Paper", "Cluster", "LitCluster",
+    "_tokenise", "_tfidf", "_cosine", "_kmeans",
+]
 
 # ---------------------------------------------------------------------------
 # Text processing
@@ -37,17 +43,26 @@ _STOPWORDS = {
 
 
 def _tokenise(text: str) -> List[str]:
+    """Lowercase, extract alphabetic tokens of length >= 3, remove stopwords."""
     tokens = re.findall(r"[a-zA-Z]{3,}", text.lower())
     return [t for t in tokens if t not in _STOPWORDS]
 
 
-def _tfidf(documents: List[List[str]]) -> Tuple[List[Dict[str,float]], List[str]]:
-    """Compute TF-IDF vectors. Returns (vectors, vocab)."""
+def _tfidf(
+    documents: List[List[str]],
+) -> Tuple[List[Dict[str, float]], List[str]]:
+    """Compute TF-IDF sparse vectors for a list of tokenised documents.
+
+    Uses smoothed IDF: idf(t) = log((N+1)/(df(t)+1)) + 1.
+
+    Returns:
+        vectors: one dict per document mapping term -> TF-IDF weight.
+        vocab: sorted list of all terms.
+    """
     n = len(documents)
     if n == 0:
         return [], []
 
-    # Build vocab
     vocab_set: set = set()
     for doc in documents:
         vocab_set.update(doc)
@@ -55,15 +70,13 @@ def _tfidf(documents: List[List[str]]) -> Tuple[List[Dict[str,float]], List[str]
     term_idx = {t: i for i, t in enumerate(vocab)}
     V = len(vocab)
 
-    # Document frequency
+    # document frequency
     df = [0] * V
     for doc in documents:
-        doc_set = set(doc)
-        for t in doc_set:
+        for t in set(doc):
             if t in term_idx:
                 df[term_idx[t]] += 1
 
-    # TF-IDF
     vectors: List[Dict[str, float]] = []
     for doc in documents:
         tf: Dict[int, int] = {}
@@ -71,8 +84,8 @@ def _tfidf(documents: List[List[str]]) -> Tuple[List[Dict[str,float]], List[str]
             if t in term_idx:
                 idx = term_idx[t]
                 tf[idx] = tf.get(idx, 0) + 1
-        vec: Dict[str, float] = {}
         doc_len = len(doc) or 1
+        vec: Dict[str, float] = {}
         for idx, count in tf.items():
             term = vocab[idx]
             tf_val = count / doc_len
@@ -83,10 +96,13 @@ def _tfidf(documents: List[List[str]]) -> Tuple[List[Dict[str,float]], List[str]
 
 
 def _cosine(a: Dict[str, float], b: Dict[str, float]) -> float:
-    dot = sum(a.get(t, 0.0) * b.get(t, 0.0) for t in b)
-    norm_a = math.sqrt(sum(v*v for v in a.values()))
-    norm_b = math.sqrt(sum(v*v for v in b.values()))
-    if norm_a == 0 or norm_b == 0:
+    """Cosine similarity between two sparse vectors represented as dicts."""
+    if not a or not b:
+        return 0.0
+    dot = sum(a.get(t, 0.0) * v for t, v in b.items())
+    norm_a = math.sqrt(sum(v * v for v in a.values()))
+    norm_b = math.sqrt(sum(v * v for v in b.values()))
+    if norm_a == 0.0 or norm_b == 0.0:
         return 0.0
     return dot / (norm_a * norm_b)
 
@@ -97,13 +113,22 @@ def _kmeans(
     max_iter: int = 100,
     seed: int = 42,
 ) -> List[int]:
-    """Lloyd's k-means on sparse TF-IDF vectors."""
+    """Lloyd's k-means on sparse cosine-similarity TF-IDF vectors.
+
+    Args:
+        vectors: sparse document vectors (list of dicts).
+        k: number of clusters (capped at len(vectors)).
+        max_iter: maximum number of Lloyd iterations.
+        seed: random seed for centroid initialisation.
+
+    Returns:
+        Integer cluster label for each document.
+    """
     n = len(vectors)
     if n == 0:
         return []
     k = min(k, n)
 
-    # Seeded centroid initialisation (evenly spaced)
     import random
     rng = random.Random(seed)
     centroid_indices = rng.sample(range(n), k)
@@ -111,28 +136,26 @@ def _kmeans(
     labels = [0] * n
 
     for _ in range(max_iter):
-        # Assignment
-        new_labels = []
-        for vec in vectors:
-            best = max(range(k), key=lambda c: _cosine(vec, centroids[c]))
-            new_labels.append(best)
-
+        new_labels = [
+            max(range(k), key=lambda c: _cosine(vec, centroids[c]))
+            for vec in vectors
+        ]
         if new_labels == labels:
             break
         labels = new_labels
 
-        # Update centroids
         for c in range(k):
-            members = [vectors[i] for i, l in enumerate(labels) if l == c]
+            members = [vectors[i] for i, lbl in enumerate(labels) if lbl == c]
             if not members:
-                centroids[c] = dict(vectors[rng.randint(0, n-1)])
+                # re-seed empty cluster to a random point
+                centroids[c] = dict(vectors[rng.randint(0, n - 1)])
                 continue
             new_centroid: Dict[str, float] = {}
             for vec in members:
                 for t, v in vec.items():
                     new_centroid[t] = new_centroid.get(t, 0.0) + v
-            total = len(members)
-            centroids[c] = {t: v/total for t, v in new_centroid.items()}
+            m = len(members)
+            centroids[c] = {t: v / m for t, v in new_centroid.items()}
 
     return labels
 
@@ -143,6 +166,8 @@ def _kmeans(
 
 @dataclass
 class Paper:
+    """Metadata for a single academic paper."""
+
     paper_id: str
     title: str
     abstract: str = ""
@@ -154,25 +179,34 @@ class Paper:
 
     @property
     def text(self) -> str:
+        """Concatenated text used for vectorisation."""
         return f"{self.title} {self.abstract} {self.keywords}"
 
     def to_dict(self) -> dict:
         return {
-            "paper_id": self.paper_id, "title": self.title, "abstract": self.abstract,
-            "authors": self.authors, "year": self.year, "venue": self.venue,
-            "doi": self.doi, "keywords": self.keywords,
+            "paper_id": self.paper_id,
+            "title": self.title,
+            "abstract": self.abstract,
+            "authors": self.authors,
+            "year": self.year,
+            "venue": self.venue,
+            "doi": self.doi,
+            "keywords": self.keywords,
         }
 
 
 @dataclass
 class Cluster:
+    """A group of thematically similar papers with extracted top terms."""
+
     cluster_id: int
     papers: List[Paper] = field(default_factory=list)
     top_terms: List[str] = field(default_factory=list)
 
     @property
     def label(self) -> str:
-        return f"Cluster {self.cluster_id}: {', '.join(self.top_terms[:3])}"
+        terms = ", ".join(self.top_terms[:3]) if self.top_terms else "—"
+        return f"Cluster {self.cluster_id}: {terms}"
 
     def to_dict(self) -> dict:
         return {
@@ -189,8 +223,30 @@ class Cluster:
 # ---------------------------------------------------------------------------
 
 class LitCluster:
-    def __init__(self, k: int = 5, max_iter: int = 100, seed: int = 42,
-                 min_term_freq: int = 2):
+    """Cluster a collection of academic papers by topic using TF-IDF + k-means.
+
+    Workflow::
+
+        lc = LitCluster.from_bibtex(Path("refs.bib"), k=6)
+        lc.fit()
+        print(lc.summary())
+        lc.export_csv(Path("clusters.csv"))
+    """
+
+    def __init__(
+        self,
+        k: int = 5,
+        max_iter: int = 100,
+        seed: int = 42,
+        min_term_freq: int = 2,
+    ) -> None:
+        """
+        Args:
+            k: number of clusters.
+            max_iter: maximum k-means iterations.
+            seed: random seed for reproducibility.
+            min_term_freq: minimum document frequency for a term to be kept.
+        """
         self.k = k
         self.max_iter = max_iter
         self.seed = seed
@@ -201,8 +257,18 @@ class LitCluster:
         self._vectors: List[Dict[str, float]] = []
         self._vocab: List[str] = []
 
+    # ------------------------------------------------------------------
+    # Loaders
+    # ------------------------------------------------------------------
+
     @classmethod
     def from_csv(cls, path: Path, **kwargs) -> "LitCluster":
+        """Load papers from a CSV file.
+
+        Expected columns: ``paper_id``, ``title``, ``abstract``, ``authors``,
+        ``year``, ``venue``, ``doi``, ``keywords``.  All columns are optional
+        except ``title``.
+        """
         obj = cls(**kwargs)
         with path.open(encoding="utf-8", errors="replace", newline="") as fh:
             reader = csv.DictReader(fh)
@@ -221,6 +287,7 @@ class LitCluster:
 
     @classmethod
     def from_jsonl(cls, path: Path, **kwargs) -> "LitCluster":
+        """Load papers from a JSONL file (one JSON object per line)."""
         obj = cls(**kwargs)
         with path.open(encoding="utf-8") as fh:
             for i, line in enumerate(fh):
@@ -242,56 +309,110 @@ class LitCluster:
 
     @classmethod
     def from_bibtex(cls, path: Path, **kwargs) -> "LitCluster":
-        """Parse a BibTeX file for titles, abstracts, keywords."""
+        """Load papers from a BibTeX (``.bib``) file.
+
+        Extracts ``title``, ``abstract``, ``author``, ``year``,
+        ``journal``/``booktitle``, ``doi``, and ``keywords`` fields.
+        Handles multi-line values and nested braces.
+        """
         obj = cls(**kwargs)
         text = path.read_text(encoding="utf-8", errors="replace")
         entries = re.split(r'(?=@\w+\s*\{)', text)
         for i, entry in enumerate(entries):
-            if not entry.strip() or not entry.startswith('@'):
+            entry = entry.strip()
+            if not entry or not entry.startswith('@'):
                 continue
-            def _get(field):
-                m = re.search(rf'{field}\s*=\s*[{{"](.*?)[}}"\,]', entry, re.IGNORECASE | re.DOTALL)
-                return m.group(1).strip() if m else ""
-            m_key = re.match(r'@\w+\s*\{\s*(\S+?)[,}]', entry)
+            m_key = re.match(r'@\w+\s*\{\s*([^,\s]+)', entry)
             key = m_key.group(1) if m_key else str(i)
+
+            def _get(field_name: str, src: str = entry) -> str:
+                m = re.search(
+                    rf'\b{field_name}\s*=\s*', src, re.IGNORECASE
+                )
+                if not m:
+                    return ""
+                pos = m.end()
+                if pos >= len(src):
+                    return ""
+                ch = src[pos]
+                if ch == '{':
+                    depth = 0
+                    for j in range(pos, len(src)):
+                        if src[j] == '{':
+                            depth += 1
+                        elif src[j] == '}':
+                            depth -= 1
+                            if depth == 0:
+                                return src[pos + 1:j].strip()
+                    return ""
+                if ch == '"':
+                    end = src.find('"', pos + 1)
+                    return src[pos + 1:end].strip() if end != -1 else ""
+                # bare numeric value (e.g. year = 2020)
+                m2 = re.match(r'\s*(\w+)', src[pos:])
+                return m2.group(1) if m2 else ""
+
             obj.papers.append(Paper(
-                paper_id=key, title=_get('title'), abstract=_get('abstract'),
-                authors=_get('author'), year=_get('year'),
+                paper_id=key,
+                title=_get('title'),
+                abstract=_get('abstract'),
+                authors=_get('author'),
+                year=_get('year'),
                 venue=_get('journal') or _get('booktitle'),
-                doi=_get('doi'), keywords=_get('keywords'),
+                doi=_get('doi'),
+                keywords=_get('keywords'),
             ))
         return obj
 
+    # ------------------------------------------------------------------
+    # Core algorithm
+    # ------------------------------------------------------------------
+
     def fit(self) -> "LitCluster":
+        """Vectorise papers and run k-means clustering.
+
+        Returns ``self`` to allow chaining::
+
+            lc = LitCluster.from_csv(path, k=5).fit()
+        """
         if not self.papers:
             return self
+
         tokens_list = [_tokenise(p.text) for p in self.papers]
 
-        # Filter rare terms
         if self.min_term_freq > 1:
             freq: Dict[str, int] = {}
             for tokens in tokens_list:
                 for t in set(tokens):
                     freq[t] = freq.get(t, 0) + 1
-            tokens_list = [[t for t in tokens if freq.get(t, 0) >= self.min_term_freq]
-                           for tokens in tokens_list]
+            tokens_list = [
+                [t for t in tokens if freq.get(t, 0) >= self.min_term_freq]
+                for tokens in tokens_list
+            ]
 
         self._vectors, self._vocab = _tfidf(tokens_list)
         self._labels = _kmeans(self._vectors, self.k, self.max_iter, self.seed)
 
-        # Build cluster objects
-        clusters: Dict[int, List] = {}
-        for paper, label in zip(self.papers, self._labels):
-            clusters.setdefault(label, []).append(paper)
+        groups: Dict[int, List[Paper]] = {}
+        for paper, lbl in zip(self.papers, self._labels):
+            groups.setdefault(lbl, []).append(paper)
 
-        self.clusters = []
-        for cid in sorted(clusters):
-            top_terms = self._top_terms_for_cluster(cid, n=10)
-            self.clusters.append(Cluster(cluster_id=cid, papers=clusters[cid], top_terms=top_terms))
+        self.clusters = [
+            Cluster(
+                cluster_id=cid,
+                papers=groups[cid],
+                top_terms=self._top_terms_for_cluster(cid),
+            )
+            for cid in sorted(groups)
+        ]
         return self
 
     def _top_terms_for_cluster(self, cid: int, n: int = 10) -> List[str]:
-        member_vecs = [self._vectors[i] for i, l in enumerate(self._labels) if l == cid]
+        member_vecs = [
+            self._vectors[i]
+            for i, lbl in enumerate(self._labels)
+            if lbl == cid
+        ]
         if not member_vecs:
             return []
         scores: Dict[str, float] = {}
@@ -300,23 +421,43 @@ class LitCluster:
                 scores[t] = scores.get(t, 0.0) + v
         return sorted(scores, key=lambda t: -scores[t])[:n]
 
+    # ------------------------------------------------------------------
+    # Export
+    # ------------------------------------------------------------------
+
     def export_csv(self, path: Path) -> None:
+        """Write cluster assignments to a CSV file."""
         with path.open("w", newline="", encoding="utf-8") as fh:
             w = csv.writer(fh)
-            w.writerow(["cluster_id","cluster_label","paper_id","title","authors","year","venue","doi"])
+            w.writerow([
+                "cluster_id", "cluster_label", "paper_id",
+                "title", "authors", "year", "venue", "doi",
+            ])
             for cluster in self.clusters:
                 for p in cluster.papers:
-                    w.writerow([cluster.cluster_id, cluster.label, p.paper_id,
-                                p.title, p.authors, p.year, p.venue, p.doi])
+                    w.writerow([
+                        cluster.cluster_id, cluster.label, p.paper_id,
+                        p.title, p.authors, p.year, p.venue, p.doi,
+                    ])
 
     def export_json(self, path: Path) -> None:
+        """Write full cluster data (papers + top terms) to a JSON file."""
         with path.open("w", encoding="utf-8") as fh:
-            json.dump([c.to_dict() for c in self.clusters], fh, indent=2, ensure_ascii=False)
+            json.dump(
+                [c.to_dict() for c in self.clusters],
+                fh, indent=2, ensure_ascii=False,
+            )
 
     def summary(self) -> str:
-        lines = [f"LitCluster: {len(self.papers)} papers in {len(self.clusters)} clusters", ""]
+        """Return a human-readable text summary of clustering results."""
+        lines = [
+            f"LitCluster: {len(self.papers)} papers in {len(self.clusters)} clusters",
+            "",
+        ]
         for c in self.clusters:
-            lines.append(f"  [{c.cluster_id}] {c.label} ({len(c.papers)} papers)")
+            lines.append(
+                f"  [{c.cluster_id}] {c.label}  ({len(c.papers)} papers)"
+            )
         return "\n".join(lines)
 
 
@@ -325,29 +466,51 @@ class LitCluster:
 # ---------------------------------------------------------------------------
 
 def _parse_args(argv=None):
-    p = argparse.ArgumentParser(prog="litcluster",
-                                description="Cluster academic papers by topic using TF-IDF + k-means.")
-    p.add_argument("input", help="Input file: CSV, JSONL, or .bib")
+    p = argparse.ArgumentParser(
+        prog="litcluster",
+        description="Cluster academic papers by topic using TF-IDF + k-means.",
+    )
+    p.add_argument("input", nargs="?",
+                   help="Input file: CSV, JSONL, or .bib (omit to launch GUI)")
     p.add_argument("-k", "--clusters", type=int, default=5, dest="k",
                    help="Number of clusters (default: 5)")
-    p.add_argument("--format", choices=["csv","json","summary"], default="summary")
-    p.add_argument("--output", "-o", default=None, help="Output file (default: stdout/auto)")
+    p.add_argument("--format", choices=["csv", "json", "summary"],
+                   default="summary")
+    p.add_argument("--output", "-o", default=None,
+                   help="Output file (default: stdout for summary, auto for csv/json)")
     p.add_argument("--seed", type=int, default=42)
     p.add_argument("--max-iter", type=int, default=100)
     p.add_argument("--min-freq", type=int, default=2,
-                   help="Minimum term frequency to include in vocabulary (default: 2)")
+                   help="Minimum term document frequency (default: 2)")
+    p.add_argument("--gui", action="store_true",
+                   help="Launch the graphical user interface")
+    p.add_argument("--version", action="version", version=f"%(prog)s {__version__}")
     return p.parse_args(argv)
 
 
 def main(argv=None) -> int:
+    """Entry point for the ``litcluster`` command."""
     args = _parse_args(argv)
+
+    if args.gui or args.input is None:
+        try:
+            from litcluster_gui import main as gui_main
+            gui_main()
+        except ImportError as exc:
+            print(f"GUI unavailable: {exc}", file=sys.stderr)
+            return 1
+        return 0
+
     path = Path(args.input)
     if not path.is_file():
         print(f"Error: {path} not found", file=sys.stderr)
         return 1
 
     suffix = path.suffix.lower()
-    kwargs = dict(k=args.k, max_iter=args.max_iter, seed=args.seed, min_term_freq=args.min_freq)
+    kwargs = dict(
+        k=args.k, max_iter=args.max_iter,
+        seed=args.seed, min_term_freq=args.min_freq,
+    )
     if suffix == ".bib":
         lc = LitCluster.from_bibtex(path, **kwargs)
     elif suffix == ".jsonl":
@@ -373,6 +536,10 @@ def main(argv=None) -> int:
         print(f"Clusters written to {out}")
 
     return 0
+
+
+# ``_cli`` is a public alias kept for compatibility with pyproject.toml scripts.
+_cli = main
 
 
 if __name__ == "__main__":

--- a/litcluster_gui.py
+++ b/litcluster_gui.py
@@ -1,0 +1,387 @@
+#!/usr/bin/env python3
+"""
+litcluster_gui.py — Graphical interface for litcluster.
+
+Launch with:
+    litcluster-gui
+    litcluster --gui
+    python litcluster_gui.py
+"""
+
+from __future__ import annotations
+
+import sys
+import threading
+from pathlib import Path
+from tkinter import filedialog, messagebox, scrolledtext
+import tkinter as tk
+import tkinter.ttk as ttk
+
+from litcluster import LitCluster, Cluster, Paper
+
+
+class _App:
+    """Main application window."""
+
+    def __init__(self) -> None:
+        self.root = tk.Tk()
+        self.root.title("litcluster — Literature Clustering")
+        self.root.minsize(960, 620)
+        self._lc: LitCluster | None = None
+        self._build_ui()
+
+    # ------------------------------------------------------------------
+    # UI construction
+    # ------------------------------------------------------------------
+
+    def _build_ui(self) -> None:
+        self.root.columnconfigure(0, weight=1)
+        self.root.rowconfigure(1, weight=1)
+
+        self._build_top_bar()
+        self._build_main_pane()
+        self._build_status_bar()
+
+    def _build_top_bar(self) -> None:
+        top = ttk.Frame(self.root, padding=(8, 6, 8, 4))
+        top.grid(row=0, column=0, sticky="ew")
+        top.columnconfigure(0, weight=1)
+
+        # ── file row ──────────────────────────────────────────────────
+        file_frame = ttk.LabelFrame(top, text="Input File", padding=(6, 4))
+        file_frame.grid(row=0, column=0, sticky="ew", pady=(0, 6))
+        file_frame.columnconfigure(0, weight=1)
+
+        self._file_var = tk.StringVar()
+        ttk.Entry(file_frame, textvariable=self._file_var).grid(
+            row=0, column=0, sticky="ew", padx=(0, 4)
+        )
+        ttk.Button(file_frame, text="Browse…", command=self._browse).grid(
+            row=0, column=1
+        )
+
+        # ── parameters row ────────────────────────────────────────────
+        params = ttk.LabelFrame(top, text="Parameters", padding=(6, 4))
+        params.grid(row=1, column=0, sticky="ew", pady=(0, 6))
+
+        self._k_var = tk.IntVar(value=5)
+        self._seed_var = tk.IntVar(value=42)
+        self._max_iter_var = tk.IntVar(value=100)
+        self._min_freq_var = tk.IntVar(value=2)
+
+        param_defs = [
+            ("Clusters (k):", self._k_var, 2, 50),
+            ("Seed:", self._seed_var, 0, 9999),
+            ("Max iterations:", self._max_iter_var, 10, 1000),
+            ("Min term freq:", self._min_freq_var, 1, 20),
+        ]
+        for col, (label, var, lo, hi) in enumerate(param_defs):
+            ttk.Label(params, text=label).grid(
+                row=0, column=col * 2, sticky="e", padx=(10, 2)
+            )
+            ttk.Spinbox(
+                params, from_=lo, to=hi, textvariable=var, width=7
+            ).grid(row=0, column=col * 2 + 1, padx=(0, 4))
+
+        # ── action buttons ────────────────────────────────────────────
+        btn_row = ttk.Frame(top)
+        btn_row.grid(row=2, column=0, sticky="w")
+
+        self._run_btn = ttk.Button(
+            btn_row, text="Run Clustering", command=self._run
+        )
+        self._run_btn.pack(side="left")
+
+        self._export_csv_btn = ttk.Button(
+            btn_row, text="Export CSV",
+            command=self._export_csv, state="disabled",
+        )
+        self._export_csv_btn.pack(side="left", padx=(6, 0))
+
+        self._export_json_btn = ttk.Button(
+            btn_row, text="Export JSON",
+            command=self._export_json, state="disabled",
+        )
+        self._export_json_btn.pack(side="left", padx=(6, 0))
+
+    def _build_main_pane(self) -> None:
+        paned = ttk.PanedWindow(self.root, orient="horizontal")
+        paned.grid(row=1, column=0, sticky="nsew", padx=8, pady=4)
+
+        # ── left: cluster / paper tree ────────────────────────────────
+        left = ttk.Frame(paned)
+        paned.add(left, weight=2)
+        left.rowconfigure(1, weight=1)
+        left.columnconfigure(0, weight=1)
+
+        ttk.Label(left, text="Clusters & Papers").grid(
+            row=0, column=0, sticky="w"
+        )
+        self._tree = ttk.Treeview(
+            left,
+            columns=("size", "terms"),
+            show="tree headings",
+            selectmode="browse",
+        )
+        self._tree.heading("#0", text="Cluster / Paper")
+        self._tree.heading("size", text="#")
+        self._tree.heading("terms", text="Top Terms")
+        self._tree.column("#0", width=220, minwidth=140)
+        self._tree.column("size", width=40, anchor="center", minwidth=30)
+        self._tree.column("terms", width=240, minwidth=100)
+
+        vsb = ttk.Scrollbar(left, orient="vertical", command=self._tree.yview)
+        self._tree.configure(yscrollcommand=vsb.set)
+        self._tree.grid(row=1, column=0, sticky="nsew")
+        vsb.grid(row=1, column=1, sticky="ns")
+        self._tree.bind("<<TreeviewSelect>>", self._on_select)
+
+        # ── right: detail pane ────────────────────────────────────────
+        right = ttk.Frame(paned)
+        paned.add(right, weight=3)
+        right.rowconfigure(1, weight=1)
+        right.columnconfigure(0, weight=1)
+
+        ttk.Label(right, text="Details").grid(row=0, column=0, sticky="w")
+        self._detail = scrolledtext.ScrolledText(
+            right, wrap="word", state="disabled",
+            font=("TkFixedFont", 10), relief="flat",
+        )
+        self._detail.grid(row=1, column=0, sticky="nsew")
+
+    def _build_status_bar(self) -> None:
+        self._status_var = tk.StringVar(
+            value="Ready — select a file and click Run Clustering."
+        )
+        ttk.Label(
+            self.root, textvariable=self._status_var,
+            relief="sunken", anchor="w", padding=(4, 2),
+        ).grid(row=2, column=0, sticky="ew")
+
+    # ------------------------------------------------------------------
+    # Actions
+    # ------------------------------------------------------------------
+
+    def _browse(self) -> None:
+        path = filedialog.askopenfilename(
+            title="Open literature file",
+            filetypes=[
+                ("All supported", "*.csv *.jsonl *.bib"),
+                ("CSV", "*.csv"),
+                ("JSONL", "*.jsonl"),
+                ("BibTeX", "*.bib"),
+                ("All files", "*"),
+            ],
+        )
+        if path:
+            self._file_var.set(path)
+
+    def _run(self) -> None:
+        path_str = self._file_var.get().strip()
+        if not path_str:
+            messagebox.showwarning("No file", "Please select an input file first.")
+            return
+        path = Path(path_str)
+        if not path.is_file():
+            messagebox.showerror("File not found", f"Cannot find:\n{path}")
+            return
+
+        self._run_btn.configure(state="disabled")
+        self._export_csv_btn.configure(state="disabled")
+        self._export_json_btn.configure(state="disabled")
+        self._status_var.set("Clustering — please wait…")
+        self._tree.delete(*self._tree.get_children())
+        self._set_detail("")
+
+        def _worker() -> None:
+            try:
+                kwargs = dict(
+                    k=self._k_var.get(),
+                    seed=self._seed_var.get(),
+                    max_iter=self._max_iter_var.get(),
+                    min_term_freq=self._min_freq_var.get(),
+                )
+                suffix = path.suffix.lower()
+                if suffix == ".bib":
+                    lc = LitCluster.from_bibtex(path, **kwargs)
+                elif suffix == ".jsonl":
+                    lc = LitCluster.from_jsonl(path, **kwargs)
+                else:
+                    lc = LitCluster.from_csv(path, **kwargs)
+                lc.fit()
+                self._lc = lc
+                self.root.after(0, self._populate_results)
+            except Exception as exc:  # pylint: disable=broad-except
+                self.root.after(
+                    0,
+                    lambda: messagebox.showerror("Clustering failed", str(exc)),
+                )
+                self.root.after(
+                    0, lambda: self._status_var.set("Error during clustering.")
+                )
+                self.root.after(
+                    0, lambda: self._run_btn.configure(state="normal")
+                )
+
+        threading.Thread(target=_worker, daemon=True).start()
+
+    def _populate_results(self) -> None:
+        lc = self._lc
+        assert lc is not None
+        self._tree.delete(*self._tree.get_children())
+
+        for cluster in lc.clusters:
+            cid_str = f"c{cluster.cluster_id}"
+            self._tree.insert(
+                "", "end", iid=cid_str,
+                text=f"Cluster {cluster.cluster_id}",
+                values=(
+                    len(cluster.papers),
+                    ", ".join(cluster.top_terms[:5]),
+                ),
+                open=False,
+            )
+            for paper in cluster.papers:
+                short = (
+                    paper.title[:58] + "…"
+                    if len(paper.title) > 58
+                    else paper.title
+                )
+                self._tree.insert(
+                    cid_str, "end",
+                    iid=f"p{paper.paper_id}",
+                    text=short,
+                    values=(1, paper.authors[:45] if paper.authors else ""),
+                )
+
+        self._run_btn.configure(state="normal")
+        self._export_csv_btn.configure(state="normal")
+        self._export_json_btn.configure(state="normal")
+
+        first_line = lc.summary().splitlines()[0]
+        self._status_var.set(first_line)
+        self._set_detail(lc.summary())
+
+    def _on_select(self, _event=None) -> None:
+        sel = self._tree.selection()
+        if not sel or self._lc is None:
+            return
+        iid = sel[0]
+
+        if iid.startswith("c"):
+            cid = int(iid[1:])
+            cluster = next(
+                (c for c in self._lc.clusters if c.cluster_id == cid), None
+            )
+            if cluster:
+                self._set_detail(self._cluster_detail(cluster))
+
+        elif iid.startswith("p"):
+            pid = iid[1:]
+            paper = next(
+                (p for c in self._lc.clusters for p in c.papers
+                 if p.paper_id == pid),
+                None,
+            )
+            if paper:
+                self._set_detail(self._paper_detail(paper))
+
+    # ------------------------------------------------------------------
+    # Export helpers
+    # ------------------------------------------------------------------
+
+    def _export_csv(self) -> None:
+        if self._lc is None:
+            return
+        path = filedialog.asksaveasfilename(
+            title="Save clusters as CSV",
+            defaultextension=".csv",
+            filetypes=[("CSV", "*.csv"), ("All files", "*")],
+        )
+        if path:
+            self._lc.export_csv(Path(path))
+            self._status_var.set(f"Exported: {path}")
+
+    def _export_json(self) -> None:
+        if self._lc is None:
+            return
+        path = filedialog.asksaveasfilename(
+            title="Save clusters as JSON",
+            defaultextension=".json",
+            filetypes=[("JSON", "*.json"), ("All files", "*")],
+        )
+        if path:
+            self._lc.export_json(Path(path))
+            self._status_var.set(f"Exported: {path}")
+
+    # ------------------------------------------------------------------
+    # Detail text helpers
+    # ------------------------------------------------------------------
+
+    def _set_detail(self, text: str) -> None:
+        self._detail.configure(state="normal")
+        self._detail.delete("1.0", "end")
+        if text:
+            self._detail.insert("end", text)
+        self._detail.configure(state="disabled")
+
+    @staticmethod
+    def _cluster_detail(cluster: Cluster) -> str:
+        lines = [
+            cluster.label,
+            f"Papers in cluster: {len(cluster.papers)}",
+            f"Top terms: {', '.join(cluster.top_terms)}",
+            "",
+        ]
+        for p in cluster.papers:
+            lines.append(f"  • {p.title}")
+            if p.authors:
+                lines.append(f"    Authors : {p.authors}")
+            if p.year:
+                lines.append(f"    Year    : {p.year}")
+            if p.venue:
+                lines.append(f"    Venue   : {p.venue}")
+            if p.doi:
+                lines.append(f"    DOI     : {p.doi}")
+            lines.append("")
+        return "\n".join(lines)
+
+    @staticmethod
+    def _paper_detail(paper: Paper) -> str:
+        fields = [
+            ("Title",    paper.title),
+            ("Authors",  paper.authors),
+            ("Year",     paper.year),
+            ("Venue",    paper.venue),
+            ("DOI",      paper.doi),
+            ("Keywords", paper.keywords),
+        ]
+        lines = [f"{k}: {v}" for k, v in fields if v]
+        if paper.abstract:
+            lines += ["", "Abstract:", paper.abstract]
+        return "\n".join(lines)
+
+    # ------------------------------------------------------------------
+    # Entry point
+    # ------------------------------------------------------------------
+
+    def run(self) -> None:
+        self.root.mainloop()
+
+
+def main() -> None:
+    """Launch the litcluster GUI."""
+    try:
+        app = _App()
+        app.run()
+    except tk.TclError as exc:
+        print(f"Cannot open GUI: {exc}", file=sys.stderr)
+        print(
+            "Ensure a display is available (e.g. set DISPLAY on Linux).",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/paper.bib
+++ b/paper.bib
@@ -1,9 +1,46 @@
-@misc{nist2015sha,
-  author       = {{National Institute of Standards and Technology}},
-  title        = {{FIPS PUB 180-4: Secure Hash Standard (SHS)}},
-  year         = {2015},
-  howpublished = {\url{https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf}},
-  institution  = {National Institute of Standards and Technology}
+@article{salton1988,
+  author  = {Salton, Gerard and Buckley, Christopher},
+  title   = {Term-weighting approaches in automatic text retrieval},
+  journal = {Information Processing \& Management},
+  volume  = {24},
+  number  = {5},
+  pages   = {513--523},
+  year    = {1988},
+  doi     = {10.1016/0306-4573(88)90021-0}
+}
+
+@article{lloyd1982,
+  author  = {Lloyd, Stuart P.},
+  title   = {Least Squares Quantization in {PCM}},
+  journal = {IEEE Transactions on Information Theory},
+  volume  = {28},
+  number  = {2},
+  pages   = {129--137},
+  year    = {1982},
+  doi     = {10.1109/TIT.1982.1056489}
+}
+
+@inproceedings{macqueen1967,
+  author    = {MacQueen, James},
+  title     = {Some methods for classification and analysis of multivariate observations},
+  booktitle = {Proceedings of the Fifth Berkeley Symposium on Mathematical Statistics and Probability},
+  volume    = {1},
+  pages     = {281--297},
+  year      = {1967},
+  publisher = {University of California Press}
+}
+
+@article{beller2018,
+  author  = {Beller, Elaine and Clark, Justin and Tsafnat, Guy and Adams, Clive and
+             Diehl, Heinz and Lund, Hans and Ouzzani, Mourad and Thayer, Kristina and
+             Thomas, James and Turner, Tari and Xia, Jing and Robinson, Karen and Glasziou, Paul},
+  title   = {Making progress with the automation of systematic reviews: principles of the
+             {International Collaboration for the Automation of Systematic Reviews (ICASR)}},
+  journal = {Systematic Reviews},
+  volume  = {7},
+  number  = {77},
+  year    = {2018},
+  doi     = {10.1186/s13643-018-0740-7}
 }
 
 @article{gundersen2018state,
@@ -13,18 +50,6 @@
   volume  = {32},
   number  = {1},
   year    = {2018}
-}
-
-@article{pineau2021improving,
-  author  = {Pineau, Joelle and Vincent-Lamarre, Philippe and Sinha, Koustuv and
-             Lariviere, Vincent and Beygelzimer, Alina and d'Alche-Buc, Florence and
-             Fox, Emily and Larochelle, Hugo},
-  title   = {Improving Reproducibility in Machine Learning Research},
-  journal = {Journal of Machine Learning Research},
-  volume  = {22},
-  number  = {242},
-  pages   = {1--20},
-  year    = {2021}
 }
 
 @article{stodden2016enhancing,
@@ -40,73 +65,9 @@
   doi     = {10.1126/science.aah6168}
 }
 
-@article{gebru2021datasheets,
-  author  = {Gebru, Timnit and Morgenstern, Jamie and Vecchione, Briana and
-             Vaughan, Jennifer Wortman and Wallach, Hanna and Daume, Hal and Crawford, Kate},
-  title   = {Datasheets for Datasets},
-  journal = {Communications of the ACM},
-  volume  = {64},
-  number  = {12},
-  pages   = {86--92},
-  year    = {2021},
-  doi     = {10.1145/3458723}
-}
-
-@article{adadi2018peeking,
-  author  = {Adadi, Amina and Berrada, Mohammed},
-  title   = {Peeking Inside the Black-Box: A Survey on Explainable Artificial Intelligence (XAI)},
-  journal = {IEEE Access},
-  volume  = {6},
-  pages   = {52138--52160},
-  year    = {2018},
-  doi     = {10.1109/ACCESS.2018.2870052}
-}
-
-@article{wei2022chain,
-  author  = {Wei, Jason and Wang, Xuezhi and Schuurmans, Dale and Bosma, Maarten and
-             Ichter, Brian and Xia, Fei and Chi, Ed and Le, Quoc and Zhou, Denny},
-  title   = {Chain-of-Thought Prompting Elicits Reasoning in Large Language Models},
-  journal = {Advances in Neural Information Processing Systems},
-  volume  = {35},
-  pages   = {24824--24837},
-  year    = {2022}
-}
-
-@article{kung2023chatgpt,
-  author  = {Kung, Tiffany H. and Cheatham, Morgan and Medenilla, Ariel and Sillos, Czarina and
-             De Leon, Lorie and Elepano, Camille and Madriaga, Maria and Aggabao, Rimel and
-             Diaz-Candido, Gerdine and Maningo, James and Tseng, Victor},
-  title   = {Performance of ChatGPT on USMLE: Potential for AI-Assisted Medical Education
-             Using Large Language Models},
-  journal = {PLOS Digital Health},
-  volume  = {2},
-  number  = {2},
-  pages   = {e0000198},
-  year    = {2023},
-  doi     = {10.1371/journal.pdig.0000198}
-}
-
-@article{gao2023reproducibility,
-  author  = {Gao, Luyu and Biderman, Stella and Black, Sid and Golding, Laurence and Hoppe, Travis and
-             Foster, Charles and Phang, Jason and He, Horace and Thite, Anish and Nabeshima, Noa and
-             Presser, Shawn and Leahy, Connor},
-  title   = {The Pile: An 800GB Dataset of Diverse Text for Language Modeling},
-  journal = {arXiv preprint arXiv:2101.00027},
-  year    = {2023}
-}
-
-@article{perez2022ignore,
-  author  = {Perez, Fabio and Ribeiro, Ian},
-  title   = {Ignore Previous Prompt: Attack Techniques For Language Models},
-  journal = {arXiv preprint arXiv:2211.09527},
-  year    = {2022}
-}
-
-@article{greshake2023not,
-  author  = {Greshake, Kai and Abdelnabi, Sahar and Mishra, Shailesh and Endres, Christoph and
-             Holz, Thorsten and Fritz, Mario},
-  title   = {Not What You've Signed Up For: Compromising Real-World LLM-Integrated Applications
-             with Indirect Prompt Injection},
-  journal = {arXiv preprint arXiv:2302.12173},
-  year    = {2023}
+@misc{pytest2024,
+  author       = {{pytest development team}},
+  title        = {pytest: helps you write better programs},
+  year         = {2024},
+  howpublished = {\url{https://pytest.org}}
 }

--- a/paper.md
+++ b/paper.md
@@ -1,5 +1,5 @@
 ---
-title: 'litcluster: Topic modelling and semantic clustering of scientific literature from BibTeX or DOI lists'
+title: 'litcluster: Topic-based clustering of scientific literature using TF-IDF and k-means'
 tags:
   - Python
   - NLP
@@ -7,6 +7,7 @@ tags:
   - clustering
   - literature-review
   - bibliometrics
+  - systematic-review
 authors:
   - name: Vaibhav Deshmukh
     orcid: 0000-0001-6745-7062
@@ -20,14 +21,87 @@ bibliography: paper.bib
 
 # Summary
 
-`litcluster` is a Python tool for semantic clustering and topic modelling of scientific literature. Given a BibTeX file, a list of DOIs, or a directory of PDF abstracts, `litcluster` fetches or extracts abstract text, embeds papers using pre-trained sentence transformers, applies dimensionality reduction (UMAP), and clusters the resulting embedding space (HDBSCAN). It outputs an interactive HTML visualisation of the literature landscape and a Markdown summary table labelling each cluster with automatically extracted topic keywords. `litcluster` is designed for researchers beginning a new domain survey or tracking how a field has evolved over time.
+`litcluster` is a lightweight Python tool for automated topic clustering of
+scientific literature.  Given a BibTeX file, a CSV, or a JSONL collection of
+paper metadata, `litcluster` tokenises title, abstract, and keyword text;
+builds sparse TF-IDF vectors [@salton1988]; and partitions papers into
+thematic groups using Lloyd's k-means algorithm [@lloyd1982] with cosine
+similarity.  For each cluster, the tool extracts the top discriminative terms
+by aggregate TF-IDF score, producing interpretable cluster labels without
+manual annotation.  Results can be exported as structured CSV or JSON and
+inspected interactively through a built-in graphical interface.
+
+`litcluster` requires only the Python standard library (Python >= 3.8) and
+introduces no external dependencies.  It is reproducible by design: the k-means
+initialisation is seeded so that repeated runs on the same input always return
+the same partition.
 
 # Statement of Need
 
-Systematic and scoping reviews require researchers to organise large collections of papers into thematic groups — a task typically done manually or with expensive proprietary tools. `litcluster` automates this using modern sentence embeddings and density-based clustering, requiring only a BibTeX file as input. Unlike keyword-based approaches, semantic clustering groups papers by meaning rather than surface vocabulary, surfacing connections that term-based methods miss [@wei2022chain]. The interactive output helps researchers quickly identify core topics, niche sub-areas, and potential gaps in a literature collection, accelerating the early stages of a systematic review.
+Systematic and scoping reviews require researchers to organise large collections
+of papers into thematic groups — a task typically done manually or with
+proprietary commercial tools [@beller2018].  Automated approaches that depend on
+large pre-trained language models impose significant computational costs and
+introduce versioning complexity, making them impractical for researchers without
+access to GPU hardware or stable internet connectivity.
+
+`litcluster` addresses this gap by providing a zero-dependency, reproducible,
+and computationally inexpensive baseline for literature triage.  TF-IDF
+vectorisation [@salton1988] captures term-frequency patterns that correlate
+strongly with topical similarity, and cosine-based k-means produces compact,
+well-separated clusters for collections of dozens to several hundred papers
+[@macqueen1967].  The `min_term_freq` parameter filters rare terms that often
+reflect typographical variation rather than genuine topics, improving cluster
+coherence.  The seeded initialisation and deterministic tokenisation pipeline
+ensure that results can be fully reproduced from the same input file
+[@gundersen2018state; @stodden2016enhancing].
+
+The tool is aimed at researchers who need a quick, auditable first-pass
+organisation of a literature search result — for example, to identify core
+topic areas before undertaking manual full-text screening — and who prefer a
+tool they can inspect and modify rather than a black-box web service.
+
+# Implementation
+
+`litcluster` is implemented as a single Python module (`litcluster.py`) with no
+third-party dependencies.  The public API consists of three classes — `Paper`,
+`Cluster`, and `LitCluster` — and four pure functions (`_tokenise`, `_tfidf`,
+`_cosine`, `_kmeans`) that are independently testable and reusable.
+
+The processing pipeline is as follows:
+
+1. **Ingestion.**  `LitCluster.from_bibtex()`, `from_csv()`, and `from_jsonl()`
+   parse input files into a list of `Paper` dataclass instances.  The BibTeX
+   parser handles nested braces and multi-line field values.
+2. **Tokenisation.**  `_tokenise()` lower-cases input text, extracts alphabetic
+   tokens of length >= 3, and removes a curated English stopword list.
+3. **Vocabulary filtering.**  Terms appearing in fewer than `min_term_freq`
+   documents are removed before vectorisation.
+4. **TF-IDF vectorisation.**  `_tfidf()` computes smoothed TF-IDF weights
+   (`idf(t) = log((N+1)/(df(t)+1)) + 1`) and returns sparse vectors as Python
+   dicts, avoiding the memory overhead of dense matrices for large vocabularies.
+5. **Clustering.**  `_kmeans()` implements Lloyd's algorithm [@lloyd1982] with
+   random-seed initialisation; empty clusters are re-seeded to a random document
+   rather than left empty.
+6. **Labelling.**  For each cluster, the top-10 terms by summed TF-IDF score
+   across member documents are returned as the cluster label.
+
+A graphical user interface built with Python's built-in `tkinter` library
+(`litcluster_gui.py`) provides file-browser, parameter controls, a hierarchical
+cluster/paper tree view, a detail panel, and one-click CSV/JSON export — all
+without additional installation steps.
+
+# Testing
+
+The test suite (`tests/test_litcluster.py`) covers all four core functions and
+the three I/O loaders with 62 unit and integration tests using `pytest`
+[@pytest2024].  Tests include edge cases such as empty input, single-document
+collections, deeply nested BibTeX braces, and round-trip export verification.
 
 # Acknowledgements
 
-The author used Claude (Anthropic) for drafting portions of this manuscript. All scientific claims and design decisions are the author's own.
+The author used Claude (Anthropic) for drafting portions of this manuscript and
+for code assistance.  All scientific claims and design decisions are the
+author's own.
 
 # References

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 license = {file = "LICENSE"}
 authors = [{name = "Vaibhav Deshmukh", email = "vdeshmukh203@gmail.com"}]
 requires-python = ">=3.8"
-keywords = ["literature", "clustering", "bibtex", "topic-modelling", "tfidf", "research"]
+keywords = ["literature", "clustering", "bibtex", "topic-modelling", "tfidf", "research", "systematic-review"]
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Science/Research",
@@ -22,6 +22,10 @@ classifiers = [
 
 [project.scripts]
 litcluster = "litcluster:_cli"
+litcluster-gui = "litcluster_gui:main"
+
+[project.optional-dependencies]
+dev = ["pytest>=7"]
 
 [tool.setuptools]
-py-modules = ["litcluster"]
+py-modules = ["litcluster", "litcluster_gui"]

--- a/src/litcluster/__init__.py
+++ b/src/litcluster/__init__.py
@@ -1,18 +1,22 @@
 """
-litcluster: Semantic clustering and topic modelling of scientific literature.
+litcluster: Topic-based clustering of scientific literature using TF-IDF and k-means.
 
-Ingests collections of scientific abstracts or full papers (via DOI lists,
-BibTeX files, or arXiv IDs), embeds them using sentence-transformers, and
-applies hierarchical clustering and topic modelling to produce interactive
-visualisations and structured cluster summaries for systematic literature
-reviews.
+Zero external dependencies — pure Python standard library.
 """
 
 __version__ = "0.1.0"
 __author__ = "Vaibhav Deshmukh"
 __license__ = "MIT"
 
-from .cluster import LitCluster
-from .embed import PaperEmbedder
+# Re-export public API from the single-module implementation.
+from litcluster import (  # noqa: F401
+    LitCluster,
+    Paper,
+    Cluster,
+    _tokenise,
+    _tfidf,
+    _cosine,
+    _kmeans,
+)
 
-__all__ = ["LitCluster", "PaperEmbedder"]
+__all__ = ["LitCluster", "Paper", "Cluster", "_tokenise", "_tfidf", "_cosine", "_kmeans"]

--- a/tests/test_litcluster.py
+++ b/tests/test_litcluster.py
@@ -1,19 +1,501 @@
-import sys, pathlib
+"""
+Tests for litcluster.
+
+Covers: tokenisation, TF-IDF, cosine similarity, k-means, Paper/Cluster
+dataclasses, LitCluster.fit(), all three loaders, and both export formats.
+"""
+
+import csv
+import json
+import sys
+import pathlib
+
+import pytest
+
 sys.path.insert(0, str(pathlib.Path(__file__).parent.parent))
 
-def test_import():
-    import litcluster as lc
-    assert hasattr(lc, 'LitCluster')
+import litcluster as lc
+from litcluster import (
+    LitCluster, Paper, Cluster,
+    _tokenise, _tfidf, _cosine, _kmeans,
+)
 
-def test_paper():
-    import litcluster as lc
-    assert hasattr(lc, 'Paper')
 
-def test_cluster():
-    import litcluster as lc
-    assert hasattr(lc, 'Cluster')
+# ---------------------------------------------------------------------------
+# Public API surface
+# ---------------------------------------------------------------------------
 
-def test_tokenise():
-    import litcluster as lc
-    tokens = lc._tokenise('hello world test foo bar')
-    assert isinstance(tokens, list) and len(tokens) > 0
+def test_module_exports_litcluster():
+    assert hasattr(lc, "LitCluster")
+
+def test_module_exports_paper():
+    assert hasattr(lc, "Paper")
+
+def test_module_exports_cluster():
+    assert hasattr(lc, "Cluster")
+
+def test_module_exports_helpers():
+    for name in ("_tokenise", "_tfidf", "_cosine", "_kmeans"):
+        assert hasattr(lc, name), f"missing: {name}"
+
+
+# ---------------------------------------------------------------------------
+# _tokenise
+# ---------------------------------------------------------------------------
+
+def test_tokenise_basic():
+    tokens = _tokenise("deep learning neural network")
+    assert "deep" in tokens
+    assert "learning" in tokens
+    assert "neural" in tokens
+    assert "network" in tokens
+
+def test_tokenise_removes_stopwords():
+    tokens = _tokenise("the quick brown fox")
+    assert "the" not in tokens
+
+def test_tokenise_min_length_three():
+    # 1-2 char words are dropped
+    tokens = _tokenise("a an in go")
+    assert tokens == []
+
+def test_tokenise_lowercases():
+    tokens = _tokenise("NEURAL Networks")
+    assert "neural" in tokens
+    assert "networks" in tokens
+    assert "NEURAL" not in tokens
+
+def test_tokenise_empty_string():
+    assert _tokenise("") == []
+
+def test_tokenise_numbers_excluded():
+    tokens = _tokenise("2024 version three four")
+    assert "2024" not in tokens
+    assert "three" in tokens
+
+def test_tokenise_punctuation_stripped():
+    tokens = _tokenise("deep-learning, NLP! text.")
+    assert "deep" in tokens
+    assert "learning" in tokens
+    assert "nlp" in tokens
+    assert "text" in tokens
+
+
+# ---------------------------------------------------------------------------
+# _tfidf
+# ---------------------------------------------------------------------------
+
+def test_tfidf_shape():
+    docs = [["neural", "network"], ["climate", "change"]]
+    vecs, vocab = _tfidf(docs)
+    assert len(vecs) == 2
+    assert len(vocab) > 0
+
+def test_tfidf_empty_input():
+    vecs, vocab = _tfidf([])
+    assert vecs == []
+    assert vocab == []
+
+def test_tfidf_single_doc():
+    vecs, vocab = _tfidf([["neural", "network"]])
+    assert len(vecs) == 1
+    assert "neural" in vecs[0]
+
+def test_tfidf_rare_term_higher_idf():
+    # "rare" appears in 1 doc, "common" appears in all 3
+    docs = [
+        ["rare", "common"],
+        ["common", "topic"],
+        ["common", "word"],
+    ]
+    vecs, _ = _tfidf(docs)
+    assert vecs[0]["rare"] > vecs[0]["common"]
+
+def test_tfidf_vocab_sorted():
+    docs = [["zebra", "apple", "mango"]]
+    _, vocab = _tfidf(docs)
+    assert vocab == sorted(vocab)
+
+def test_tfidf_empty_document_in_list():
+    # An empty document should yield an empty vector without crashing
+    docs = [["neural"], [], ["gene"]]
+    vecs, vocab = _tfidf(docs)
+    assert len(vecs) == 3
+    assert vecs[1] == {}
+
+
+# ---------------------------------------------------------------------------
+# _cosine
+# ---------------------------------------------------------------------------
+
+def test_cosine_identical_vectors():
+    v = {"a": 1.0, "b": 2.0}
+    assert abs(_cosine(v, v) - 1.0) < 1e-9
+
+def test_cosine_orthogonal_vectors():
+    assert _cosine({"a": 1.0}, {"b": 1.0}) == 0.0
+
+def test_cosine_empty_vector():
+    assert _cosine({}, {"a": 1.0}) == 0.0
+    assert _cosine({"a": 1.0}, {}) == 0.0
+    assert _cosine({}, {}) == 0.0
+
+def test_cosine_symmetry():
+    a = {"x": 1.0, "y": 2.0}
+    b = {"x": 3.0, "z": 1.0}
+    assert abs(_cosine(a, b) - _cosine(b, a)) < 1e-9
+
+def test_cosine_range():
+    a = {"x": 1.0, "y": 0.5}
+    b = {"x": 0.3, "y": 1.0, "z": 0.2}
+    sim = _cosine(a, b)
+    assert 0.0 <= sim <= 1.0
+
+
+# ---------------------------------------------------------------------------
+# _kmeans
+# ---------------------------------------------------------------------------
+
+def test_kmeans_returns_correct_length():
+    vecs = [{"a": 1.0}, {"b": 1.0}, {"c": 1.0}]
+    labels = _kmeans(vecs, k=2)
+    assert len(labels) == 3
+
+def test_kmeans_labels_are_integers():
+    vecs = [{"a": 1.0}, {"b": 1.0}]
+    labels = _kmeans(vecs, k=2)
+    assert all(isinstance(l, int) for l in labels)
+
+def test_kmeans_empty_input():
+    assert _kmeans([], k=3) == []
+
+def test_kmeans_k_capped_at_n():
+    vecs = [{"a": 1.0}, {"b": 1.0}]
+    labels = _kmeans(vecs, k=100)
+    assert len(labels) == 2
+
+def test_kmeans_single_cluster():
+    vecs = [{"a": 1.0}, {"a": 0.9, "b": 0.1}]
+    labels = _kmeans(vecs, k=1)
+    assert all(l == 0 for l in labels)
+
+def test_kmeans_reproducible_with_seed():
+    vecs = [{"a": float(i), "b": float(i % 3)} for i in range(10)]
+    l1 = _kmeans(vecs, k=3, seed=7)
+    l2 = _kmeans(vecs, k=3, seed=7)
+    assert l1 == l2
+
+def test_kmeans_different_seeds_may_differ():
+    vecs = [{"a": float(i)} for i in range(20)]
+    l1 = _kmeans(vecs, k=4, seed=1)
+    l2 = _kmeans(vecs, k=4, seed=99)
+    # Not guaranteed to differ, but with very different seeds they often do.
+    # Just check both are valid.
+    assert len(l1) == len(l2) == 20
+
+
+# ---------------------------------------------------------------------------
+# Paper
+# ---------------------------------------------------------------------------
+
+def test_paper_text_combines_fields():
+    p = Paper("1", "Deep Learning", abstract="Neural networks", keywords="AI ML")
+    assert "Deep Learning" in p.text
+    assert "Neural networks" in p.text
+    assert "AI ML" in p.text
+
+def test_paper_to_dict_keys():
+    p = Paper("42", "Title", abstract="Abs", authors="Alice", year="2024")
+    d = p.to_dict()
+    for key in ("paper_id", "title", "abstract", "authors", "year", "venue", "doi", "keywords"):
+        assert key in d
+
+def test_paper_to_dict_values():
+    p = Paper("42", "Title", abstract="Abs", year="2024")
+    d = p.to_dict()
+    assert d["paper_id"] == "42"
+    assert d["title"] == "Title"
+    assert d["abstract"] == "Abs"
+    assert d["year"] == "2024"
+
+def test_paper_defaults():
+    p = Paper("1", "Title")
+    assert p.abstract == ""
+    assert p.doi == ""
+
+
+# ---------------------------------------------------------------------------
+# Cluster
+# ---------------------------------------------------------------------------
+
+def test_cluster_label_includes_terms():
+    c = Cluster(0, papers=[], top_terms=["neural", "network", "deep"])
+    assert "neural" in c.label
+    assert "network" in c.label
+
+def test_cluster_label_empty_terms():
+    c = Cluster(1, papers=[], top_terms=[])
+    assert "Cluster 1" in c.label
+
+def test_cluster_to_dict_structure():
+    p = Paper("1", "T1", abstract="abstract one")
+    c = Cluster(0, papers=[p], top_terms=["neural"])
+    d = c.to_dict()
+    assert d["cluster_id"] == 0
+    assert d["size"] == 1
+    assert len(d["papers"]) == 1
+    assert d["top_terms"] == ["neural"]
+
+def test_cluster_size_reflects_papers():
+    papers = [Paper(str(i), f"Paper {i}") for i in range(5)]
+    c = Cluster(0, papers=papers)
+    assert c.to_dict()["size"] == 5
+
+
+# ---------------------------------------------------------------------------
+# LitCluster.fit()
+# ---------------------------------------------------------------------------
+
+def _make_lc(n: int = 12, k: int = 3) -> LitCluster:
+    """Helper: create a fitted LitCluster with synthetic multi-topic data."""
+    topics = [
+        ("deep learning neural network training",
+         "deep neural network training epochs gradient"),
+        ("climate change temperature greenhouse emissions",
+         "carbon emissions global warming temperature rise"),
+        ("gene expression protein sequence genome",
+         "genomics sequencing DNA protein analysis biology"),
+    ]
+    obj = LitCluster(k=k, min_term_freq=1, seed=0)
+    for i in range(n):
+        title, abstract = topics[i % len(topics)]
+        obj.papers.append(Paper(str(i), f"Paper {i}", abstract=abstract))
+    obj.fit()
+    return obj
+
+
+def test_fit_returns_self():
+    obj = LitCluster(k=2, min_term_freq=1)
+    obj.papers.append(Paper("1", "ML", abstract="neural network"))
+    obj.papers.append(Paper("2", "Bio", abstract="gene protein"))
+    assert obj.fit() is obj
+
+def test_fit_creates_clusters():
+    obj = _make_lc()
+    assert len(obj.clusters) > 0
+
+def test_fit_all_papers_assigned():
+    n = 12
+    obj = _make_lc(n=n)
+    total = sum(len(c.papers) for c in obj.clusters)
+    assert total == n
+
+def test_fit_no_papers():
+    obj = LitCluster().fit()
+    assert obj.clusters == []
+
+def test_fit_single_paper():
+    obj = LitCluster(k=3, min_term_freq=1)
+    obj.papers.append(Paper("1", "Only paper", abstract="deep learning"))
+    obj.fit()
+    assert len(obj.clusters) == 1
+
+def test_fit_top_terms_nonempty():
+    obj = _make_lc()
+    for c in obj.clusters:
+        assert len(c.top_terms) > 0
+
+def test_summary_contains_paper_count():
+    obj = _make_lc()
+    s = obj.summary()
+    assert "12" in s
+
+def test_summary_contains_cluster_count():
+    obj = _make_lc(k=3)
+    s = obj.summary()
+    assert "cluster" in s.lower()
+
+
+# ---------------------------------------------------------------------------
+# LitCluster.from_csv
+# ---------------------------------------------------------------------------
+
+def test_from_csv_basic(tmp_path):
+    f = tmp_path / "data.csv"
+    f.write_text(
+        "paper_id,title,abstract\n"
+        "1,Deep Learning,neural network training\n"
+        "2,Climate Science,global warming temperature\n",
+        encoding="utf-8",
+    )
+    obj = LitCluster.from_csv(f)
+    assert len(obj.papers) == 2
+    assert obj.papers[0].title == "Deep Learning"
+    assert obj.papers[1].abstract == "global warming temperature"
+
+def test_from_csv_missing_optional_columns(tmp_path):
+    f = tmp_path / "minimal.csv"
+    f.write_text("title\nOnly Title\n", encoding="utf-8")
+    obj = LitCluster.from_csv(f)
+    assert len(obj.papers) == 1
+    assert obj.papers[0].doi == ""
+
+def test_from_csv_kwargs_passed(tmp_path):
+    f = tmp_path / "data.csv"
+    f.write_text("title\nPaper A\nPaper B\n", encoding="utf-8")
+    obj = LitCluster.from_csv(f, k=7, seed=123)
+    assert obj.k == 7
+    assert obj.seed == 123
+
+
+# ---------------------------------------------------------------------------
+# LitCluster.from_jsonl
+# ---------------------------------------------------------------------------
+
+def test_from_jsonl_basic(tmp_path):
+    f = tmp_path / "data.jsonl"
+    f.write_text(
+        '{"paper_id":"1","title":"DL","abstract":"neural"}\n'
+        '{"paper_id":"2","title":"Bio","abstract":"gene protein"}\n',
+        encoding="utf-8",
+    )
+    obj = LitCluster.from_jsonl(f)
+    assert len(obj.papers) == 2
+    assert obj.papers[0].title == "DL"
+
+def test_from_jsonl_skips_blank_lines(tmp_path):
+    f = tmp_path / "data.jsonl"
+    f.write_text(
+        '{"title":"A"}\n\n{"title":"B"}\n',
+        encoding="utf-8",
+    )
+    obj = LitCluster.from_jsonl(f)
+    assert len(obj.papers) == 2
+
+
+# ---------------------------------------------------------------------------
+# LitCluster.from_bibtex
+# ---------------------------------------------------------------------------
+
+_BIBTEX_SAMPLE = """\
+@article{smith2020,
+  title     = {Deep Learning Advances},
+  abstract  = {We study neural networks and training methods.},
+  author    = {Smith, Alice and Jones, Bob},
+  year      = {2020},
+  journal   = {Nature},
+  doi       = {10.1000/xyz123},
+  keywords  = {deep learning, neural networks},
+}
+
+@inproceedings{doe2021,
+  title    = {Climate Modelling},
+  abstract = {Temperature change and greenhouse gas emissions.},
+  author   = {Doe, John},
+  year     = {2021},
+  booktitle = {Proceedings of ICCS},
+}
+"""
+
+def test_from_bibtex_basic(tmp_path):
+    bib = tmp_path / "refs.bib"
+    bib.write_text(_BIBTEX_SAMPLE, encoding="utf-8")
+    obj = LitCluster.from_bibtex(bib)
+    assert len(obj.papers) >= 2
+
+def test_from_bibtex_title_parsed(tmp_path):
+    bib = tmp_path / "refs.bib"
+    bib.write_text(_BIBTEX_SAMPLE, encoding="utf-8")
+    obj = LitCluster.from_bibtex(bib)
+    titles = [p.title for p in obj.papers]
+    assert "Deep Learning Advances" in titles
+
+def test_from_bibtex_abstract_parsed(tmp_path):
+    bib = tmp_path / "refs.bib"
+    bib.write_text(_BIBTEX_SAMPLE, encoding="utf-8")
+    obj = LitCluster.from_bibtex(bib)
+    abstracts = [p.abstract for p in obj.papers]
+    assert any("neural networks" in a for a in abstracts)
+
+def test_from_bibtex_year_parsed(tmp_path):
+    bib = tmp_path / "refs.bib"
+    bib.write_text(_BIBTEX_SAMPLE, encoding="utf-8")
+    obj = LitCluster.from_bibtex(bib)
+    years = {p.year for p in obj.papers}
+    assert "2020" in years or "2021" in years
+
+def test_from_bibtex_venue_journal(tmp_path):
+    bib = tmp_path / "refs.bib"
+    bib.write_text(_BIBTEX_SAMPLE, encoding="utf-8")
+    obj = LitCluster.from_bibtex(bib)
+    venues = [p.venue for p in obj.papers]
+    assert any("Nature" in v for v in venues)
+
+def test_from_bibtex_nested_braces(tmp_path):
+    bib = tmp_path / "nested.bib"
+    bib.write_text(
+        "@article{test1,\n"
+        "  title = {A {Nested} Title},\n"
+        "  abstract = {Contains {nested} and {more} braces.},\n"
+        "  year = {2022},\n"
+        "}\n",
+        encoding="utf-8",
+    )
+    obj = LitCluster.from_bibtex(bib)
+    assert len(obj.papers) >= 1
+    assert "Nested" in obj.papers[0].title
+
+def test_from_bibtex_empty_file(tmp_path):
+    bib = tmp_path / "empty.bib"
+    bib.write_text("", encoding="utf-8")
+    obj = LitCluster.from_bibtex(bib)
+    assert obj.papers == []
+
+
+# ---------------------------------------------------------------------------
+# Export
+# ---------------------------------------------------------------------------
+
+def test_export_csv_header(tmp_path):
+    obj = _make_lc()
+    out = tmp_path / "out.csv"
+    obj.export_csv(out)
+    with out.open(encoding="utf-8") as fh:
+        header = next(csv.reader(fh))
+    assert "cluster_id" in header
+    assert "title" in header
+
+def test_export_csv_row_count(tmp_path):
+    obj = _make_lc(n=12)
+    out = tmp_path / "out.csv"
+    obj.export_csv(out)
+    with out.open(encoding="utf-8") as fh:
+        rows = list(csv.reader(fh))
+    # header + 12 data rows
+    assert len(rows) == 13
+
+def test_export_json_is_list(tmp_path):
+    obj = _make_lc()
+    out = tmp_path / "out.json"
+    obj.export_json(out)
+    data = json.loads(out.read_text(encoding="utf-8"))
+    assert isinstance(data, list)
+    assert len(data) > 0
+
+def test_export_json_cluster_structure(tmp_path):
+    obj = _make_lc()
+    out = tmp_path / "out.json"
+    obj.export_json(out)
+    data = json.loads(out.read_text(encoding="utf-8"))
+    for cluster in data:
+        assert "cluster_id" in cluster
+        assert "papers" in cluster
+        assert "top_terms" in cluster
+
+def test_export_json_roundtrip(tmp_path):
+    obj = _make_lc(n=6, k=2)
+    out = tmp_path / "out.json"
+    obj.export_json(out)
+    data = json.loads(out.read_text(encoding="utf-8"))
+    total = sum(c["size"] for c in data)
+    assert total == 6


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Bug fixes** in `litcluster.py`: rewritten BibTeX parser with proper nested-brace handling (the previous regex silently truncated abstracts containing commas or closing braces); fixed variable shadowing (`l` → `lbl`) in `_kmeans`; early return in `_cosine` for empty vectors; cleaner centroid-update loop
- **JOSS-quality refinements**: added `__all__`, `__version__`, full docstrings and type hints throughout, `_cli` alias so the `pyproject.toml` entry point resolves correctly, `--gui` / `--version` CLI flags
- **New GUI** (`litcluster_gui.py`): full tkinter application (stdlib — zero extra deps) with file browser, parameter spinboxes, a hierarchical cluster/paper tree view, a detail panel showing per-cluster or per-paper metadata, and one-click CSV/JSON export
- **Fixed `src/litcluster/__init__.py`**: replaced broken `.cluster`/`.embed` imports (those modules never existed) with correct re-exports from the root module
- **`pyproject.toml`**: fixed CLI entry point, added `litcluster-gui` script, added `[dev]` extras
- **62-test suite** (up from 4): covers every public function and all three loaders, including edge cases (empty input, nested BibTeX braces, missing CSV columns, round-trip export)
- **Full `README.md`** with installation, quick-start examples for CLI/GUI/API, parameter table, and algorithm description
- **`paper.md` / `paper.bib` rewrite**: paper now accurately describes TF-IDF + k-means (not UMAP/HDBSCAN/sentence-transformers); added proper JOSS-required sections (Implementation, Testing); replaced unrelated AI references with canonical citations for Salton & Buckley (TF-IDF), Lloyd (k-means), MacQueen, Beller et al. (systematic review automation), and reproducibility papers

## Test plan

- [ ] `pytest tests/ -v` — all 62 tests pass
- [ ] `python litcluster.py --version` — prints `litcluster 0.1.0`
- [ ] `python litcluster.py --help` — shows `--gui` flag
- [ ] `python litcluster_gui.py` — GUI opens (requires display)
- [ ] Load a `.bib` file in the GUI, run clustering, inspect tree, export CSV and JSON

https://claude.ai/code/session_01Ge3Ui93uRAXT7e2d4aMSYW
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ge3Ui93uRAXT7e2d4aMSYW)_