### PR TITLE
feat: debug, JOSS-level refinement, and desktop GUI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,36 @@
+# Byte-compiled / optimised / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# Distribution / packaging
+dist/
+build/
+*.egg-info/
+*.egg
+.eggs/
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Virtual environments
+.venv/
+venv/
+env/
+
+# pytest cache
+.pytest_cache/
+.cache/
+
+# Editor / OS artefacts
+.DS_Store
+Thumbs.db
+*.swp
+*.swo
+.idea/
+.vscode/
+
+# Exported results (generated files)
+*.clusters.csv
+*.clusters.json

--- a/README.md
+++ b/README.md
@@ -1,1 +1,128 @@
 # litcluster
+
+[![CI](https://github.com/vdeshmukh203/litcluster/actions/workflows/ci.yml/badge.svg)](https://github.com/vdeshmukh203/litcluster/actions/workflows/ci.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+[![Python 3.8+](https://img.shields.io/badge/python-3.8%2B-blue.svg)](https://www.python.org/)
+
+**litcluster** clusters academic papers into thematic groups using TF-IDF
+vectorisation and k-means (Lloyd's algorithm).  It accepts BibTeX, CSV, or
+JSON Lines input and requires **no external dependencies** — only Python 3.8+.
+
+---
+
+## Installation
+
+```bash
+# From source (no pip install required — stdlib only)
+git clone https://github.com/vdeshmukh203/litcluster.git
+cd litcluster
+
+# Or install as a package for the `litcluster` CLI command:
+pip install .
+```
+
+## Quick start
+
+### Command line
+
+```bash
+# Cluster a BibTeX file into 8 groups and print a summary
+litcluster refs.bib -k 8
+
+# Export to JSON
+litcluster refs.bib -k 6 --format json -o clusters.json
+
+# Export to CSV
+litcluster papers.csv -k 5 --format csv -o assignments.csv
+
+# Use a CSV or JSON Lines file
+litcluster papers.jsonl -k 10 --seed 7
+```
+
+### GUI
+
+```bash
+python litcluster_gui.py
+# or, after pip install:
+litcluster-gui
+```
+
+The GUI lets you open a file, adjust parameters with spinboxes, inspect each
+cluster's papers interactively, and export results — no command line needed.
+
+### Python API
+
+```python
+from litcluster import LitCluster
+
+# Load from BibTeX
+lc = LitCluster.from_bibtex("refs.bib", k=6, seed=42)
+lc.fit()
+
+# Inspect results
+print(lc.summary())
+for cluster in lc.clusters:
+    print(cluster.label, "—", len(cluster.papers), "papers")
+
+# Export
+lc.export_csv("clusters.csv")
+lc.export_json("clusters.json")
+```
+
+## CLI reference
+
+```
+litcluster [-h] [-k K] [--format {csv,json,summary}]
+           [--output FILE] [--seed N] [--max-iter N]
+           [--min-freq N] [--version]
+           input
+```
+
+| Option | Default | Description |
+|---|---|---|
+| `input` | — | Input file: `.bib`, `.csv`, or `.jsonl` |
+| `-k`, `--clusters` | 5 | Number of clusters |
+| `--format` | `summary` | Output format: `summary`, `csv`, or `json` |
+| `-o`, `--output` | stdout / auto | Output file path |
+| `--seed` | 42 | Random seed for reproducibility |
+| `--max-iter` | 100 | Maximum k-means iterations |
+| `--min-freq` | 2 | Minimum document frequency for vocabulary terms |
+
+## Input formats
+
+| Format | File extension | Required columns/fields |
+|---|---|---|
+| BibTeX | `.bib` | Any `@article`/`@inproceedings` entries — `title`, `abstract`, `keywords` used |
+| CSV | `.csv` | `title`, `abstract` recommended; `paper_id`, `authors`, `year`, `venue`, `doi`, `keywords` optional |
+| JSON Lines | `.jsonl` | Same field names as CSV, one JSON object per line |
+
+## How it works
+
+1. **Tokenise** each paper's title + abstract + keywords (lowercase, alphabetic
+   tokens ≥ 3 chars, stopwords removed).
+2. **Filter** terms appearing in fewer than `--min-freq` documents.
+3. **TF-IDF** vectorise the corpus (smoothed IDF: `log((n+1)/(df+1)) + 1`).
+4. **k-means** cluster the sparse vectors using cosine similarity.
+5. **Label** each cluster with its top 10 TF-IDF terms.
+
+## Running tests
+
+```bash
+pip install pytest
+pytest tests/
+```
+
+## Citation
+
+If you use litcluster in academic work, please cite:
+
+```
+Deshmukh, V. (2026). litcluster: Topic-based clustering of scientific
+literature using TF-IDF and k-means. Journal of Open Source Software.
+```
+
+See `CITATION.cff` for machine-readable citation metadata.
+
+## Licence
+
+MIT — see [LICENSE](LICENSE).

--- a/litcluster.py
+++ b/litcluster.py
@@ -1,8 +1,25 @@
 #!/usr/bin/env python3
 """
-litcluster.py — Literature Clustering Tool
-Clusters academic papers by topic using TF-IDF + k-means (pure stdlib).
-Stdlib-only. No external dependencies.
+litcluster — Literature Clustering Tool
+========================================
+Cluster academic papers by topic using TF-IDF vectorisation and k-means
+(Lloyd's algorithm).  All functionality uses Python's standard library only —
+no third-party packages are required.
+
+Command-line usage::
+
+    litcluster papers.bib -k 8 --format json -o results.json
+    litcluster papers.csv -k 5
+    litcluster papers.jsonl --format csv -o clusters.csv
+
+Python API::
+
+    from litcluster import LitCluster
+
+    lc = LitCluster.from_bibtex("refs.bib", k=6)
+    lc.fit()
+    print(lc.summary())
+    lc.export_json("clusters.json")
 """
 
 from __future__ import annotations
@@ -17,76 +34,147 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
+__version__ = "0.1.0"
+__all__ = ["LitCluster", "Paper", "Cluster"]
+
 
 # ---------------------------------------------------------------------------
 # Text processing
 # ---------------------------------------------------------------------------
 
-_STOPWORDS = {
-    'a','an','the','and','or','but','in','on','at','to','for','of','with',
-    'by','from','is','was','are','were','be','been','being','have','has',
-    'had','do','does','did','will','would','could','should','may','might',
-    'this','that','these','those','it','its','we','our','they','their',
-    'as','if','not','no','nor','so','yet','both','either','whether',
-    'each','few','more','most','other','some','such','than','too','very',
-    'just','also','only','then','here','there','when','where','who','which',
-    'how','all','any','can','into','through','during','before','after',
-    'above','below','between','out','off','over','under','again','further',
-    'once','i','my','me','he','she','his','her','him','you','your',
-}
+# General-purpose stopwords plus common high-frequency academic/scientific
+# terms that appear across virtually all papers and carry no discriminating
+# information for clustering.
+_STOPWORDS: frozenset = frozenset({
+    # --- function words ---
+    "a", "an", "the", "and", "or", "but", "in", "on", "at", "to", "for",
+    "of", "with", "by", "from", "is", "was", "are", "were", "be", "been",
+    "being", "have", "has", "had", "do", "does", "did", "will", "would",
+    "could", "should", "may", "might", "this", "that", "these", "those",
+    "it", "its", "we", "our", "they", "their", "as", "if", "not", "no",
+    "nor", "so", "yet", "both", "either", "whether", "each", "few", "more",
+    "most", "other", "some", "such", "than", "too", "very", "just", "also",
+    "only", "then", "here", "there", "when", "where", "who", "which", "how",
+    "all", "any", "can", "into", "through", "during", "before", "after",
+    "above", "below", "between", "out", "off", "over", "under", "again",
+    "further", "once", "i", "my", "me", "he", "she", "his", "her", "him",
+    "you", "your", "while", "about", "against", "what", "one", "two",
+    "three", "four", "five", "first", "second", "third", "last", "among",
+    "within", "without", "per",
+    # --- ubiquitous academic verbs / nouns ---
+    "study", "studies", "research", "paper", "article", "work", "works",
+    "method", "methods", "approach", "approaches", "technique", "techniques",
+    "result", "results", "analysis", "analyses", "evaluation", "evaluations",
+    "performance", "experiment", "experiments", "experimental",
+    "show", "shows", "shown", "demonstrate", "demonstrates", "demonstrated",
+    "present", "presents", "presented", "propose", "proposes", "proposed",
+    "introduce", "introduces", "introduced", "describe", "describes",
+    "described", "develop", "develops", "developed", "use", "used", "using",
+    "provide", "provides", "provided", "based", "applied", "apply", "applies",
+    "investigate", "investigates", "investigated",
+    "compare", "compared", "comparison", "discuss", "discusses", "discussed",
+    "consider", "considered", "existing", "novel", "new", "recent", "current",
+    "previous", "prior", "several", "many", "large", "high", "low",
+    "significant", "significantly", "important", "general", "specific",
+    "different", "various", "however", "therefore", "thus", "hence",
+    "furthermore", "moreover", "although", "despite",
+    "conclusion", "conclusions", "conclude", "concluded",
+    "finding", "findings", "contribution", "contributions",
+    "able", "well", "good", "set", "number", "finally", "respectively",
+    "data", "dataset", "datasets", "model", "models", "task", "tasks",
+    "problem", "problems", "system", "systems", "framework", "frameworks",
+    "algorithm", "algorithms", "implementation", "implementations",
+    "test", "testing", "tested", "train", "training", "trained",
+    "evaluate", "evaluated", "report", "reports", "reported",
+    "aim", "aims", "goal", "goals", "objective", "objectives",
+    "table", "figure", "section", "appendix", "equation", "equations",
+    "respectively", "typically", "often", "usually", "commonly",
+    "known", "given", "possible", "following", "related", "used",
+})
 
 
 def _tokenise(text: str) -> List[str]:
+    """Return lowercase alphabetic tokens (≥ 3 chars) excluding stopwords.
+
+    Parameters
+    ----------
+    text:
+        Raw text to tokenise (title, abstract, keywords, etc.).
+
+    Returns
+    -------
+    list of str
+        Filtered token list ready for TF-IDF computation.
+    """
     tokens = re.findall(r"[a-zA-Z]{3,}", text.lower())
     return [t for t in tokens if t not in _STOPWORDS]
 
 
-def _tfidf(documents: List[List[str]]) -> Tuple[List[Dict[str,float]], List[str]]:
-    """Compute TF-IDF vectors. Returns (vectors, vocab)."""
+def _tfidf(
+    documents: List[List[str]],
+) -> Tuple[List[Dict[str, float]], List[str]]:
+    """Compute sparse TF-IDF vectors for a list of tokenised documents.
+
+    Uses smoothed IDF  ``log((n+1)/(df+1)) + 1``  (sklearn convention) to
+    prevent zero-division and to assign non-zero weight to every term.
+
+    Parameters
+    ----------
+    documents:
+        List of token lists, one per document.
+
+    Returns
+    -------
+    vectors:
+        List of sparse dicts ``{term: tfidf_score}`` — one per document.
+    vocab:
+        Sorted list of all terms in the corpus.
+    """
     n = len(documents)
     if n == 0:
         return [], []
 
-    # Build vocab
     vocab_set: set = set()
     for doc in documents:
         vocab_set.update(doc)
-    vocab = sorted(vocab_set)
-    term_idx = {t: i for i, t in enumerate(vocab)}
-    V = len(vocab)
+    vocab: List[str] = sorted(vocab_set)
+    term_idx: Dict[str, int] = {t: i for i, t in enumerate(vocab)}
 
-    # Document frequency
-    df = [0] * V
+    # Document frequency per term
+    df: List[int] = [0] * len(vocab)
     for doc in documents:
-        doc_set = set(doc)
-        for t in doc_set:
-            if t in term_idx:
-                df[term_idx[t]] += 1
+        for t in set(doc):
+            idx = term_idx.get(t)
+            if idx is not None:
+                df[idx] += 1
 
-    # TF-IDF
+    # Build sparse TF-IDF vectors
     vectors: List[Dict[str, float]] = []
     for doc in documents:
-        tf: Dict[int, int] = {}
+        raw_tf: Dict[int, int] = {}
         for t in doc:
-            if t in term_idx:
-                idx = term_idx[t]
-                tf[idx] = tf.get(idx, 0) + 1
+            idx = term_idx.get(t)
+            if idx is not None:
+                raw_tf[idx] = raw_tf.get(idx, 0) + 1
+        doc_len = max(len(doc), 1)
         vec: Dict[str, float] = {}
-        doc_len = len(doc) or 1
-        for idx, count in tf.items():
-            term = vocab[idx]
+        for idx, count in raw_tf.items():
             tf_val = count / doc_len
             idf_val = math.log((n + 1) / (df[idx] + 1)) + 1.0
-            vec[term] = tf_val * idf_val
+            vec[vocab[idx]] = tf_val * idf_val
         vectors.append(vec)
+
     return vectors, vocab
 
 
 def _cosine(a: Dict[str, float], b: Dict[str, float]) -> float:
-    dot = sum(a.get(t, 0.0) * b.get(t, 0.0) for t in b)
-    norm_a = math.sqrt(sum(v*v for v in a.values()))
-    norm_b = math.sqrt(sum(v*v for v in b.values()))
-    if norm_a == 0 or norm_b == 0:
+    """Cosine similarity between two sparse TF-IDF vectors."""
+    if not a or not b:
+        return 0.0
+    dot = sum(a.get(t, 0.0) * v for t, v in b.items())
+    norm_a = math.sqrt(sum(v * v for v in a.values()))
+    norm_b = math.sqrt(sum(v * v for v in b.values()))
+    if norm_a == 0.0 or norm_b == 0.0:
         return 0.0
     return dot / (norm_a * norm_b)
 
@@ -97,44 +185,128 @@ def _kmeans(
     max_iter: int = 100,
     seed: int = 42,
 ) -> List[int]:
-    """Lloyd's k-means on sparse TF-IDF vectors."""
+    """Lloyd's k-means over sparse TF-IDF vectors using cosine similarity.
+
+    Centroids are initialised by random sampling without replacement (seeded
+    for reproducibility).  Empty clusters are reinitialised to a random
+    member vector rather than being left degenerate.
+
+    Parameters
+    ----------
+    vectors:
+        Sparse document vectors as returned by :func:`_tfidf`.
+    k:
+        Number of clusters.  Clamped to ``len(vectors)`` if larger.
+    max_iter:
+        Maximum number of Lloyd iterations.
+    seed:
+        RNG seed for centroid initialisation.
+
+    Returns
+    -------
+    list of int
+        Cluster label (0 … k-1) for each input vector.
+    """
+    import random
+
     n = len(vectors)
     if n == 0:
         return []
     k = min(k, n)
 
-    # Seeded centroid initialisation (evenly spaced)
-    import random
     rng = random.Random(seed)
     centroid_indices = rng.sample(range(n), k)
-    centroids = [dict(vectors[i]) for i in centroid_indices]
-    labels = [0] * n
+    centroids: List[Dict[str, float]] = [dict(vectors[i]) for i in centroid_indices]
+
+    # Initialise labels to a sentinel that never matches a real assignment so
+    # the first-iteration convergence check is never a false positive.
+    labels: List[int] = [-1] * n
 
     for _ in range(max_iter):
-        # Assignment
-        new_labels = []
-        for vec in vectors:
-            best = max(range(k), key=lambda c: _cosine(vec, centroids[c]))
-            new_labels.append(best)
-
+        new_labels = [
+            max(range(k), key=lambda c: _cosine(vec, centroids[c]))
+            for vec in vectors
+        ]
         if new_labels == labels:
             break
         labels = new_labels
 
-        # Update centroids
+        # Update centroids as mean of member vectors
         for c in range(k):
-            members = [vectors[i] for i, l in enumerate(labels) if l == c]
+            members = [vectors[i] for i, lbl in enumerate(labels) if lbl == c]
             if not members:
-                centroids[c] = dict(vectors[rng.randint(0, n-1)])
+                centroids[c] = dict(vectors[rng.randint(0, n - 1)])
                 continue
             new_centroid: Dict[str, float] = {}
             for vec in members:
                 for t, v in vec.items():
                     new_centroid[t] = new_centroid.get(t, 0.0) + v
             total = len(members)
-            centroids[c] = {t: v/total for t, v in new_centroid.items()}
+            centroids[c] = {t: v / total for t, v in new_centroid.items()}
 
     return labels
+
+
+# ---------------------------------------------------------------------------
+# BibTeX field extraction
+# ---------------------------------------------------------------------------
+
+def _bibtex_field(entry: str, field: str) -> str:
+    """Extract a named field value from a single BibTeX entry string.
+
+    Handles the three legal BibTeX value syntaxes:
+
+    * Brace-delimited  ``field = {value}``  — supports nested braces.
+    * Quote-delimited  ``field = "value"``  — stops at the first unescaped
+      closing double-quote.
+    * Bare (numeric)   ``field = 2024``     — captured up to whitespace/comma.
+
+    Parameters
+    ----------
+    entry:
+        Raw text of a single ``@type{key, …}`` BibTeX entry.
+    field:
+        Field name to extract (case-insensitive).
+
+    Returns
+    -------
+    str
+        Extracted value, stripped of leading/trailing whitespace, or ``""``
+        if the field is absent.
+    """
+    pattern = re.compile(rf'\b{re.escape(field)}\s*=\s*', re.IGNORECASE)
+    m = pattern.search(entry)
+    if not m:
+        return ""
+    pos = m.end()
+    while pos < len(entry) and entry[pos] == " ":
+        pos += 1
+    if pos >= len(entry):
+        return ""
+
+    c = entry[pos]
+    if c == "{":
+        # Brace-balanced extraction — handles nested LaTeX markup.
+        depth = 0
+        start = pos + 1
+        i = pos
+        while i < len(entry):
+            if entry[i] == "{":
+                depth += 1
+            elif entry[i] == "}":
+                depth -= 1
+                if depth == 0:
+                    return entry[start:i].strip()
+            i += 1
+        return entry[start:].strip()
+    elif c == '"':
+        end = entry.find('"', pos + 1)
+        if end == -1:
+            return entry[pos + 1:].strip()
+        return entry[pos + 1:end].strip()
+    else:
+        m2 = re.match(r'([^\s,}\n]+)', entry[pos:])
+        return m2.group(1) if m2 else ""
 
 
 # ---------------------------------------------------------------------------
@@ -143,6 +315,28 @@ def _kmeans(
 
 @dataclass
 class Paper:
+    """Lightweight representation of a single academic paper.
+
+    Attributes
+    ----------
+    paper_id:
+        Unique identifier (BibTeX cite key, row index, etc.).
+    title:
+        Paper title.
+    abstract:
+        Full abstract text.
+    authors:
+        Author list (free-form string, e.g. ``"Smith, J. and Doe, A."``).
+    year:
+        Publication year as a string.
+    venue:
+        Journal or conference name.
+    doi:
+        Digital Object Identifier.
+    keywords:
+        Author-supplied keywords (semicolon or comma separated).
+    """
+
     paper_id: str
     title: str
     abstract: str = ""
@@ -154,27 +348,50 @@ class Paper:
 
     @property
     def text(self) -> str:
+        """Concatenation of title, abstract, and keywords used for clustering."""
         return f"{self.title} {self.abstract} {self.keywords}"
 
     def to_dict(self) -> dict:
+        """Serialise to a plain dictionary."""
         return {
-            "paper_id": self.paper_id, "title": self.title, "abstract": self.abstract,
-            "authors": self.authors, "year": self.year, "venue": self.venue,
-            "doi": self.doi, "keywords": self.keywords,
+            "paper_id": self.paper_id,
+            "title": self.title,
+            "abstract": self.abstract,
+            "authors": self.authors,
+            "year": self.year,
+            "venue": self.venue,
+            "doi": self.doi,
+            "keywords": self.keywords,
         }
 
 
 @dataclass
 class Cluster:
+    """A single topic cluster produced by :meth:`LitCluster.fit`.
+
+    Attributes
+    ----------
+    cluster_id:
+        Integer cluster index (0-based).
+    papers:
+        Papers assigned to this cluster.
+    top_terms:
+        Up to 10 highest-scoring TF-IDF terms in the cluster, ordered by
+        aggregate score (most representative first).
+    """
+
     cluster_id: int
     papers: List[Paper] = field(default_factory=list)
     top_terms: List[str] = field(default_factory=list)
 
     @property
     def label(self) -> str:
-        return f"Cluster {self.cluster_id}: {', '.join(self.top_terms[:3])}"
+        """Short human-readable label using the three top terms."""
+        terms = ", ".join(self.top_terms[:3]) if self.top_terms else "—"
+        return f"Cluster {self.cluster_id}: {terms}"
 
     def to_dict(self) -> dict:
+        """Serialise cluster and all its papers to a plain dictionary."""
         return {
             "cluster_id": self.cluster_id,
             "size": len(self.papers),
@@ -185,12 +402,46 @@ class Cluster:
 
 
 # ---------------------------------------------------------------------------
-# LitCluster
+# Main API class
 # ---------------------------------------------------------------------------
 
 class LitCluster:
-    def __init__(self, k: int = 5, max_iter: int = 100, seed: int = 42,
-                 min_term_freq: int = 2):
+    """Cluster a collection of academic papers by topic using TF-IDF + k-means.
+
+    Parameters
+    ----------
+    k:
+        Number of clusters to create.  Automatically clamped to the number
+        of loaded papers if ``k`` exceeds the corpus size.
+    max_iter:
+        Maximum number of Lloyd's algorithm iterations (default 100).
+    seed:
+        Random seed for reproducible centroid initialisation (default 42).
+    min_term_freq:
+        Minimum number of documents a term must appear in to be included in
+        the vocabulary.  Increasing this value filters rare/noisy terms.
+
+    Examples
+    --------
+    >>> lc = LitCluster.from_bibtex("refs.bib", k=5)
+    >>> lc.fit()
+    >>> print(lc.summary())
+    """
+
+    def __init__(
+        self,
+        k: int = 5,
+        max_iter: int = 100,
+        seed: int = 42,
+        min_term_freq: int = 2,
+    ) -> None:
+        if k < 1:
+            raise ValueError(f"k must be ≥ 1, got {k}")
+        if max_iter < 1:
+            raise ValueError(f"max_iter must be ≥ 1, got {max_iter}")
+        if min_term_freq < 1:
+            raise ValueError(f"min_term_freq must be ≥ 1, got {min_term_freq}")
+
         self.k = k
         self.max_iter = max_iter
         self.seed = seed
@@ -201,9 +452,31 @@ class LitCluster:
         self._vectors: List[Dict[str, float]] = []
         self._vocab: List[str] = []
 
+    # ------------------------------------------------------------------
+    # Loaders
+    # ------------------------------------------------------------------
+
     @classmethod
     def from_csv(cls, path: Path, **kwargs) -> "LitCluster":
+        """Load papers from a CSV file.
+
+        The CSV must contain a header row.  Recognised column names (all
+        optional except at least one of *title* or *abstract*):
+        ``paper_id``, ``title``, ``abstract``, ``authors``, ``year``,
+        ``venue``, ``doi``, ``keywords``.
+
+        Parameters
+        ----------
+        path:
+            Path to the CSV file.
+        **kwargs:
+            Forwarded to :class:`LitCluster` constructor
+            (``k``, ``max_iter``, ``seed``, ``min_term_freq``).
+        """
         obj = cls(**kwargs)
+        path = Path(path)
+        if not path.is_file():
+            raise FileNotFoundError(f"CSV file not found: {path}")
         with path.open(encoding="utf-8", errors="replace", newline="") as fh:
             reader = csv.DictReader(fh)
             for i, row in enumerate(reader):
@@ -221,13 +494,30 @@ class LitCluster:
 
     @classmethod
     def from_jsonl(cls, path: Path, **kwargs) -> "LitCluster":
+        """Load papers from a JSON Lines file (one JSON object per line).
+
+        Each object should have the same keys as the CSV columns above.
+
+        Parameters
+        ----------
+        path:
+            Path to the ``.jsonl`` file.
+        **kwargs:
+            Forwarded to :class:`LitCluster` constructor.
+        """
         obj = cls(**kwargs)
+        path = Path(path)
+        if not path.is_file():
+            raise FileNotFoundError(f"JSONL file not found: {path}")
         with path.open(encoding="utf-8") as fh:
-            for i, line in enumerate(fh):
+            for i, line in enumerate(fh, start=1):
                 line = line.strip()
                 if not line:
                     continue
-                row = json.loads(line)
+                try:
+                    row = json.loads(line)
+                except json.JSONDecodeError as exc:
+                    raise ValueError(f"Invalid JSON on line {i}: {exc}") from exc
                 obj.papers.append(Paper(
                     paper_id=row.get("paper_id", str(i)),
                     title=row.get("title", ""),
@@ -242,56 +532,123 @@ class LitCluster:
 
     @classmethod
     def from_bibtex(cls, path: Path, **kwargs) -> "LitCluster":
-        """Parse a BibTeX file for titles, abstracts, keywords."""
+        """Load papers from a BibTeX (``.bib``) file.
+
+        Extracts ``title``, ``abstract``, ``author``, ``year``,
+        ``journal``/``booktitle``, ``doi``, and ``keywords`` fields.
+        Supports brace-delimited, quote-delimited, and bare field values,
+        including nested braces in LaTeX markup.
+
+        Parameters
+        ----------
+        path:
+            Path to the BibTeX file.
+        **kwargs:
+            Forwarded to :class:`LitCluster` constructor.
+        """
         obj = cls(**kwargs)
+        path = Path(path)
+        if not path.is_file():
+            raise FileNotFoundError(f"BibTeX file not found: {path}")
         text = path.read_text(encoding="utf-8", errors="replace")
         entries = re.split(r'(?=@\w+\s*\{)', text)
         for i, entry in enumerate(entries):
-            if not entry.strip() or not entry.startswith('@'):
+            entry = entry.strip()
+            if not entry or not entry.startswith("@"):
                 continue
-            def _get(field):
-                m = re.search(rf'{field}\s*=\s*[{{"](.*?)[}}"\,]', entry, re.IGNORECASE | re.DOTALL)
-                return m.group(1).strip() if m else ""
-            m_key = re.match(r'@\w+\s*\{\s*(\S+?)[,}]', entry)
+            m_key = re.match(r'@\w+\s*\{\s*(\S+?)\s*[,}]', entry)
             key = m_key.group(1) if m_key else str(i)
             obj.papers.append(Paper(
-                paper_id=key, title=_get('title'), abstract=_get('abstract'),
-                authors=_get('author'), year=_get('year'),
-                venue=_get('journal') or _get('booktitle'),
-                doi=_get('doi'), keywords=_get('keywords'),
+                paper_id=key,
+                title=_bibtex_field(entry, "title"),
+                abstract=_bibtex_field(entry, "abstract"),
+                authors=_bibtex_field(entry, "author"),
+                year=_bibtex_field(entry, "year"),
+                venue=(
+                    _bibtex_field(entry, "journal")
+                    or _bibtex_field(entry, "booktitle")
+                ),
+                doi=_bibtex_field(entry, "doi"),
+                keywords=_bibtex_field(entry, "keywords"),
             ))
         return obj
 
+    # ------------------------------------------------------------------
+    # Clustering
+    # ------------------------------------------------------------------
+
     def fit(self) -> "LitCluster":
+        """Run the TF-IDF + k-means clustering pipeline.
+
+        Steps:
+
+        1. Tokenise each paper's ``text`` property.
+        2. Remove terms appearing in fewer than ``min_term_freq`` documents.
+        3. Compute sparse TF-IDF vectors.
+        4. Apply k-means (Lloyd's algorithm, cosine similarity).
+        5. Extract the top 10 TF-IDF terms per cluster.
+        6. Populate :attr:`clusters`.
+
+        Returns
+        -------
+        LitCluster
+            Returns ``self`` to allow method chaining.
+        """
         if not self.papers:
             return self
+
         tokens_list = [_tokenise(p.text) for p in self.papers]
 
-        # Filter rare terms
         if self.min_term_freq > 1:
             freq: Dict[str, int] = {}
             for tokens in tokens_list:
                 for t in set(tokens):
                     freq[t] = freq.get(t, 0) + 1
-            tokens_list = [[t for t in tokens if freq.get(t, 0) >= self.min_term_freq]
-                           for tokens in tokens_list]
+            tokens_list = [
+                [t for t in tokens if freq.get(t, 0) >= self.min_term_freq]
+                for tokens in tokens_list
+            ]
+
+        # Warn if many documents have empty token lists after filtering
+        empty_count = sum(1 for t in tokens_list if not t)
+        if empty_count == len(self.papers):
+            raise ValueError(
+                "All papers produced empty token lists. "
+                "Try lowering --min-freq or check that the input contains "
+                "title/abstract text."
+            )
 
         self._vectors, self._vocab = _tfidf(tokens_list)
-        self._labels = _kmeans(self._vectors, self.k, self.max_iter, self.seed)
+        effective_k = min(self.k, len(self.papers))
+        if effective_k < self.k:
+            import warnings
+            warnings.warn(
+                f"k={self.k} reduced to {effective_k} (fewer papers than clusters).",
+                stacklevel=2,
+            )
+        self._labels = _kmeans(self._vectors, effective_k, self.max_iter, self.seed)
 
-        # Build cluster objects
-        clusters: Dict[int, List] = {}
-        for paper, label in zip(self.papers, self._labels):
-            clusters.setdefault(label, []).append(paper)
+        cluster_map: Dict[int, List[Paper]] = {}
+        for paper, lbl in zip(self.papers, self._labels):
+            cluster_map.setdefault(lbl, []).append(paper)
 
-        self.clusters = []
-        for cid in sorted(clusters):
-            top_terms = self._top_terms_for_cluster(cid, n=10)
-            self.clusters.append(Cluster(cluster_id=cid, papers=clusters[cid], top_terms=top_terms))
+        self.clusters = [
+            Cluster(
+                cluster_id=cid,
+                papers=cluster_map[cid],
+                top_terms=self._top_terms_for_cluster(cid, n=10),
+            )
+            for cid in sorted(cluster_map)
+        ]
         return self
 
     def _top_terms_for_cluster(self, cid: int, n: int = 10) -> List[str]:
-        member_vecs = [self._vectors[i] for i, l in enumerate(self._labels) if l == cid]
+        """Return the *n* highest aggregate-TF-IDF terms for cluster *cid*."""
+        member_vecs = [
+            self._vectors[i]
+            for i, lbl in enumerate(self._labels)
+            if lbl == cid
+        ]
         if not member_vecs:
             return []
         scores: Dict[str, float] = {}
@@ -300,23 +657,64 @@ class LitCluster:
                 scores[t] = scores.get(t, 0.0) + v
         return sorted(scores, key=lambda t: -scores[t])[:n]
 
+    # ------------------------------------------------------------------
+    # Export
+    # ------------------------------------------------------------------
+
     def export_csv(self, path: Path) -> None:
+        """Write cluster assignments to a CSV file.
+
+        Each row represents one paper and includes its cluster ID, cluster
+        label, and all metadata fields.
+
+        Parameters
+        ----------
+        path:
+            Destination file path.
+        """
+        path = Path(path)
         with path.open("w", newline="", encoding="utf-8") as fh:
-            w = csv.writer(fh)
-            w.writerow(["cluster_id","cluster_label","paper_id","title","authors","year","venue","doi"])
+            writer = csv.writer(fh)
+            writer.writerow([
+                "cluster_id", "cluster_label",
+                "paper_id", "title", "authors", "year", "venue", "doi",
+            ])
             for cluster in self.clusters:
                 for p in cluster.papers:
-                    w.writerow([cluster.cluster_id, cluster.label, p.paper_id,
-                                p.title, p.authors, p.year, p.venue, p.doi])
+                    writer.writerow([
+                        cluster.cluster_id, cluster.label,
+                        p.paper_id, p.title, p.authors, p.year, p.venue, p.doi,
+                    ])
 
     def export_json(self, path: Path) -> None:
+        """Write full cluster data (including paper metadata) to a JSON file.
+
+        Parameters
+        ----------
+        path:
+            Destination file path.
+        """
+        path = Path(path)
         with path.open("w", encoding="utf-8") as fh:
-            json.dump([c.to_dict() for c in self.clusters], fh, indent=2, ensure_ascii=False)
+            json.dump(
+                [c.to_dict() for c in self.clusters],
+                fh,
+                indent=2,
+                ensure_ascii=False,
+            )
 
     def summary(self) -> str:
-        lines = [f"LitCluster: {len(self.papers)} papers in {len(self.clusters)} clusters", ""]
+        """Return a human-readable plain-text summary of clustering results."""
+        lines = [
+            f"litcluster v{__version__}",
+            f"{len(self.papers)} papers → {len(self.clusters)} clusters",
+            "",
+        ]
         for c in self.clusters:
-            lines.append(f"  [{c.cluster_id}] {c.label} ({len(c.papers)} papers)")
+            lines.append(
+                f"  [{c.cluster_id:2d}]  {len(c.papers):4d} papers  "
+                f"({', '.join(c.top_terms[:5])})"
+            )
         return "\n".join(lines)
 
 
@@ -324,45 +722,102 @@ class LitCluster:
 # CLI
 # ---------------------------------------------------------------------------
 
-def _parse_args(argv=None):
-    p = argparse.ArgumentParser(prog="litcluster",
-                                description="Cluster academic papers by topic using TF-IDF + k-means.")
-    p.add_argument("input", help="Input file: CSV, JSONL, or .bib")
-    p.add_argument("-k", "--clusters", type=int, default=5, dest="k",
-                   help="Number of clusters (default: 5)")
-    p.add_argument("--format", choices=["csv","json","summary"], default="summary")
-    p.add_argument("--output", "-o", default=None, help="Output file (default: stdout/auto)")
-    p.add_argument("--seed", type=int, default=42)
-    p.add_argument("--max-iter", type=int, default=100)
-    p.add_argument("--min-freq", type=int, default=2,
-                   help="Minimum term frequency to include in vocabulary (default: 2)")
-    return p.parse_args(argv)
+def _parse_args(argv=None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        prog="litcluster",
+        description=(
+            "Cluster academic papers by topic using TF-IDF + k-means. "
+            "Accepts BibTeX (.bib), CSV, or JSON Lines (.jsonl) input."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=(
+            "Examples:\n"
+            "  litcluster refs.bib -k 8\n"
+            "  litcluster papers.csv --format json -o clusters.json\n"
+            "  litcluster papers.jsonl -k 10 --format csv\n"
+        ),
+    )
+    parser.add_argument("input", help="Input file: .bib, .csv, or .jsonl")
+    parser.add_argument(
+        "-k", "--clusters", type=int, default=5, dest="k",
+        metavar="K",
+        help="Number of clusters (default: 5)",
+    )
+    parser.add_argument(
+        "--format", choices=["csv", "json", "summary"], default="summary",
+        help="Output format (default: summary)",
+    )
+    parser.add_argument(
+        "--output", "-o", default=None,
+        metavar="FILE",
+        help="Output file path (default: stdout for summary, auto-named for csv/json)",
+    )
+    parser.add_argument(
+        "--seed", type=int, default=42,
+        help="Random seed for reproducibility (default: 42)",
+    )
+    parser.add_argument(
+        "--max-iter", type=int, default=100,
+        metavar="N",
+        help="Maximum k-means iterations (default: 100)",
+    )
+    parser.add_argument(
+        "--min-freq", type=int, default=2,
+        metavar="N",
+        help="Minimum document frequency for vocabulary terms (default: 2)",
+    )
+    parser.add_argument(
+        "--version", action="version", version=f"litcluster {__version__}",
+    )
+    return parser.parse_args(argv)
 
 
 def main(argv=None) -> int:
+    """Entry point for the ``litcluster`` command-line tool.
+
+    Returns
+    -------
+    int
+        Exit code: 0 on success, 1 on error.
+    """
     args = _parse_args(argv)
     path = Path(args.input)
     if not path.is_file():
-        print(f"Error: {path} not found", file=sys.stderr)
+        print(f"litcluster: error: file not found: {path}", file=sys.stderr)
         return 1
 
-    suffix = path.suffix.lower()
-    kwargs = dict(k=args.k, max_iter=args.max_iter, seed=args.seed, min_term_freq=args.min_freq)
-    if suffix == ".bib":
-        lc = LitCluster.from_bibtex(path, **kwargs)
-    elif suffix == ".jsonl":
-        lc = LitCluster.from_jsonl(path, **kwargs)
-    else:
-        lc = LitCluster.from_csv(path, **kwargs)
+    kwargs = dict(
+        k=args.k,
+        max_iter=args.max_iter,
+        seed=args.seed,
+        min_term_freq=args.min_freq,
+    )
 
-    lc.fit()
+    try:
+        suffix = path.suffix.lower()
+        if suffix == ".bib":
+            lc = LitCluster.from_bibtex(path, **kwargs)
+        elif suffix == ".jsonl":
+            lc = LitCluster.from_jsonl(path, **kwargs)
+        else:
+            lc = LitCluster.from_csv(path, **kwargs)
+
+        if not lc.papers:
+            print("litcluster: warning: no papers loaded from input file.", file=sys.stderr)
+            return 1
+
+        lc.fit()
+    except (FileNotFoundError, ValueError) as exc:
+        print(f"litcluster: error: {exc}", file=sys.stderr)
+        return 1
 
     if args.format == "summary":
-        output = lc.summary()
+        text = lc.summary()
         if args.output:
-            Path(args.output).write_text(output, encoding="utf-8")
+            Path(args.output).write_text(text, encoding="utf-8")
+            print(f"Summary written to {args.output}")
         else:
-            print(output)
+            print(text)
     elif args.format == "csv":
         out = Path(args.output) if args.output else path.with_suffix(".clusters.csv")
         lc.export_csv(out)
@@ -373,6 +828,10 @@ def main(argv=None) -> int:
         print(f"Clusters written to {out}")
 
     return 0
+
+
+# Alias expected by pyproject.toml entry-point ``litcluster = "litcluster:_cli"``
+_cli = main
 
 
 if __name__ == "__main__":

--- a/litcluster_gui.py
+++ b/litcluster_gui.py
@@ -1,0 +1,480 @@
+#!/usr/bin/env python3
+"""
+litcluster_gui.py — Desktop GUI for litcluster
+================================================
+Provides a graphical interface for loading academic paper collections,
+configuring clustering parameters, inspecting results, and exporting
+cluster assignments.  Uses only Python's standard library (tkinter).
+
+Launch with::
+
+    python litcluster_gui.py
+    # or, after installation:
+    litcluster-gui
+"""
+
+from __future__ import annotations
+
+import pathlib
+import sys
+import threading
+import tkinter as tk
+from tkinter import filedialog, messagebox, ttk
+
+# Ensure litcluster is importable from the same directory as this script.
+sys.path.insert(0, str(pathlib.Path(__file__).parent))
+
+try:
+    import litcluster as _lc
+    from litcluster import LitCluster, __version__
+except ImportError as _exc:  # pragma: no cover
+    raise SystemExit(
+        "Cannot import litcluster.  Make sure litcluster.py is in the same "
+        "directory as litcluster_gui.py, or that the package is installed."
+    ) from _exc
+
+
+# ---------------------------------------------------------------------------
+# Tooltip helper
+# ---------------------------------------------------------------------------
+
+class _Tooltip:
+    """Simple hover tooltip for any tkinter widget."""
+
+    def __init__(self, widget: tk.Widget, text: str) -> None:
+        self._widget = widget
+        self._text = text
+        self._tip: Optional[tk.Toplevel] = None
+        widget.bind("<Enter>", self._show)
+        widget.bind("<Leave>", self._hide)
+
+    def _show(self, _event=None) -> None:
+        x = self._widget.winfo_rootx() + 20
+        y = self._widget.winfo_rooty() + self._widget.winfo_height() + 4
+        self._tip = tk.Toplevel(self._widget)
+        self._tip.wm_overrideredirect(True)
+        self._tip.wm_geometry(f"+{x}+{y}")
+        lbl = tk.Label(
+            self._tip, text=self._text,
+            background="#ffffe0", relief=tk.SOLID, borderwidth=1,
+            font=("TkDefaultFont", 9), wraplength=300, justify=tk.LEFT,
+            padx=4, pady=2,
+        )
+        lbl.pack()
+
+    def _hide(self, _event=None) -> None:
+        if self._tip:
+            self._tip.destroy()
+            self._tip = None
+
+
+# ---------------------------------------------------------------------------
+# Main application window
+# ---------------------------------------------------------------------------
+
+class LitClusterApp(tk.Tk):
+    """Main application window for the litcluster GUI."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.title(f"litcluster {__version__} — Literature Clustering Tool")
+        self.minsize(960, 620)
+        self._lc_result: LitCluster | None = None
+        self._build_menu()
+        self._build_toolbar()
+        self._build_params()
+        self._build_results()
+        self._build_statusbar()
+        self.resizable(True, True)
+        self._set_status("Ready.  Open a BibTeX, CSV, or JSONL file to begin.")
+
+    # ------------------------------------------------------------------
+    # Layout builders
+    # ------------------------------------------------------------------
+
+    def _build_menu(self) -> None:
+        menubar = tk.Menu(self)
+
+        # File menu
+        file_menu = tk.Menu(menubar, tearoff=False)
+        file_menu.add_command(
+            label="Open File…", command=self._open_file, accelerator="Ctrl+O"
+        )
+        file_menu.add_separator()
+        file_menu.add_command(
+            label="Export CSV…", command=self._export_csv, accelerator="Ctrl+S"
+        )
+        file_menu.add_command(
+            label="Export JSON…", command=self._export_json
+        )
+        file_menu.add_separator()
+        file_menu.add_command(label="Quit", command=self.destroy, accelerator="Ctrl+Q")
+        menubar.add_cascade(label="File", menu=file_menu)
+
+        # Help menu
+        help_menu = tk.Menu(menubar, tearoff=False)
+        help_menu.add_command(label="About litcluster", command=self._show_about)
+        menubar.add_cascade(label="Help", menu=help_menu)
+
+        self.config(menu=menubar)
+        self.bind("<Control-o>", lambda _: self._open_file())
+        self.bind("<Control-s>", lambda _: self._export_csv())
+        self.bind("<Control-q>", lambda _: self.destroy())
+
+    def _build_toolbar(self) -> None:
+        toolbar = ttk.Frame(self, padding=(6, 4))
+        toolbar.pack(fill=tk.X, side=tk.TOP)
+
+        ttk.Button(
+            toolbar, text="Open File…", command=self._open_file, width=12
+        ).grid(row=0, column=0, padx=2)
+
+        self._path_var = tk.StringVar(value="No file selected")
+        path_lbl = ttk.Label(
+            toolbar, textvariable=self._path_var,
+            foreground="#555555", font=("TkDefaultFont", 9),
+        )
+        path_lbl.grid(row=0, column=1, padx=8, sticky=tk.W)
+
+        # Right-align the Run button
+        toolbar.columnconfigure(2, weight=1)
+        ttk.Button(
+            toolbar, text="▶  Run Clustering", command=self._run, width=18
+        ).grid(row=0, column=3, padx=4)
+
+    def _build_params(self) -> None:
+        frame = ttk.LabelFrame(self, text="Clustering Parameters", padding=(10, 6))
+        frame.pack(fill=tk.X, padx=8, pady=(0, 4))
+
+        self._k_var = tk.IntVar(value=5)
+        self._seed_var = tk.IntVar(value=42)
+        self._minfreq_var = tk.IntVar(value=2)
+        self._maxiter_var = tk.IntVar(value=100)
+
+        params = [
+            ("Clusters (k):", self._k_var, 2, 50,
+             "Number of topic clusters to create."),
+            ("Seed:", self._seed_var, 0, 9999,
+             "Random seed for reproducible results."),
+            ("Min Term Freq:", self._minfreq_var, 1, 20,
+             "Minimum number of documents a term must appear in to enter the vocabulary."),
+            ("Max Iterations:", self._maxiter_var, 10, 500,
+             "Maximum number of k-means iterations."),
+        ]
+        for col, (label, var, from_, to, tip) in enumerate(params):
+            lbl = ttk.Label(frame, text=label)
+            lbl.grid(row=0, column=col * 2, padx=(8, 2), sticky=tk.E)
+            spn = ttk.Spinbox(
+                frame, textvariable=var, from_=from_, to=to, width=7
+            )
+            spn.grid(row=0, column=col * 2 + 1, padx=(0, 8))
+            _Tooltip(lbl, tip)
+            _Tooltip(spn, tip)
+
+    def _build_results(self) -> None:
+        paned = ttk.PanedWindow(self, orient=tk.HORIZONTAL)
+        paned.pack(fill=tk.BOTH, expand=True, padx=8, pady=4)
+
+        # ---- Left panel: cluster list ----
+        left = ttk.Frame(paned)
+        paned.add(left, weight=1)
+
+        ttk.Label(left, text="Clusters", font=("TkDefaultFont", 10, "bold")).pack(
+            anchor=tk.W, pady=(0, 2)
+        )
+
+        list_frame = ttk.Frame(left)
+        list_frame.pack(fill=tk.BOTH, expand=True)
+
+        scrollbar = ttk.Scrollbar(list_frame, orient=tk.VERTICAL)
+        self._cluster_lb = tk.Listbox(
+            list_frame,
+            yscrollcommand=scrollbar.set,
+            font=("Courier", 10),
+            selectbackground="#4a90d9",
+            selectforeground="white",
+            activestyle="none",
+        )
+        scrollbar.config(command=self._cluster_lb.yview)
+        self._cluster_lb.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
+        scrollbar.pack(side=tk.RIGHT, fill=tk.Y)
+        self._cluster_lb.bind("<<ListboxSelect>>", self._on_cluster_select)
+
+        # ---- Right panel: paper details ----
+        right = ttk.Frame(paned)
+        paned.add(right, weight=3)
+
+        ttk.Label(
+            right, text="Papers in selected cluster",
+            font=("TkDefaultFont", 10, "bold"),
+        ).pack(anchor=tk.W, pady=(0, 2))
+
+        # Top-terms banner
+        self._terms_var = tk.StringVar(value="")
+        ttk.Label(
+            right, textvariable=self._terms_var,
+            foreground="#1a5f9e", wraplength=600,
+            font=("TkDefaultFont", 9, "italic"),
+        ).pack(anchor=tk.W, padx=2, pady=(0, 4))
+
+        # Papers treeview
+        tree_frame = ttk.Frame(right)
+        tree_frame.pack(fill=tk.BOTH, expand=True)
+
+        columns = ("title", "authors", "year", "venue")
+        self._tree = ttk.Treeview(
+            tree_frame, columns=columns, show="headings", selectmode="extended"
+        )
+        col_widths = {"title": 340, "authors": 160, "year": 55, "venue": 160}
+        for col in columns:
+            self._tree.heading(col, text=col.capitalize(),
+                               command=lambda c=col: self._sort_tree(c))
+            self._tree.column(col, width=col_widths[col], anchor=tk.W, stretch=True)
+
+        vsb = ttk.Scrollbar(tree_frame, orient=tk.VERTICAL, command=self._tree.yview)
+        hsb = ttk.Scrollbar(tree_frame, orient=tk.HORIZONTAL, command=self._tree.xview)
+        self._tree.configure(yscrollcommand=vsb.set, xscrollcommand=hsb.set)
+
+        self._tree.grid(row=0, column=0, sticky="nsew")
+        vsb.grid(row=0, column=1, sticky="ns")
+        hsb.grid(row=1, column=0, sticky="ew")
+        tree_frame.rowconfigure(0, weight=1)
+        tree_frame.columnconfigure(0, weight=1)
+
+        self._tree.bind("<Double-1>", self._on_paper_double_click)
+
+    def _build_statusbar(self) -> None:
+        self._status_var = tk.StringVar(value="")
+        bar = ttk.Label(
+            self, textvariable=self._status_var,
+            relief=tk.SUNKEN, anchor=tk.W, padding=(6, 2),
+            font=("TkDefaultFont", 9),
+        )
+        bar.pack(fill=tk.X, side=tk.BOTTOM)
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _set_status(self, msg: str) -> None:
+        self._status_var.set(msg)
+
+    def _clear_results(self) -> None:
+        self._cluster_lb.delete(0, tk.END)
+        for row in self._tree.get_children():
+            self._tree.delete(row)
+        self._terms_var.set("")
+
+    # ------------------------------------------------------------------
+    # Actions
+    # ------------------------------------------------------------------
+
+    def _open_file(self) -> None:
+        path = filedialog.askopenfilename(
+            title="Open paper collection",
+            filetypes=[
+                ("All supported", "*.bib *.csv *.jsonl"),
+                ("BibTeX", "*.bib"),
+                ("CSV", "*.csv"),
+                ("JSON Lines", "*.jsonl"),
+                ("All files", "*.*"),
+            ],
+        )
+        if path:
+            self._path_var.set(path)
+            self._set_status(f"File selected: {path}")
+
+    def _run(self) -> None:
+        path_str = self._path_var.get()
+        if path_str in ("No file selected", ""):
+            messagebox.showwarning("No file selected", "Please open a file first.")
+            return
+        path = pathlib.Path(path_str)
+        if not path.is_file():
+            messagebox.showerror("File not found", f"Cannot find:\n{path}")
+            return
+
+        self._clear_results()
+        self._set_status("Clustering… please wait.")
+        self.update_idletasks()
+
+        def _worker() -> None:
+            try:
+                kwargs = dict(
+                    k=self._k_var.get(),
+                    seed=self._seed_var.get(),
+                    min_term_freq=self._minfreq_var.get(),
+                    max_iter=self._maxiter_var.get(),
+                )
+                suffix = path.suffix.lower()
+                if suffix == ".bib":
+                    obj = LitCluster.from_bibtex(path, **kwargs)
+                elif suffix == ".jsonl":
+                    obj = LitCluster.from_jsonl(path, **kwargs)
+                else:
+                    obj = LitCluster.from_csv(path, **kwargs)
+                obj.fit()
+                self._lc_result = obj
+                self.after(0, self._populate_clusters)
+            except Exception as exc:  # noqa: BLE001
+                self.after(0, lambda: self._on_run_error(exc))
+
+        threading.Thread(target=_worker, daemon=True).start()
+
+    def _populate_clusters(self) -> None:
+        if self._lc_result is None:
+            return
+        self._cluster_lb.delete(0, tk.END)
+        for c in self._lc_result.clusters:
+            terms_preview = ", ".join(c.top_terms[:4])
+            self._cluster_lb.insert(
+                tk.END,
+                f"[{c.cluster_id:2d}]  {len(c.papers):4d} papers  {terms_preview}",
+            )
+        n_papers = len(self._lc_result.papers)
+        n_clusters = len(self._lc_result.clusters)
+        self._set_status(f"Done: {n_papers} papers → {n_clusters} clusters.")
+
+    def _on_cluster_select(self, _event=None) -> None:
+        sel = self._cluster_lb.curselection()
+        if not sel or self._lc_result is None:
+            return
+        cluster = self._lc_result.clusters[sel[0]]
+
+        for row in self._tree.get_children():
+            self._tree.delete(row)
+        for p in cluster.papers:
+            self._tree.insert("", tk.END, values=(
+                p.title or "(no title)",
+                p.authors,
+                p.year,
+                p.venue,
+            ), tags=(p.paper_id,))
+
+        self._terms_var.set(
+            "Top terms:  " + "  ·  ".join(cluster.top_terms)
+        )
+
+    def _on_paper_double_click(self, _event=None) -> None:
+        """Show a detail pop-up for the double-clicked paper."""
+        sel = self._tree.selection()
+        if not sel or self._lc_result is None:
+            return
+        item = sel[0]
+        values = self._tree.item(item, "values")
+        title, authors, year, venue = values
+
+        # Locate the Paper object to access abstract and DOI
+        paper = None
+        for p in self._lc_result.papers:
+            if p.title == title and p.authors == authors:
+                paper = p
+                break
+
+        if paper is None:
+            return
+
+        win = tk.Toplevel(self)
+        win.title("Paper details")
+        win.geometry("620x380")
+        win.resizable(True, True)
+
+        txt = tk.Text(win, wrap=tk.WORD, font=("TkDefaultFont", 10), padx=8, pady=8)
+        sb = ttk.Scrollbar(win, orient=tk.VERTICAL, command=txt.yview)
+        txt.configure(yscrollcommand=sb.set)
+        txt.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
+        sb.pack(side=tk.RIGHT, fill=tk.Y)
+
+        fields = [
+            ("Title", paper.title),
+            ("Authors", paper.authors),
+            ("Year", paper.year),
+            ("Venue", paper.venue),
+            ("DOI", paper.doi),
+            ("Keywords", paper.keywords),
+            ("Abstract", paper.abstract),
+        ]
+        txt.tag_configure("field_name", font=("TkDefaultFont", 10, "bold"))
+        for name, value in fields:
+            if value:
+                txt.insert(tk.END, f"{name}:\n", "field_name")
+                txt.insert(tk.END, f"{value}\n\n")
+        txt.configure(state=tk.DISABLED)
+
+    def _sort_tree(self, col: str) -> None:
+        """Sort the papers treeview by *col*."""
+        data = [
+            (self._tree.set(child, col), child)
+            for child in self._tree.get_children("")
+        ]
+        data.sort(key=lambda t: t[0].lower())
+        for index, (_, child) in enumerate(data):
+            self._tree.move(child, "", index)
+
+    def _export_csv(self) -> None:
+        if self._lc_result is None:
+            messagebox.showwarning("No results", "Run clustering before exporting.")
+            return
+        path = filedialog.asksaveasfilename(
+            title="Export clusters as CSV",
+            defaultextension=".csv",
+            filetypes=[("CSV files", "*.csv"), ("All files", "*.*")],
+        )
+        if path:
+            try:
+                self._lc_result.export_csv(pathlib.Path(path))
+                self._set_status(f"Exported CSV: {path}")
+            except OSError as exc:
+                messagebox.showerror("Export failed", str(exc))
+
+    def _export_json(self) -> None:
+        if self._lc_result is None:
+            messagebox.showwarning("No results", "Run clustering before exporting.")
+            return
+        path = filedialog.asksaveasfilename(
+            title="Export clusters as JSON",
+            defaultextension=".json",
+            filetypes=[("JSON files", "*.json"), ("All files", "*.*")],
+        )
+        if path:
+            try:
+                self._lc_result.export_json(pathlib.Path(path))
+                self._set_status(f"Exported JSON: {path}")
+            except OSError as exc:
+                messagebox.showerror("Export failed", str(exc))
+
+    def _on_run_error(self, exc: Exception) -> None:
+        self._set_status(f"Error: {exc}")
+        messagebox.showerror(
+            "Clustering failed",
+            f"{type(exc).__name__}: {exc}\n\n"
+            "Common causes:\n"
+            "• k is larger than the number of papers\n"
+            "• All papers have empty title and abstract text\n"
+            "• min-freq is too high for the corpus size",
+        )
+
+    def _show_about(self) -> None:
+        messagebox.showinfo(
+            "About litcluster",
+            f"litcluster {__version__}\n\n"
+            "Cluster academic papers by topic using TF-IDF\n"
+            "vectorisation and k-means (Lloyd's algorithm).\n\n"
+            "All functionality uses Python's standard library.\n\n"
+            "Author: Vaibhav Deshmukh\n"
+            "Licence: MIT",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    """Launch the litcluster GUI."""
+    app = LitClusterApp()
+    app.mainloop()
+
+
+if __name__ == "__main__":
+    main()

--- a/paper.bib
+++ b/paper.bib
@@ -1,112 +1,48 @@
-@misc{nist2015sha,
-  author       = {{National Institute of Standards and Technology}},
-  title        = {{FIPS PUB 180-4: Secure Hash Standard (SHS)}},
-  year         = {2015},
-  howpublished = {\url{https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf}},
-  institution  = {National Institute of Standards and Technology}
+@article{kitchenham2007guidelines,
+  author    = {Kitchenham, Barbara and Charters, Stuart},
+  title     = {Guidelines for performing systematic literature reviews in software engineering},
+  journal   = {Technical Report EBSE-2007-01, Keele University and Durham University},
+  year      = {2007},
 }
 
-@article{gundersen2018state,
-  author  = {Gundersen, Odd Erik and Kjensmo, Sigurd},
-  title   = {State of the Art: Reproducibility in Artificial Intelligence},
-  journal = {Proceedings of the AAAI Conference on Artificial Intelligence},
-  volume  = {32},
-  number  = {1},
-  year    = {2018}
-}
-
-@article{pineau2021improving,
-  author  = {Pineau, Joelle and Vincent-Lamarre, Philippe and Sinha, Koustuv and
-             Lariviere, Vincent and Beygelzimer, Alina and d'Alche-Buc, Florence and
-             Fox, Emily and Larochelle, Hugo},
-  title   = {Improving Reproducibility in Machine Learning Research},
+@article{pedregosa2011scikit,
+  author  = {Pedregosa, Fabian and Varoquaux, Ga{\"e}l and Gramfort, Alexandre
+             and Michel, Vincent and Thirion, Bertrand and Grisel, Olivier
+             and Blondel, Mathieu and Prettenhofer, Peter and Weiss, Ron
+             and Dubourg, Vincent and others},
+  title   = {Scikit-learn: Machine learning in {Python}},
   journal = {Journal of Machine Learning Research},
-  volume  = {22},
-  number  = {242},
-  pages   = {1--20},
-  year    = {2021}
+  volume  = {12},
+  pages   = {2825--2830},
+  year    = {2011},
 }
 
-@article{stodden2016enhancing,
-  author  = {Stodden, Victoria and McNutt, Marcia and Bailey, David H. and Deelman, Ewa and
-             Gil, Yolanda and Hanson, Brooks and Heroux, Michael A. and Ioannidis, John P. A. and
-             Taufer, Michela},
-  title   = {Enhancing Reproducibility for Computational Methods},
-  journal = {Science},
-  volume  = {354},
-  number  = {6317},
-  pages   = {1240--1241},
-  year    = {2016},
-  doi     = {10.1126/science.aah6168}
+@article{lloyd1982least,
+  author    = {Lloyd, Stuart P.},
+  title     = {Least squares quantization in {PCM}},
+  journal   = {IEEE Transactions on Information Theory},
+  volume    = {28},
+  number    = {2},
+  pages     = {129--137},
+  year      = {1982},
+  doi       = {10.1109/TIT.1982.1056489},
 }
 
-@article{gebru2021datasheets,
-  author  = {Gebru, Timnit and Morgenstern, Jamie and Vecchione, Briana and
-             Vaughan, Jennifer Wortman and Wallach, Hanna and Daume, Hal and Crawford, Kate},
-  title   = {Datasheets for Datasets},
-  journal = {Communications of the ACM},
-  volume  = {64},
-  number  = {12},
-  pages   = {86--92},
-  year    = {2021},
-  doi     = {10.1145/3458723}
+@article{salton1988tfidf,
+  author    = {Salton, Gerard and Buckley, Christopher},
+  title     = {Term-weighting approaches in automatic text retrieval},
+  journal   = {Information Processing \& Management},
+  volume    = {24},
+  number    = {5},
+  pages     = {513--523},
+  year      = {1988},
+  doi       = {10.1016/0306-4573(88)90021-0},
 }
 
-@article{adadi2018peeking,
-  author  = {Adadi, Amina and Berrada, Mohammed},
-  title   = {Peeking Inside the Black-Box: A Survey on Explainable Artificial Intelligence (XAI)},
-  journal = {IEEE Access},
-  volume  = {6},
-  pages   = {52138--52160},
-  year    = {2018},
-  doi     = {10.1109/ACCESS.2018.2870052}
-}
-
-@article{wei2022chain,
-  author  = {Wei, Jason and Wang, Xuezhi and Schuurmans, Dale and Bosma, Maarten and
-             Ichter, Brian and Xia, Fei and Chi, Ed and Le, Quoc and Zhou, Denny},
-  title   = {Chain-of-Thought Prompting Elicits Reasoning in Large Language Models},
-  journal = {Advances in Neural Information Processing Systems},
-  volume  = {35},
-  pages   = {24824--24837},
-  year    = {2022}
-}
-
-@article{kung2023chatgpt,
-  author  = {Kung, Tiffany H. and Cheatham, Morgan and Medenilla, Ariel and Sillos, Czarina and
-             De Leon, Lorie and Elepano, Camille and Madriaga, Maria and Aggabao, Rimel and
-             Diaz-Candido, Gerdine and Maningo, James and Tseng, Victor},
-  title   = {Performance of ChatGPT on USMLE: Potential for AI-Assisted Medical Education
-             Using Large Language Models},
-  journal = {PLOS Digital Health},
-  volume  = {2},
-  number  = {2},
-  pages   = {e0000198},
-  year    = {2023},
-  doi     = {10.1371/journal.pdig.0000198}
-}
-
-@article{gao2023reproducibility,
-  author  = {Gao, Luyu and Biderman, Stella and Black, Sid and Golding, Laurence and Hoppe, Travis and
-             Foster, Charles and Phang, Jason and He, Horace and Thite, Anish and Nabeshima, Noa and
-             Presser, Shawn and Leahy, Connor},
-  title   = {The Pile: An 800GB Dataset of Diverse Text for Language Modeling},
-  journal = {arXiv preprint arXiv:2101.00027},
-  year    = {2023}
-}
-
-@article{perez2022ignore,
-  author  = {Perez, Fabio and Ribeiro, Ian},
-  title   = {Ignore Previous Prompt: Attack Techniques For Language Models},
-  journal = {arXiv preprint arXiv:2211.09527},
-  year    = {2022}
-}
-
-@article{greshake2023not,
-  author  = {Greshake, Kai and Abdelnabi, Sahar and Mishra, Shailesh and Endres, Christoph and
-             Holz, Thorsten and Fritz, Mario},
-  title   = {Not What You've Signed Up For: Compromising Real-World LLM-Integrated Applications
-             with Indirect Prompt Injection},
-  journal = {arXiv preprint arXiv:2302.12173},
-  year    = {2023}
+@book{manning2008introduction,
+  author    = {Manning, Christopher D. and Raghavan, Prabhakar and Sch{\"u}tze, Hinrich},
+  title     = {Introduction to Information Retrieval},
+  publisher = {Cambridge University Press},
+  year      = {2008},
+  doi       = {10.1017/CBO9780511809071},
 }

--- a/paper.md
+++ b/paper.md
@@ -1,5 +1,5 @@
 ---
-title: 'litcluster: Topic modelling and semantic clustering of scientific literature from BibTeX or DOI lists'
+title: 'litcluster: Topic-based clustering of scientific literature using TF-IDF and k-means'
 tags:
   - Python
   - NLP
@@ -7,6 +7,7 @@ tags:
   - clustering
   - literature-review
   - bibliometrics
+  - systematic-review
 authors:
   - name: Vaibhav Deshmukh
     orcid: 0000-0001-6745-7062
@@ -14,20 +15,101 @@ authors:
 affiliations:
   - name: Independent Researcher, Nagpur, India
     index: 1
-date: 23 April 2026
+date: 4 May 2026
 bibliography: paper.bib
 ---
 
 # Summary
 
-`litcluster` is a Python tool for semantic clustering and topic modelling of scientific literature. Given a BibTeX file, a list of DOIs, or a directory of PDF abstracts, `litcluster` fetches or extracts abstract text, embeds papers using pre-trained sentence transformers, applies dimensionality reduction (UMAP), and clusters the resulting embedding space (HDBSCAN). It outputs an interactive HTML visualisation of the literature landscape and a Markdown summary table labelling each cluster with automatically extracted topic keywords. `litcluster` is designed for researchers beginning a new domain survey or tracking how a field has evolved over time.
+`litcluster` is a dependency-free Python tool for topic-based clustering and
+organisation of scientific literature.  Given a BibTeX file, a CSV spreadsheet,
+or a JSON Lines file of paper metadata, `litcluster` tokenises title, abstract,
+and keyword text, builds TF-IDF (Term Frequency–Inverse Document Frequency)
+vectors for each document, and groups the collection into *k* thematic clusters
+using Lloyd's k-means algorithm with cosine similarity.  Each cluster is
+automatically labelled with its most discriminative TF-IDF terms.  Results can
+be exported as a human-readable summary, a flat CSV, or a structured JSON file.
+An optional desktop GUI (built on the standard-library `tkinter` toolkit)
+provides point-and-click access to the full pipeline without requiring any
+command-line interaction.
+
+`litcluster` uses only Python's standard library; it has no third-party
+dependencies and installs instantly in any Python 3.8+ environment.
 
 # Statement of Need
 
-Systematic and scoping reviews require researchers to organise large collections of papers into thematic groups — a task typically done manually or with expensive proprietary tools. `litcluster` automates this using modern sentence embeddings and density-based clustering, requiring only a BibTeX file as input. Unlike keyword-based approaches, semantic clustering groups papers by meaning rather than surface vocabulary, surfacing connections that term-based methods miss [@wei2022chain]. The interactive output helps researchers quickly identify core topics, niche sub-areas, and potential gaps in a literature collection, accelerating the early stages of a systematic review.
+Systematic and scoping reviews require researchers to organise potentially
+hundreds of papers into thematic groups — a task that is time-consuming when
+performed manually and typically requires either expensive proprietary software
+or complex NLP toolchains with heavy dependencies.
+
+`litcluster` fills the gap between rudimentary keyword search and heavyweight
+machine-learning pipelines.  It requires only a BibTeX export from any
+reference manager (Zotero, Mendeley, EndNote) or a simple CSV spreadsheet, and
+produces cluster assignments and topic keywords in seconds with a single
+command.  Because the tool relies on no external packages, it can be deployed in
+restricted computing environments (e.g., institutional HPC clusters, air-gapped
+systems) without additional installation steps.
+
+The TF-IDF + k-means approach is well understood, deterministic given a fixed
+random seed, and fast enough to process several thousand papers on a standard
+laptop.  The explainable top-term labels make it straightforward for researchers
+to interpret and validate cluster content — a property that is important for
+reproducibility in systematic reviews [@kitchenham2007guidelines].
+
+# Algorithm
+
+## Text representation
+
+Each paper is represented by the concatenation of its title, abstract, and
+author-supplied keywords.  The text is lowercased, split on word boundaries
+(3+ alphabetic characters), and filtered against an extended stopword list that
+covers both common English function words and high-frequency academic phrases
+(e.g., *results*, *proposed*, *method*) that carry no discriminating information
+across disciplines.
+
+Term frequencies are normalised by document length (raw TF) and combined with a
+smoothed inverse document frequency:
+
+$$\text{IDF}(t) = \log\!\left(\frac{n+1}{df(t)+1}\right) + 1$$
+
+where $n$ is the number of documents and $df(t)$ is the number of documents
+containing term $t$.  The additive smoothing prevents zero-IDF for terms that
+appear in every document [@pedregosa2011scikit].
+
+## Clustering
+
+Lloyd's k-means algorithm [@lloyd1982least] is applied to the sparse TF-IDF
+vectors using cosine similarity as the distance metric.  Cosine similarity is
+preferable to Euclidean distance for text vectors because it is invariant to
+document length.  Centroids are initialised by random sampling without
+replacement, with the RNG seeded for full reproducibility.  Empty clusters
+(which can arise if an initialised centroid has no nearest neighbours) are
+re-seeded from a random existing document rather than being left degenerate.
+
+The algorithm converges when cluster assignments are unchanged between
+iterations, or after a user-specified maximum number of iterations (default 100).
+
+## Cluster labelling
+
+Each cluster is labelled with its top-10 terms by aggregate TF-IDF score across
+member documents, providing a human-readable summary of each topic.
+
+# Features
+
+- **Input formats**: BibTeX (`.bib`), CSV, and JSON Lines (`.jsonl`).
+- **Output formats**: plain-text summary, flat CSV of assignments, and
+  structured JSON with full paper metadata.
+- **CLI**: `litcluster refs.bib -k 8 --format json -o clusters.json`
+- **Python API**: `LitCluster.from_bibtex("refs.bib", k=5).fit()`
+- **GUI**: `python litcluster_gui.py` — file browser, parameter spinboxes,
+  interactive cluster/paper explorer, and CSV/JSON export.
+- **Reproducibility**: deterministic output via `--seed`.
+- **Zero dependencies**: Python 3.8+ standard library only.
 
 # Acknowledgements
 
-The author used Claude (Anthropic) for drafting portions of this manuscript. All scientific claims and design decisions are the author's own.
+The author used Claude (Anthropic) for drafting portions of this manuscript.
+All scientific claims and design decisions are the author's own.
 
 # References

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ classifiers = [
 
 [project.scripts]
 litcluster = "litcluster:_cli"
+litcluster-gui = "litcluster_gui:main"
 
 [tool.setuptools]
 py-modules = ["litcluster"]

--- a/src/litcluster/__init__.py
+++ b/src/litcluster/__init__.py
@@ -1,18 +1,19 @@
 """
-litcluster: Semantic clustering and topic modelling of scientific literature.
+litcluster: Topic-based clustering of scientific literature using TF-IDF and k-means.
 
-Ingests collections of scientific abstracts or full papers (via DOI lists,
-BibTeX files, or arXiv IDs), embeds them using sentence-transformers, and
-applies hierarchical clustering and topic modelling to produce interactive
-visualisations and structured cluster summaries for systematic literature
-reviews.
+This package re-exports the public API from the top-level ``litcluster`` module
+so that both ``import litcluster`` and ``from litcluster import LitCluster``
+work regardless of whether the package is installed from source or used
+in-place.
 """
 
-__version__ = "0.1.0"
+from litcluster import (  # noqa: F401
+    LitCluster,
+    Paper,
+    Cluster,
+    __version__,
+    __all__,
+)
+
 __author__ = "Vaibhav Deshmukh"
 __license__ = "MIT"
-
-from .cluster import LitCluster
-from .embed import PaperEmbedder
-
-__all__ = ["LitCluster", "PaperEmbedder"]

--- a/tests/test_litcluster.py
+++ b/tests/test_litcluster.py
@@ -1,19 +1,479 @@
-import sys, pathlib
+"""
+Tests for litcluster — Literature Clustering Tool.
+Run with:  pytest tests/
+"""
+
+import csv
+import json
+import math
+import pathlib
+import sys
+import tempfile
+import textwrap
+
+import pytest
+
+# Ensure the root module is importable from the project root.
 sys.path.insert(0, str(pathlib.Path(__file__).parent.parent))
 
-def test_import():
-    import litcluster as lc
-    assert hasattr(lc, 'LitCluster')
+import litcluster as lc
+from litcluster import Cluster, LitCluster, Paper, _bibtex_field, _cosine, _tfidf, _tokenise
 
-def test_paper():
-    import litcluster as lc
-    assert hasattr(lc, 'Paper')
 
-def test_cluster():
-    import litcluster as lc
-    assert hasattr(lc, 'Cluster')
+# ---------------------------------------------------------------------------
+# Smoke tests — public API surface
+# ---------------------------------------------------------------------------
 
-def test_tokenise():
-    import litcluster as lc
-    tokens = lc._tokenise('hello world test foo bar')
-    assert isinstance(tokens, list) and len(tokens) > 0
+def test_public_api():
+    assert hasattr(lc, "LitCluster")
+    assert hasattr(lc, "Paper")
+    assert hasattr(lc, "Cluster")
+    assert hasattr(lc, "__version__")
+
+
+# ---------------------------------------------------------------------------
+# _tokenise
+# ---------------------------------------------------------------------------
+
+def test_tokenise_basic():
+    tokens = _tokenise("Machine learning algorithms for text classification")
+    assert "machine" in tokens
+    assert "learning" in tokens
+    assert "classification" in tokens
+
+
+def test_tokenise_stopwords_removed():
+    tokens = _tokenise("the quick brown fox jumps over the lazy dog")
+    assert "the" not in tokens
+    assert "over" not in tokens
+
+
+def test_tokenise_min_length():
+    tokens = _tokenise("a ab abc abcd")
+    # "a" and "ab" are shorter than 3 chars — must be excluded.
+    assert "a" not in tokens
+    assert "ab" not in tokens
+    assert "abc" in tokens
+
+
+def test_tokenise_empty():
+    assert _tokenise("") == []
+    assert _tokenise("a an the") == []
+
+
+# ---------------------------------------------------------------------------
+# _tfidf
+# ---------------------------------------------------------------------------
+
+def test_tfidf_empty():
+    vecs, vocab = _tfidf([])
+    assert vecs == []
+    assert vocab == []
+
+
+def test_tfidf_single_doc():
+    vecs, vocab = _tfidf([["neural", "network", "deep"]])
+    assert len(vecs) == 1
+    assert all(v > 0 for v in vecs[0].values())
+
+
+def test_tfidf_scores_positive():
+    docs = [["neural", "deep", "learning"], ["graph", "network", "node"]]
+    vecs, vocab = _tfidf(docs)
+    for vec in vecs:
+        for score in vec.values():
+            assert score > 0
+
+
+def test_tfidf_rare_term_higher_idf():
+    """A term appearing in only 1 of 3 docs should have higher IDF than a common one."""
+    docs = [
+        ["common", "rare"],
+        ["common", "other"],
+        ["common", "extra"],
+    ]
+    vecs, vocab = _tfidf(docs)
+    # "common" has df=3, "rare" has df=1 → rare should get higher IDF weight.
+    common_idf = math.log((3 + 1) / (3 + 1)) + 1.0
+    rare_idf = math.log((3 + 1) / (1 + 1)) + 1.0
+    assert rare_idf > common_idf
+
+
+# ---------------------------------------------------------------------------
+# _cosine
+# ---------------------------------------------------------------------------
+
+def test_cosine_identical():
+    v = {"a": 1.0, "b": 2.0}
+    assert abs(_cosine(v, v) - 1.0) < 1e-9
+
+
+def test_cosine_orthogonal():
+    a = {"x": 1.0}
+    b = {"y": 1.0}
+    assert _cosine(a, b) == 0.0
+
+
+def test_cosine_empty():
+    assert _cosine({}, {"a": 1.0}) == 0.0
+    assert _cosine({"a": 1.0}, {}) == 0.0
+
+
+def test_cosine_range():
+    a = {"a": 1.0, "b": 0.5}
+    b = {"a": 0.8, "b": 0.6, "c": 0.3}
+    sim = _cosine(a, b)
+    assert 0.0 <= sim <= 1.0
+
+
+# ---------------------------------------------------------------------------
+# _bibtex_field
+# ---------------------------------------------------------------------------
+
+def test_bibtex_field_brace():
+    entry = "@article{key, title = {Learning with Neural Networks}, year = {2024}}"
+    assert _bibtex_field(entry, "title") == "Learning with Neural Networks"
+    assert _bibtex_field(entry, "year") == "2024"
+
+
+def test_bibtex_field_nested_braces():
+    entry = "@article{k, title = {A Study of {Machine} Learning}}"
+    assert _bibtex_field(entry, "title") == "A Study of {Machine} Learning"
+
+
+def test_bibtex_field_quote_delimited():
+    entry = '@article{k, journal = "Nature Methods"}'
+    assert _bibtex_field(entry, "journal") == "Nature Methods"
+
+
+def test_bibtex_field_bare_number():
+    entry = "@article{k, year = 2023, pages = {1--10}}"
+    assert _bibtex_field(entry, "year") == "2023"
+
+
+def test_bibtex_field_missing():
+    entry = "@article{k, title = {Some title}}"
+    assert _bibtex_field(entry, "abstract") == ""
+
+
+def test_bibtex_field_case_insensitive():
+    entry = "@article{k, TITLE = {Upper Case Field}}"
+    assert _bibtex_field(entry, "title") == "Upper Case Field"
+
+
+# ---------------------------------------------------------------------------
+# Paper dataclass
+# ---------------------------------------------------------------------------
+
+def test_paper_text_combines_fields():
+    p = Paper(paper_id="1", title="Deep Learning", abstract="Neural networks", keywords="CNN")
+    assert "Deep Learning" in p.text
+    assert "Neural networks" in p.text
+    assert "CNN" in p.text
+
+
+def test_paper_to_dict_keys():
+    p = Paper(paper_id="42", title="T", abstract="A")
+    d = p.to_dict()
+    assert set(d.keys()) == {"paper_id", "title", "abstract", "authors", "year", "venue", "doi", "keywords"}
+
+
+# ---------------------------------------------------------------------------
+# Cluster dataclass
+# ---------------------------------------------------------------------------
+
+def test_cluster_label():
+    c = Cluster(cluster_id=0, top_terms=["neural", "network", "deep", "learning"])
+    assert "neural" in c.label
+    assert "Cluster 0" in c.label
+
+
+def test_cluster_to_dict():
+    p = Paper(paper_id="1", title="T")
+    c = Cluster(cluster_id=1, papers=[p], top_terms=["foo", "bar"])
+    d = c.to_dict()
+    assert d["cluster_id"] == 1
+    assert d["size"] == 1
+    assert len(d["papers"]) == 1
+
+
+# ---------------------------------------------------------------------------
+# LitCluster.fit — end-to-end
+# ---------------------------------------------------------------------------
+
+def _make_papers():
+    """Return a small synthetic corpus with two clear topic groups."""
+    ml_papers = [
+        Paper(f"ml{i}", f"Deep learning neural network paper {i}",
+              abstract="We train a deep neural network using gradient descent backpropagation.")
+        for i in range(5)
+    ]
+    bio_papers = [
+        Paper(f"bio{i}", f"Gene expression protein biology paper {i}",
+              abstract="We sequence genomes and analyse protein expression in cells.")
+        for i in range(5)
+    ]
+    return ml_papers + bio_papers
+
+
+def test_fit_basic():
+    obj = LitCluster(k=2, min_term_freq=1, seed=0)
+    obj.papers = _make_papers()
+    obj.fit()
+    assert len(obj.clusters) == 2
+    total = sum(len(c.papers) for c in obj.clusters)
+    assert total == 10
+
+
+def test_fit_top_terms():
+    obj = LitCluster(k=2, min_term_freq=1, seed=0)
+    obj.papers = _make_papers()
+    obj.fit()
+    for cluster in obj.clusters:
+        assert len(cluster.top_terms) > 0
+
+
+def test_fit_labels_coverage():
+    obj = LitCluster(k=3, min_term_freq=1, seed=42)
+    obj.papers = _make_papers()
+    obj.fit()
+    labelled = set(obj._labels)
+    assert all(lbl in labelled for lbl in range(len(obj.clusters)))
+
+
+def test_fit_empty_corpus():
+    obj = LitCluster(k=3)
+    obj.fit()
+    assert obj.clusters == []
+
+
+def test_fit_k_clamped(recwarn):
+    """k larger than corpus size should be clamped with a warning."""
+    obj = LitCluster(k=20, min_term_freq=1, seed=0)
+    obj.papers = _make_papers()
+    obj.fit()
+    assert len(obj.clusters) <= 10
+    assert any("reduced" in str(w.message).lower() for w in recwarn.list)
+
+
+def test_fit_returns_self():
+    obj = LitCluster(k=2, min_term_freq=1)
+    obj.papers = _make_papers()
+    result = obj.fit()
+    assert result is obj
+
+
+def test_fit_summary_nonempty():
+    obj = LitCluster(k=2, min_term_freq=1, seed=0)
+    obj.papers = _make_papers()
+    obj.fit()
+    s = obj.summary()
+    assert "10 papers" in s
+    assert "2 clusters" in s
+
+
+# ---------------------------------------------------------------------------
+# LitCluster.from_csv
+# ---------------------------------------------------------------------------
+
+def test_from_csv(tmp_path):
+    csv_file = tmp_path / "papers.csv"
+    rows = [
+        {"paper_id": "1", "title": "Deep learning", "abstract": "Neural nets", "authors": "A", "year": "2020", "venue": "NeurIPS", "doi": "", "keywords": ""},
+        {"paper_id": "2", "title": "Graph networks", "abstract": "Graph theory", "authors": "B", "year": "2021", "venue": "ICML", "doi": "", "keywords": ""},
+    ]
+    with csv_file.open("w", newline="") as fh:
+        writer = csv.DictWriter(fh, fieldnames=rows[0].keys())
+        writer.writeheader()
+        writer.writerows(rows)
+    obj = LitCluster.from_csv(csv_file)
+    assert len(obj.papers) == 2
+    assert obj.papers[0].title == "Deep learning"
+
+
+def test_from_csv_missing_file():
+    with pytest.raises(FileNotFoundError):
+        LitCluster.from_csv(pathlib.Path("/nonexistent/path.csv"))
+
+
+# ---------------------------------------------------------------------------
+# LitCluster.from_jsonl
+# ---------------------------------------------------------------------------
+
+def test_from_jsonl(tmp_path):
+    jsonl_file = tmp_path / "papers.jsonl"
+    records = [
+        {"paper_id": "a", "title": "Neural networks", "abstract": "Deep learning"},
+        {"paper_id": "b", "title": "Protein folding", "abstract": "Biology"},
+    ]
+    with jsonl_file.open("w") as fh:
+        for rec in records:
+            fh.write(json.dumps(rec) + "\n")
+    obj = LitCluster.from_jsonl(jsonl_file)
+    assert len(obj.papers) == 2
+
+
+def test_from_jsonl_skips_blank_lines(tmp_path):
+    jsonl_file = tmp_path / "papers.jsonl"
+    jsonl_file.write_text(
+        '{"paper_id": "1", "title": "Test"}\n\n{"paper_id": "2", "title": "Other"}\n'
+    )
+    obj = LitCluster.from_jsonl(jsonl_file)
+    assert len(obj.papers) == 2
+
+
+def test_from_jsonl_invalid_json(tmp_path):
+    jsonl_file = tmp_path / "bad.jsonl"
+    jsonl_file.write_text('{"title": "ok"}\nnot-valid-json\n')
+    with pytest.raises(ValueError, match="Invalid JSON"):
+        LitCluster.from_jsonl(jsonl_file)
+
+
+# ---------------------------------------------------------------------------
+# LitCluster.from_bibtex
+# ---------------------------------------------------------------------------
+
+_BIBTEX_SAMPLE = textwrap.dedent("""\
+    @article{Smith2020,
+      author  = {John Smith and Jane Doe},
+      title   = {Deep Learning for {Natural} Language Processing},
+      journal = {Journal of Machine Learning},
+      year    = {2020},
+      abstract = {We present a deep neural network for NLP tasks including classification.},
+      keywords = {deep learning, NLP, neural networks},
+      doi     = {10.1234/jml.2020},
+    }
+
+    @inproceedings{Brown2021,
+      author    = {Alice Brown},
+      title     = {Graph Neural Networks: A Survey},
+      booktitle = {International Conference on Machine Learning},
+      year      = {2021},
+      abstract  = {We survey recent advances in graph neural networks.},
+    }
+""")
+
+
+def test_from_bibtex(tmp_path):
+    bib_file = tmp_path / "refs.bib"
+    bib_file.write_text(_BIBTEX_SAMPLE)
+    obj = LitCluster.from_bibtex(bib_file)
+    assert len(obj.papers) == 2
+    paper = obj.papers[0]
+    assert paper.paper_id == "Smith2020"
+    assert "Natural" in paper.title  # nested braces preserved
+    assert paper.authors == "John Smith and Jane Doe"
+    assert paper.year == "2020"
+    assert paper.venue == "Journal of Machine Learning"
+    assert paper.doi == "10.1234/jml.2020"
+
+
+def test_from_bibtex_booktitle_fallback(tmp_path):
+    bib_file = tmp_path / "refs.bib"
+    bib_file.write_text(_BIBTEX_SAMPLE)
+    obj = LitCluster.from_bibtex(bib_file)
+    assert obj.papers[1].venue == "International Conference on Machine Learning"
+
+
+def test_from_bibtex_missing_file():
+    with pytest.raises(FileNotFoundError):
+        LitCluster.from_bibtex(pathlib.Path("/no/such/file.bib"))
+
+
+# ---------------------------------------------------------------------------
+# Export
+# ---------------------------------------------------------------------------
+
+def test_export_csv(tmp_path):
+    obj = LitCluster(k=2, min_term_freq=1, seed=0)
+    obj.papers = _make_papers()
+    obj.fit()
+    out = tmp_path / "out.csv"
+    obj.export_csv(out)
+    assert out.is_file()
+    with out.open() as fh:
+        rows = list(csv.DictReader(fh))
+    assert len(rows) == 10
+    assert "cluster_id" in rows[0]
+    assert "title" in rows[0]
+
+
+def test_export_json(tmp_path):
+    obj = LitCluster(k=2, min_term_freq=1, seed=0)
+    obj.papers = _make_papers()
+    obj.fit()
+    out = tmp_path / "out.json"
+    obj.export_json(out)
+    assert out.is_file()
+    data = json.loads(out.read_text())
+    assert isinstance(data, list)
+    assert len(data) == 2
+    assert "top_terms" in data[0]
+    assert "papers" in data[0]
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def test_cli_summary(tmp_path, capsys):
+    bib_file = tmp_path / "refs.bib"
+    bib_file.write_text(_BIBTEX_SAMPLE)
+    rc = lc.main([str(bib_file), "-k", "2", "--min-freq", "1"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "papers" in out
+
+
+def test_cli_missing_file(capsys):
+    rc = lc.main(["/nonexistent/file.csv"])
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "not found" in err
+
+
+def test_cli_version(capsys):
+    with pytest.raises(SystemExit) as exc_info:
+        lc.main(["--version"])
+    assert exc_info.value.code == 0
+
+
+def test_cli_json_output(tmp_path, capsys):
+    bib_file = tmp_path / "refs.bib"
+    bib_file.write_text(_BIBTEX_SAMPLE)
+    out_file = tmp_path / "out.json"
+    rc = lc.main([str(bib_file), "-k", "2", "--format", "json",
+                  "-o", str(out_file), "--min-freq", "1"])
+    assert rc == 0
+    assert out_file.is_file()
+    data = json.loads(out_file.read_text())
+    assert isinstance(data, list)
+
+
+def test_cli_csv_output(tmp_path, capsys):
+    bib_file = tmp_path / "refs.bib"
+    bib_file.write_text(_BIBTEX_SAMPLE)
+    out_file = tmp_path / "out.csv"
+    rc = lc.main([str(bib_file), "-k", "2", "--format", "csv",
+                  "-o", str(out_file), "--min-freq", "1"])
+    assert rc == 0
+    assert out_file.is_file()
+
+
+# ---------------------------------------------------------------------------
+# LitCluster constructor validation
+# ---------------------------------------------------------------------------
+
+def test_invalid_k():
+    with pytest.raises(ValueError):
+        LitCluster(k=0)
+
+
+def test_invalid_max_iter():
+    with pytest.raises(ValueError):
+        LitCluster(max_iter=0)
+
+
+def test_invalid_min_term_freq():
+    with pytest.raises(ValueError):
+        LitCluster(min_term_freq=0)


### PR DESCRIPTION
## Summary

- **Bug fixes** in `litcluster.py`: missing `_cli` entry-point alias, broken BibTeX parser (now brace-balanced, handles nested LaTeX markup), false-positive k-means early convergence, ambiguous loop variable names, broken `src/litcluster/__init__.py` imports
- **JOSS-level refinements**: expanded stopwords (~80 academic terms), full docstrings with Parameters/Returns, input validation with helpful errors, `--version` flag, k-clamping warning, improved CLI help
- **New `litcluster_gui.py`**: stdlib-only tkinter desktop GUI with file browser, parameter spinboxes, threaded clustering, split-pane cluster/paper explorer, sortable columns, paper detail pop-up, CSV/JSON export, tooltips, keyboard shortcuts
- **Tests**: expanded from 4 → 48 passing tests covering all public API, edge cases, CLI, and BibTeX field extraction
- **Docs**: `paper.md` updated to accurately describe the TF-IDF + k-means implementation (algorithm section with IDF formula); `paper.bib` updated with correct domain references; `README.md` rewritten with install guide, quickstart, CLI reference table, and algorithm overview

## Bug fixes in detail

| Bug | Fix |
|---|---|
| `pyproject.toml` references `litcluster:_cli` but only `main()` existed | Added `_cli = main` alias |
| BibTeX regex `[}",]` stops at first `}` — breaks nested LaTeX like `{Neural}` in titles | Replaced with proper brace-balanced character-by-character parser |
| `labels = [0]*n` sentinel — if all papers land in cluster 0 on iter 1, algorithm terminates falsely | Changed to `labels = [-1]*n` |
| `src/litcluster/__init__.py` imports from non-existent `.cluster` / `.embed` modules | Fixed to re-export from root `litcluster` module |
| JSONL loader gave no context on parse errors | Now reports line number |

## Test plan

- [x] `pytest tests/` — all 48 tests pass in 0.14 s
- [x] CLI smoke test: `python litcluster.py --version`
- [x] GUI import check: `python -c "import litcluster_gui"`

https://claude.ai/code/session_01CNMUgP8CyVUGbTuGUwpVDF

---
_Generated by [Claude Code](https://claude.ai/code/session_01CNMUgP8CyVUGbTuGUwpVDF)_