### PR TITLE
fix: debug and refine to JOSS quality; add Tkinter GUI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,24 @@
+# Python
+__pycache__/
+*.py[cod]
+*.pyo
+*.pyd
+
+# Build / packaging
+*.egg-info/
+dist/
+build/
+*.egg
+*.whl
+
+# Testing / coverage
+.pytest_cache/
+.coverage
+htmlcov/
+
+# Editors / OS
+.DS_Store
+*.swp
+*.swo
+.idea/
+.vscode/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,31 @@
 # Changelog
 
+All notable changes to this project will be documented in this file.
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
 ## [Unreleased]
+
+### Planned
 - BERTopic backend for interpretable topic labels (#1)
-- Semantic Scholar API for bulk paper fetching (#2)
+- Semantic Scholar API integration for bulk paper fetching (#2)
 - Per-cluster LLM-generated summaries (#3)
+- UMAP 2D embedding visualisation
 
 ## [0.1.0] - 2026-04-23
+
 ### Added
-- SPECTER2 sentence-transformer embeddings for scientific literature
-- HDBSCAN, k-means, and agglomerative clustering backends
-- UMAP 2D projection for visualisation
-- Interactive HTML report with cluster explorer
-- BibTeX input support
-- CLI: `litcluster cluster refs.bib`
-- Python API: `LitCluster`, `PaperEmbedder`
+- TF-IDF vectorisation with smoothed IDF weighting
+- k-means clustering (Lloyd's algorithm) with cosine similarity
+- Seeded centroid initialisation for fully reproducible results
+- Input support: BibTeX (`.bib`), CSV, JSON Lines (`.jsonl`)
+- Robust BibTeX parser handling nested braces, quoted fields, and bare numbers
+- Filtering of `@comment`, `@preamble`, and `@string` meta-entries
+- Output formats: plain-text summary, CSV, JSON, interactive HTML report
+- `export_html()` generating a self-contained, zero-dependency report
+- Progress callback parameter on `LitCluster.fit()` for GUI/TUI integration
+- Graphical interface (`gui.py` / `litcluster-gui`) via Tkinter (stdlib)
+- CLI entry point: `litcluster input.bib -k 8 --format html`
+- GUI entry point: `litcluster-gui`
+- Python API: `LitCluster`, `Paper`, `Cluster`
+- Comprehensive test suite (60+ tests covering all public API)
+- JOSS paper (`paper.md`) with accurate description and relevant references

--- a/README.md
+++ b/README.md
@@ -1,1 +1,115 @@
 # litcluster
+
+**Topic-based clustering of scientific literature — pure Python, zero dependencies.**
+
+`litcluster` reads a BibTeX file (or CSV / JSON Lines), clusters papers by topic
+using TF-IDF + k-means, and outputs a plain-text summary, structured CSV/JSON,
+or an interactive HTML report.  A Tkinter GUI is also included.
+
+## Installation
+
+```bash
+pip install litcluster
+```
+
+Python ≥ 3.8, no third-party packages required.
+
+## Quick start
+
+```bash
+# Cluster a BibTeX library exported from Zotero / Mendeley / JabRef
+litcluster refs.bib -k 8 --format html -o report.html
+
+# CSV (columns: paper_id, title, abstract, authors, year, venue, doi, keywords)
+litcluster papers.csv -k 5
+
+# JSON Lines
+litcluster papers.jsonl -k 10 --format json -o clusters.json
+
+# Launch the graphical interface
+litcluster-gui
+```
+
+## Python API
+
+```python
+from pathlib import Path
+from litcluster import LitCluster
+
+lc = LitCluster.from_bibtex(Path("refs.bib"), k=8, min_term_freq=2)
+lc.fit(progress=print)        # optional progress messages
+
+print(lc.summary())
+lc.export_csv(Path("clusters.csv"))
+lc.export_json(Path("clusters.json"))
+lc.export_html(Path("report.html"))   # self-contained HTML report
+```
+
+## CLI reference
+
+```
+litcluster <input> [options]
+
+Positional:
+  input               .bib, .csv, or .jsonl file
+
+Options:
+  -k, --clusters N    Number of clusters          (default: 5)
+  --format FMT        summary | csv | json | html  (default: summary)
+  -o, --output FILE   Output file (auto-named if omitted)
+  --seed N            Random seed                  (default: 42)
+  --max-iter N        K-means iteration cap        (default: 100)
+  --min-freq N        Minimum term document freq   (default: 2)
+```
+
+## Parameters
+
+| Parameter      | Default | Description                                         |
+|----------------|---------|-----------------------------------------------------|
+| `k`            | 5       | Number of clusters                                  |
+| `seed`         | 42      | Random seed for reproducible results                |
+| `max_iter`     | 100     | Maximum k-means iterations                          |
+| `min_term_freq`| 2       | Minimum document frequency for vocabulary inclusion |
+
+## Output formats
+
+| Format    | Flag              | Description                                      |
+|-----------|-------------------|--------------------------------------------------|
+| `summary` | `--format summary`| Human-readable cluster labels (default)          |
+| `csv`     | `--format csv`    | One row per paper with cluster assignment        |
+| `json`    | `--format json`   | Nested cluster → papers structure                |
+| `html`    | `--format html`   | Self-contained interactive report with DOI links |
+
+## How it works
+
+1. **Tokenise** — lowercase, remove English stopwords, discard tokens < 3 chars
+2. **TF-IDF** — compute smoothed TF-IDF vectors (sparse dict representation)
+3. **k-means** — Lloyd's algorithm with cosine similarity, seeded for reproducibility
+4. **Export** — summary text, CSV, JSON, or interactive HTML report
+
+## Graphical interface
+
+```bash
+litcluster-gui       # or: python gui.py
+```
+
+The GUI lets you browse for a file, adjust clustering parameters, view the
+cluster tree and paper details interactively, and export results in any format.
+
+## Citation
+
+If you use `litcluster` in published research, please cite:
+
+```bibtex
+@software{deshmukh2026litcluster,
+  author  = {Deshmukh, Vaibhav},
+  title   = {litcluster: Topic-based clustering of scientific literature},
+  year    = {2026},
+  url     = {https://github.com/vdeshmukh203/litcluster},
+  version = {0.1.0}
+}
+```
+
+## License
+
+MIT © 2026 Vaibhav Deshmukh

--- a/gui.py
+++ b/gui.py
@@ -1,0 +1,460 @@
+#!/usr/bin/env python3
+"""
+gui.py — Graphical interface for litcluster.
+
+Requires Python >= 3.8 with Tkinter (included in most standard distributions).
+Run standalone:  python gui.py
+Or via CLI:      litcluster-gui
+"""
+
+from __future__ import annotations
+
+import threading
+import tkinter as tk
+from pathlib import Path
+from tkinter import filedialog, messagebox, ttk
+
+try:
+    import litcluster as _lc_module
+    from litcluster import LitCluster, Paper
+except ImportError as _e:  # pragma: no cover
+    raise SystemExit(
+        "litcluster not found. "
+        "Install it with: pip install litcluster\n"
+        f"({_e})"
+    ) from _e
+
+
+_VERSION = getattr(_lc_module, "__version__", "0.1.0")
+_SUPPORTED_FILETYPES = [
+    ("All supported", "*.bib *.csv *.jsonl"),
+    ("BibTeX", "*.bib"),
+    ("CSV", "*.csv"),
+    ("JSON Lines", "*.jsonl"),
+    ("All files", "*"),
+]
+
+
+class _App(tk.Tk):
+    """Main application window."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.title("litcluster — Literature Clustering")
+        self.geometry("1100x700")
+        self.minsize(760, 480)
+
+        self._lc: LitCluster | None = None
+        self._input_path: Path | None = None
+
+        self._build_menu()
+        self._build_toolbar()
+        self._build_main_area()
+        self._build_statusbar()
+        self._set_status("Open a BibTeX (.bib), CSV, or JSON Lines (.jsonl) file to begin.")
+
+    # ------------------------------------------------------------------
+    # Menu
+    # ------------------------------------------------------------------
+
+    def _build_menu(self) -> None:
+        mb = tk.Menu(self)
+        self.config(menu=mb)
+
+        file_menu = tk.Menu(mb, tearoff=False)
+        mb.add_cascade(label="File", menu=file_menu)
+        file_menu.add_command(
+            label="Open…", accelerator="Ctrl+O", command=self._browse
+        )
+        file_menu.add_separator()
+        file_menu.add_command(
+            label="Export CSV…", command=lambda: self._export("csv")
+        )
+        file_menu.add_command(
+            label="Export JSON…", command=lambda: self._export("json")
+        )
+        file_menu.add_command(
+            label="Export HTML Report…", command=lambda: self._export("html")
+        )
+        file_menu.add_separator()
+        file_menu.add_command(
+            label="Quit", accelerator="Ctrl+Q", command=self.destroy
+        )
+
+        help_menu = tk.Menu(mb, tearoff=False)
+        mb.add_cascade(label="Help", menu=help_menu)
+        help_menu.add_command(label="About litcluster", command=self._about)
+
+        self.bind("<Control-o>", lambda _e: self._browse())
+        self.bind("<Control-q>", lambda _e: self.destroy())
+
+    # ------------------------------------------------------------------
+    # Toolbar
+    # ------------------------------------------------------------------
+
+    def _build_toolbar(self) -> None:
+        bar = tk.Frame(self, bd=1, relief=tk.GROOVE, bg="#f0f0f0")
+        bar.pack(side=tk.TOP, fill=tk.X, padx=2, pady=(2, 0))
+
+        # File path section
+        tk.Label(bar, text="File:", bg="#f0f0f0").pack(side=tk.LEFT, padx=(6, 2))
+        self._path_var = tk.StringVar(value="(none)")
+        tk.Label(
+            bar, textvariable=self._path_var, anchor="w", width=38,
+            relief=tk.SUNKEN, bg="#ffffff", padx=3,
+        ).pack(side=tk.LEFT, padx=(0, 4))
+        tk.Button(bar, text="Browse…", command=self._browse).pack(side=tk.LEFT, padx=2)
+
+        ttk.Separator(bar, orient=tk.VERTICAL).pack(
+            side=tk.LEFT, fill=tk.Y, padx=8, pady=4
+        )
+
+        # Parameters
+        for label, var_name, default, lo, hi, width in [
+            ("k:", "_k_var",        5,   1, 200,  4),
+            ("Seed:", "_seed_var",  42,  0, 9999, 6),
+            ("Max iter:", "_iter_var", 100, 1, 2000, 5),
+            ("Min freq:", "_freq_var",  2, 1,   20, 4),
+        ]:
+            tk.Label(bar, text=label, bg="#f0f0f0").pack(side=tk.LEFT, padx=(0, 2))
+            var = tk.IntVar(value=default)
+            setattr(self, var_name, var)
+            tk.Spinbox(
+                bar, from_=lo, to=hi, width=width, textvariable=var,
+            ).pack(side=tk.LEFT, padx=(0, 8))
+
+        ttk.Separator(bar, orient=tk.VERTICAL).pack(
+            side=tk.LEFT, fill=tk.Y, padx=4, pady=4
+        )
+
+        # Run button
+        self._run_btn = tk.Button(
+            bar, text="▶  Cluster", command=self._run,
+            bg="#4e79a7", fg="white", padx=10, relief=tk.RAISED,
+        )
+        self._run_btn.pack(side=tk.LEFT, padx=6)
+
+        ttk.Separator(bar, orient=tk.VERTICAL).pack(
+            side=tk.LEFT, fill=tk.Y, padx=8, pady=4
+        )
+
+        # Export buttons
+        for label, fmt in [("CSV", "csv"), ("JSON", "json"), ("HTML", "html")]:
+            tk.Button(
+                bar, text=f"Export {label}",
+                command=lambda f=fmt: self._export(f),
+            ).pack(side=tk.LEFT, padx=2)
+
+    # ------------------------------------------------------------------
+    # Main paned area
+    # ------------------------------------------------------------------
+
+    def _build_main_area(self) -> None:
+        pane = tk.PanedWindow(self, orient=tk.HORIZONTAL, sashrelief=tk.RAISED,
+                              sashwidth=5)
+        pane.pack(fill=tk.BOTH, expand=True, padx=4, pady=4)
+
+        # ---- Left: cluster tree ----
+        left = tk.Frame(pane)
+        pane.add(left, minsize=260, width=360)
+
+        tk.Label(left, text="Clusters", font=("", 11, "bold"), anchor="w").pack(
+            fill=tk.X, padx=6, pady=(4, 2)
+        )
+
+        tree_frame = tk.Frame(left)
+        tree_frame.pack(fill=tk.BOTH, expand=True)
+        tree_frame.rowconfigure(0, weight=1)
+        tree_frame.columnconfigure(0, weight=1)
+
+        self._tree = ttk.Treeview(
+            tree_frame, columns=("details",), show="tree headings", selectmode="browse"
+        )
+        self._tree.heading("#0", text="Name")
+        self._tree.heading("details", text="Details")
+        self._tree.column("#0", width=190, stretch=True)
+        self._tree.column("details", width=150, stretch=True)
+
+        vsb = ttk.Scrollbar(tree_frame, orient="vertical", command=self._tree.yview)
+        hsb = ttk.Scrollbar(tree_frame, orient="horizontal", command=self._tree.xview)
+        self._tree.configure(yscrollcommand=vsb.set, xscrollcommand=hsb.set)
+        self._tree.grid(row=0, column=0, sticky="nsew")
+        vsb.grid(row=0, column=1, sticky="ns")
+        hsb.grid(row=1, column=0, sticky="ew")
+
+        self._tree.tag_configure("cluster", font=("", 10, "bold"))
+        self._tree.tag_configure("paper", font=("", 9))
+        self._tree.bind("<<TreeviewSelect>>", self._on_select)
+
+        # ---- Right: detail panel ----
+        right = tk.Frame(pane)
+        pane.add(right, minsize=380)
+
+        tk.Label(right, text="Details", font=("", 11, "bold"), anchor="w").pack(
+            fill=tk.X, padx=6, pady=(4, 2)
+        )
+
+        detail_frame = tk.Frame(right)
+        detail_frame.pack(fill=tk.BOTH, expand=True)
+
+        self._detail = tk.Text(
+            detail_frame, wrap=tk.WORD, state=tk.DISABLED,
+            bg="#fafafa", relief=tk.FLAT, font=("", 10),
+            padx=8, pady=6,
+        )
+        vsb2 = ttk.Scrollbar(detail_frame, orient="vertical",
+                              command=self._detail.yview)
+        self._detail.configure(yscrollcommand=vsb2.set)
+        self._detail.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
+        vsb2.pack(side=tk.RIGHT, fill=tk.Y)
+
+        # Text tags for formatting
+        self._detail.tag_configure("h1", font=("", 12, "bold"), spacing3=4)
+        self._detail.tag_configure("h2", font=("", 10, "bold"), spacing3=2)
+        self._detail.tag_configure("key", foreground="#555", font=("", 9))
+        self._detail.tag_configure("val", font=("", 9))
+        self._detail.tag_configure("abstract", font=("", 9), spacing1=4,
+                                   foreground="#333")
+
+        # Progress bar (hidden until needed)
+        self._progress = ttk.Progressbar(self, mode="indeterminate")
+
+    # ------------------------------------------------------------------
+    # Status bar
+    # ------------------------------------------------------------------
+
+    def _build_statusbar(self) -> None:
+        bar = tk.Frame(self, bd=1, relief=tk.SUNKEN)
+        bar.pack(side=tk.BOTTOM, fill=tk.X)
+        self._status_var = tk.StringVar()
+        tk.Label(bar, textvariable=self._status_var, anchor="w", padx=6).pack(
+            fill=tk.X
+        )
+
+    # ------------------------------------------------------------------
+    # Actions
+    # ------------------------------------------------------------------
+
+    def _browse(self) -> None:
+        path_str = filedialog.askopenfilename(
+            title="Open literature file",
+            filetypes=_SUPPORTED_FILETYPES,
+        )
+        if not path_str:
+            return
+        self._input_path = Path(path_str)
+        self._path_var.set(str(self._input_path))
+        self._lc = None
+        self._clear_results()
+        self._set_status(
+            f"Loaded: {self._input_path.name} — press ▶ Cluster to run."
+        )
+
+    def _run(self) -> None:
+        if self._input_path is None:
+            messagebox.showwarning("No file", "Please open an input file first.")
+            return
+        self._run_btn.config(state=tk.DISABLED)
+        self._progress.pack(fill=tk.X, padx=4, pady=2, before=self._progress.master)
+        self._progress.start(12)
+        self._clear_results()
+
+        kwargs = dict(
+            k=self._k_var.get(),
+            seed=self._seed_var.get(),
+            max_iter=self._iter_var.get(),
+            min_term_freq=self._freq_var.get(),
+        )
+
+        def _worker() -> None:
+            try:
+                suffix = self._input_path.suffix.lower()
+                if suffix == ".bib":
+                    lc = LitCluster.from_bibtex(self._input_path, **kwargs)
+                elif suffix == ".jsonl":
+                    lc = LitCluster.from_jsonl(self._input_path, **kwargs)
+                else:
+                    lc = LitCluster.from_csv(self._input_path, **kwargs)
+                lc.fit(
+                    progress=lambda s: self.after(
+                        0, lambda msg=s: self._set_status(msg)
+                    )
+                )
+                self.after(0, lambda: self._on_fit_done(lc))
+            except Exception as exc:  # noqa: BLE001
+                self.after(0, lambda: self._on_fit_error(exc))
+
+        threading.Thread(target=_worker, daemon=True).start()
+
+    def _on_fit_done(self, lc: LitCluster) -> None:
+        self._lc = lc
+        self._stop_progress()
+        self._populate_tree()
+        self._set_status(
+            f"Done — {len(lc.papers)} papers clustered "
+            f"into {len(lc.clusters)} groups."
+        )
+
+    def _on_fit_error(self, exc: Exception) -> None:
+        self._stop_progress()
+        self._set_status(f"Error: {exc}")
+        messagebox.showerror("Clustering failed", str(exc))
+
+    def _stop_progress(self) -> None:
+        self._progress.stop()
+        self._progress.pack_forget()
+        self._run_btn.config(state=tk.NORMAL)
+
+    # ------------------------------------------------------------------
+    # Tree population
+    # ------------------------------------------------------------------
+
+    def _populate_tree(self) -> None:
+        self._tree.delete(*self._tree.get_children())
+        if not self._lc:
+            return
+        for cluster in self._lc.clusters:
+            cnode = self._tree.insert(
+                "", "end",
+                iid=f"c_{cluster.cluster_id}",
+                text=f"Cluster {cluster.cluster_id}",
+                values=(
+                    f"{len(cluster.papers)} papers | "
+                    f"{', '.join(cluster.top_terms[:3])}",
+                ),
+                tags=("cluster",),
+                open=True,
+            )
+            for paper in cluster.papers:
+                self._tree.insert(
+                    cnode, "end",
+                    iid=f"p_{paper.paper_id}",
+                    text=(paper.title[:72] or "(no title)"),
+                    values=(f"{paper.year}  {paper.authors[:28]}",),
+                    tags=("paper",),
+                )
+
+    # ------------------------------------------------------------------
+    # Detail panel
+    # ------------------------------------------------------------------
+
+    def _on_select(self, _event=None) -> None:
+        sel = self._tree.selection()
+        if not sel:
+            return
+        item_id = sel[0]
+        self._detail.config(state=tk.NORMAL)
+        self._detail.delete("1.0", tk.END)
+
+        if item_id.startswith("c_") and self._lc:
+            cid = int(item_id[2:])
+            cluster = next(
+                (c for c in self._lc.clusters if c.cluster_id == cid), None
+            )
+            if cluster:
+                self._detail.insert(tk.END, f"Cluster {cid}\n", "h1")
+                self._detail.insert(
+                    tk.END, f"{len(cluster.papers)} papers\n\n", "val"
+                )
+                self._detail.insert(tk.END, "Top terms\n", "h2")
+                self._detail.insert(
+                    tk.END,
+                    "  " + "  ·  ".join(cluster.top_terms) + "\n",
+                    "val",
+                )
+
+        elif item_id.startswith("p_") and self._lc:
+            pid = item_id[2:]
+            paper = next(
+                (p for c in self._lc.clusters for p in c.papers
+                 if p.paper_id == pid),
+                None,
+            )
+            if paper:
+                self._detail.insert(tk.END, (paper.title or "(no title)") + "\n", "h1")
+                for key, val in [
+                    ("Authors", paper.authors),
+                    ("Year", paper.year),
+                    ("Venue", paper.venue),
+                    ("DOI", paper.doi),
+                    ("ID", paper.paper_id),
+                ]:
+                    if val:
+                        self._detail.insert(tk.END, f"{key}: ", "key")
+                        self._detail.insert(tk.END, val + "\n", "val")
+                if paper.abstract:
+                    self._detail.insert(tk.END, "\nAbstract\n", "h2")
+                    self._detail.insert(tk.END, paper.abstract + "\n", "abstract")
+
+        self._detail.config(state=tk.DISABLED)
+
+    # ------------------------------------------------------------------
+    # Export
+    # ------------------------------------------------------------------
+
+    def _export(self, fmt: str) -> None:
+        if not self._lc or not self._lc.clusters:
+            messagebox.showwarning("No results", "Run clustering first.")
+            return
+        ext = {"csv": ".csv", "json": ".json", "html": ".html"}[fmt]
+        ftypes = {
+            "csv": [("CSV files", "*.csv")],
+            "json": [("JSON files", "*.json")],
+            "html": [("HTML files", "*.html")],
+        }[fmt]
+        default = (
+            self._input_path.stem + ".clusters" + ext
+            if self._input_path
+            else f"clusters{ext}"
+        )
+        out = filedialog.asksaveasfilename(
+            title=f"Export {fmt.upper()}",
+            defaultextension=ext,
+            filetypes=ftypes,
+            initialfile=default,
+        )
+        if not out:
+            return
+        out_path = Path(out)
+        try:
+            if fmt == "csv":
+                self._lc.export_csv(out_path)
+            elif fmt == "json":
+                self._lc.export_json(out_path)
+            elif fmt == "html":
+                self._lc.export_html(out_path)
+            self._set_status(f"Exported → {out_path.name}")
+        except Exception as exc:  # noqa: BLE001
+            messagebox.showerror("Export failed", str(exc))
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _clear_results(self) -> None:
+        self._tree.delete(*self._tree.get_children())
+        self._detail.config(state=tk.NORMAL)
+        self._detail.delete("1.0", tk.END)
+        self._detail.config(state=tk.DISABLED)
+
+    def _set_status(self, msg: str) -> None:
+        self._status_var.set(msg)
+
+    def _about(self) -> None:
+        messagebox.showinfo(
+            "About litcluster",
+            f"litcluster v{_VERSION}\n\n"
+            "Topic-based clustering of scientific literature\n"
+            "using TF-IDF + k-means (pure stdlib).\n\n"
+            "© 2026 Vaibhav Deshmukh — MIT License",
+        )
+
+
+def run_gui() -> None:
+    """Launch the litcluster graphical interface."""
+    app = _App()
+    app.mainloop()
+
+
+if __name__ == "__main__":
+    run_gui()

--- a/litcluster.py
+++ b/litcluster.py
@@ -1,8 +1,7 @@
 #!/usr/bin/env python3
 """
-litcluster.py — Literature Clustering Tool
+litcluster — Literature Clustering Tool
 Clusters academic papers by topic using TF-IDF + k-means (pure stdlib).
-Stdlib-only. No external dependencies.
 """
 
 from __future__ import annotations
@@ -15,39 +14,48 @@ import re
 import sys
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple
+from typing import Callable, Dict, List, Optional, Tuple
 
+__version__ = "0.1.0"
+__author__ = "Vaibhav Deshmukh"
+__license__ = "MIT"
 
 # ---------------------------------------------------------------------------
 # Text processing
 # ---------------------------------------------------------------------------
 
 _STOPWORDS = {
-    'a','an','the','and','or','but','in','on','at','to','for','of','with',
-    'by','from','is','was','are','were','be','been','being','have','has',
-    'had','do','does','did','will','would','could','should','may','might',
-    'this','that','these','those','it','its','we','our','they','their',
-    'as','if','not','no','nor','so','yet','both','either','whether',
-    'each','few','more','most','other','some','such','than','too','very',
-    'just','also','only','then','here','there','when','where','who','which',
-    'how','all','any','can','into','through','during','before','after',
-    'above','below','between','out','off','over','under','again','further',
-    'once','i','my','me','he','she','his','her','him','you','your',
+    'a', 'an', 'the', 'and', 'or', 'but', 'in', 'on', 'at', 'to', 'for',
+    'of', 'with', 'by', 'from', 'is', 'was', 'are', 'were', 'be', 'been',
+    'being', 'have', 'has', 'had', 'do', 'does', 'did', 'will', 'would',
+    'could', 'should', 'may', 'might', 'this', 'that', 'these', 'those',
+    'it', 'its', 'we', 'our', 'they', 'their', 'as', 'if', 'not', 'no',
+    'nor', 'so', 'yet', 'both', 'either', 'whether', 'each', 'few', 'more',
+    'most', 'other', 'some', 'such', 'than', 'too', 'very', 'just', 'also',
+    'only', 'then', 'here', 'there', 'when', 'where', 'who', 'which', 'how',
+    'all', 'any', 'can', 'into', 'through', 'during', 'before', 'after',
+    'above', 'below', 'between', 'out', 'off', 'over', 'under', 'again',
+    'further', 'once', 'i', 'my', 'me', 'he', 'she', 'his', 'her', 'him',
+    'you', 'your', 'use', 'used', 'using', 'show', 'shows', 'shown',
+    'present', 'propose', 'paper', 'study', 'results', 'based', 'approach',
+    'method', 'methods', 'new', 'two', 'three', 'one', 'first', 'second',
 }
 
 
 def _tokenise(text: str) -> List[str]:
+    """Lowercase, strip stopwords, keep alphabetic tokens >= 3 chars."""
     tokens = re.findall(r"[a-zA-Z]{3,}", text.lower())
     return [t for t in tokens if t not in _STOPWORDS]
 
 
-def _tfidf(documents: List[List[str]]) -> Tuple[List[Dict[str,float]], List[str]]:
-    """Compute TF-IDF vectors. Returns (vectors, vocab)."""
+def _tfidf(
+    documents: List[List[str]],
+) -> Tuple[List[Dict[str, float]], List[str]]:
+    """Compute smoothed TF-IDF vectors (sparse dicts). Returns (vectors, vocab)."""
     n = len(documents)
     if n == 0:
         return [], []
 
-    # Build vocab
     vocab_set: set = set()
     for doc in documents:
         vocab_set.update(doc)
@@ -55,15 +63,12 @@ def _tfidf(documents: List[List[str]]) -> Tuple[List[Dict[str,float]], List[str]
     term_idx = {t: i for i, t in enumerate(vocab)}
     V = len(vocab)
 
-    # Document frequency
     df = [0] * V
     for doc in documents:
-        doc_set = set(doc)
-        for t in doc_set:
+        for t in set(doc):
             if t in term_idx:
                 df[term_idx[t]] += 1
 
-    # TF-IDF
     vectors: List[Dict[str, float]] = []
     for doc in documents:
         tf: Dict[int, int] = {}
@@ -83,10 +88,13 @@ def _tfidf(documents: List[List[str]]) -> Tuple[List[Dict[str,float]], List[str]
 
 
 def _cosine(a: Dict[str, float], b: Dict[str, float]) -> float:
-    dot = sum(a.get(t, 0.0) * b.get(t, 0.0) for t in b)
-    norm_a = math.sqrt(sum(v*v for v in a.values()))
-    norm_b = math.sqrt(sum(v*v for v in b.values()))
-    if norm_a == 0 or norm_b == 0:
+    """Cosine similarity between two sparse TF-IDF vectors."""
+    if not a or not b:
+        return 0.0
+    dot = sum(a.get(t, 0.0) * v for t, v in b.items())
+    norm_a = math.sqrt(sum(v * v for v in a.values()))
+    norm_b = math.sqrt(sum(v * v for v in b.values()))
+    if norm_a == 0.0 or norm_b == 0.0:
         return 0.0
     return dot / (norm_a * norm_b)
 
@@ -97,44 +105,71 @@ def _kmeans(
     max_iter: int = 100,
     seed: int = 42,
 ) -> List[int]:
-    """Lloyd's k-means on sparse TF-IDF vectors."""
+    """Lloyd's k-means on sparse TF-IDF vectors (cosine similarity)."""
     n = len(vectors)
     if n == 0:
         return []
     k = min(k, n)
 
-    # Seeded centroid initialisation (evenly spaced)
     import random
     rng = random.Random(seed)
     centroid_indices = rng.sample(range(n), k)
     centroids = [dict(vectors[i]) for i in centroid_indices]
-    labels = [0] * n
+    labels: List[int] = [-1] * n  # sentinel so first iteration always runs
 
     for _ in range(max_iter):
-        # Assignment
-        new_labels = []
-        for vec in vectors:
-            best = max(range(k), key=lambda c: _cosine(vec, centroids[c]))
-            new_labels.append(best)
-
+        new_labels = [
+            max(range(k), key=lambda c: _cosine(vec, centroids[c]))
+            for vec in vectors
+        ]
         if new_labels == labels:
             break
         labels = new_labels
 
-        # Update centroids
         for c in range(k):
-            members = [vectors[i] for i, l in enumerate(labels) if l == c]
+            members = [vectors[i] for i, lbl in enumerate(labels) if lbl == c]
             if not members:
-                centroids[c] = dict(vectors[rng.randint(0, n-1)])
+                centroids[c] = dict(vectors[rng.randint(0, n - 1)])
                 continue
             new_centroid: Dict[str, float] = {}
             for vec in members:
                 for t, v in vec.items():
                     new_centroid[t] = new_centroid.get(t, 0.0) + v
-            total = len(members)
-            centroids[c] = {t: v/total for t, v in new_centroid.items()}
+            m = len(members)
+            centroids[c] = {t: v / m for t, v in new_centroid.items()}
 
     return labels
+
+
+# ---------------------------------------------------------------------------
+# BibTeX field extraction
+# ---------------------------------------------------------------------------
+
+_BIBTEX_NON_PAPER_TYPES = frozenset({"comment", "preamble", "string"})
+
+
+def _parse_bibtex_field(entry: str, field_name: str) -> str:
+    """Extract a BibTeX field value, correctly handling nested braces and quotes."""
+    pattern = re.compile(rf"(?i)\b{re.escape(field_name)}\s*=\s*")
+    m = pattern.search(entry)
+    if not m:
+        return ""
+    rest = entry[m.end():].lstrip()
+    if rest.startswith("{"):
+        depth = 0
+        for i, ch in enumerate(rest):
+            if ch == "{":
+                depth += 1
+            elif ch == "}":
+                depth -= 1
+                if depth == 0:
+                    return rest[1:i].strip()
+        return rest[1:].strip()
+    if rest.startswith('"'):
+        end = rest.find('"', 1)
+        return rest[1:end].strip() if end != -1 else rest[1:].strip()
+    m2 = re.match(r"[\w./-]+", rest)
+    return m2.group() if m2 else ""
 
 
 # ---------------------------------------------------------------------------
@@ -143,6 +178,8 @@ def _kmeans(
 
 @dataclass
 class Paper:
+    """Metadata for a single academic paper."""
+
     paper_id: str
     title: str
     abstract: str = ""
@@ -154,25 +191,37 @@ class Paper:
 
     @property
     def text(self) -> str:
+        """Concatenated text used for vectorisation."""
         return f"{self.title} {self.abstract} {self.keywords}"
 
     def to_dict(self) -> dict:
         return {
-            "paper_id": self.paper_id, "title": self.title, "abstract": self.abstract,
-            "authors": self.authors, "year": self.year, "venue": self.venue,
-            "doi": self.doi, "keywords": self.keywords,
+            "paper_id": self.paper_id,
+            "title": self.title,
+            "abstract": self.abstract,
+            "authors": self.authors,
+            "year": self.year,
+            "venue": self.venue,
+            "doi": self.doi,
+            "keywords": self.keywords,
         }
+
+    def __repr__(self) -> str:
+        return f"Paper(id={self.paper_id!r}, title={self.title[:50]!r})"
 
 
 @dataclass
 class Cluster:
+    """A topic cluster containing a group of papers."""
+
     cluster_id: int
     papers: List[Paper] = field(default_factory=list)
     top_terms: List[str] = field(default_factory=list)
 
     @property
     def label(self) -> str:
-        return f"Cluster {self.cluster_id}: {', '.join(self.top_terms[:3])}"
+        terms = ", ".join(self.top_terms[:3]) if self.top_terms else "—"
+        return f"Cluster {self.cluster_id}: {terms}"
 
     def to_dict(self) -> dict:
         return {
@@ -183,14 +232,46 @@ class Cluster:
             "papers": [p.to_dict() for p in self.papers],
         }
 
+    def __repr__(self) -> str:
+        return (
+            f"Cluster(id={self.cluster_id}, "
+            f"size={len(self.papers)}, "
+            f"terms={self.top_terms[:3]})"
+        )
+
 
 # ---------------------------------------------------------------------------
 # LitCluster
 # ---------------------------------------------------------------------------
 
 class LitCluster:
-    def __init__(self, k: int = 5, max_iter: int = 100, seed: int = 42,
-                 min_term_freq: int = 2):
+    """Cluster academic papers by topic using TF-IDF + k-means.
+
+    Parameters
+    ----------
+    k:
+        Number of clusters.
+    max_iter:
+        Maximum k-means iterations.
+    seed:
+        Random seed for reproducible centroid initialisation.
+    min_term_freq:
+        Minimum document frequency for a term to be included in the vocabulary.
+    """
+
+    def __init__(
+        self,
+        k: int = 5,
+        max_iter: int = 100,
+        seed: int = 42,
+        min_term_freq: int = 2,
+    ) -> None:
+        if k < 1:
+            raise ValueError(f"k must be >= 1, got {k}")
+        if max_iter < 1:
+            raise ValueError(f"max_iter must be >= 1, got {max_iter}")
+        if min_term_freq < 1:
+            raise ValueError(f"min_term_freq must be >= 1, got {min_term_freq}")
         self.k = k
         self.max_iter = max_iter
         self.seed = seed
@@ -201,14 +282,43 @@ class LitCluster:
         self._vectors: List[Dict[str, float]] = []
         self._vocab: List[str] = []
 
+    # ------------------------------------------------------------------
+    # Paper management
+    # ------------------------------------------------------------------
+
+    def clear(self) -> "LitCluster":
+        """Remove all loaded papers and reset cluster state."""
+        self.papers.clear()
+        self.clusters.clear()
+        self._labels.clear()
+        self._vectors.clear()
+        self._vocab.clear()
+        return self
+
+    def add_paper(self, paper: Paper) -> "LitCluster":
+        """Add a single :class:`Paper` and invalidate prior cluster state."""
+        self.papers.append(paper)
+        self.clusters.clear()
+        return self
+
+    # ------------------------------------------------------------------
+    # Loaders
+    # ------------------------------------------------------------------
+
     @classmethod
     def from_csv(cls, path: Path, **kwargs) -> "LitCluster":
+        """Load papers from a CSV file (header row required).
+
+        Expected columns: ``paper_id``, ``title``, ``abstract``, ``authors``,
+        ``year``, ``venue``, ``doi``, ``keywords``.  Unknown columns are ignored;
+        missing columns default to empty strings.
+        """
         obj = cls(**kwargs)
         with path.open(encoding="utf-8", errors="replace", newline="") as fh:
             reader = csv.DictReader(fh)
             for i, row in enumerate(reader):
                 obj.papers.append(Paper(
-                    paper_id=row.get("paper_id", str(i)),
+                    paper_id=row.get("paper_id") or str(i),
                     title=row.get("title", ""),
                     abstract=row.get("abstract", ""),
                     authors=row.get("authors", ""),
@@ -221,6 +331,7 @@ class LitCluster:
 
     @classmethod
     def from_jsonl(cls, path: Path, **kwargs) -> "LitCluster":
+        """Load papers from a JSON Lines file (one JSON object per line)."""
         obj = cls(**kwargs)
         with path.open(encoding="utf-8") as fh:
             for i, line in enumerate(fh):
@@ -229,7 +340,7 @@ class LitCluster:
                     continue
                 row = json.loads(line)
                 obj.papers.append(Paper(
-                    paper_id=row.get("paper_id", str(i)),
+                    paper_id=row.get("paper_id") or str(i),
                     title=row.get("title", ""),
                     abstract=row.get("abstract", ""),
                     authors=row.get("authors", ""),
@@ -242,56 +353,120 @@ class LitCluster:
 
     @classmethod
     def from_bibtex(cls, path: Path, **kwargs) -> "LitCluster":
-        """Parse a BibTeX file for titles, abstracts, keywords."""
+        """Parse a BibTeX file and load paper entries.
+
+        Handles ``{brace}`` and ``"quote"`` field delimiters as well as nested
+        braces (common in titles with protected case).  Skips ``@comment``,
+        ``@preamble``, and ``@string`` meta-entries.
+        """
         obj = cls(**kwargs)
         text = path.read_text(encoding="utf-8", errors="replace")
-        entries = re.split(r'(?=@\w+\s*\{)', text)
+        entries = re.split(r"(?=@\w+\s*\{)", text)
         for i, entry in enumerate(entries):
-            if not entry.strip() or not entry.startswith('@'):
+            entry = entry.strip()
+            if not entry or not entry.startswith("@"):
                 continue
-            def _get(field):
-                m = re.search(rf'{field}\s*=\s*[{{"](.*?)[}}"\,]', entry, re.IGNORECASE | re.DOTALL)
-                return m.group(1).strip() if m else ""
-            m_key = re.match(r'@\w+\s*\{\s*(\S+?)[,}]', entry)
+            m_type = re.match(r"@(\w+)", entry)
+            if m_type and m_type.group(1).lower() in _BIBTEX_NON_PAPER_TYPES:
+                continue
+            m_key = re.match(r"@\w+\s*\{\s*(\S+?)\s*[,}]", entry)
             key = m_key.group(1) if m_key else str(i)
             obj.papers.append(Paper(
-                paper_id=key, title=_get('title'), abstract=_get('abstract'),
-                authors=_get('author'), year=_get('year'),
-                venue=_get('journal') or _get('booktitle'),
-                doi=_get('doi'), keywords=_get('keywords'),
+                paper_id=key,
+                title=_parse_bibtex_field(entry, "title"),
+                abstract=_parse_bibtex_field(entry, "abstract"),
+                authors=_parse_bibtex_field(entry, "author"),
+                year=_parse_bibtex_field(entry, "year"),
+                venue=(
+                    _parse_bibtex_field(entry, "journal")
+                    or _parse_bibtex_field(entry, "booktitle")
+                ),
+                doi=_parse_bibtex_field(entry, "doi"),
+                keywords=_parse_bibtex_field(entry, "keywords"),
             ))
         return obj
 
-    def fit(self) -> "LitCluster":
+    # ------------------------------------------------------------------
+    # Fitting
+    # ------------------------------------------------------------------
+
+    def fit(
+        self,
+        progress: Optional[Callable[[str], None]] = None,
+    ) -> "LitCluster":
+        """Tokenise, vectorise, and cluster the loaded papers.
+
+        Parameters
+        ----------
+        progress:
+            Optional callback that receives human-readable status messages
+            during fitting (useful for GUI progress indicators).
+
+        Raises
+        ------
+        ValueError
+            If no papers have been loaded.
+        """
         if not self.papers:
-            return self
+            raise ValueError(
+                "No papers loaded. Call from_csv(), from_jsonl(), or "
+                "from_bibtex() before fit()."
+            )
+
+        def _msg(s: str) -> None:
+            if progress:
+                progress(s)
+
+        _msg(f"Tokenising {len(self.papers)} papers…")
         tokens_list = [_tokenise(p.text) for p in self.papers]
 
-        # Filter rare terms
         if self.min_term_freq > 1:
+            _msg("Filtering rare terms…")
             freq: Dict[str, int] = {}
             for tokens in tokens_list:
                 for t in set(tokens):
                     freq[t] = freq.get(t, 0) + 1
-            tokens_list = [[t for t in tokens if freq.get(t, 0) >= self.min_term_freq]
-                           for tokens in tokens_list]
+            tokens_list = [
+                [t for t in toks if freq.get(t, 0) >= self.min_term_freq]
+                for toks in tokens_list
+            ]
 
+        _msg("Computing TF-IDF vectors…")
         self._vectors, self._vocab = _tfidf(tokens_list)
-        self._labels = _kmeans(self._vectors, self.k, self.max_iter, self.seed)
 
-        # Build cluster objects
-        clusters: Dict[int, List] = {}
-        for paper, label in zip(self.papers, self._labels):
-            clusters.setdefault(label, []).append(paper)
+        effective_k = min(self.k, len(self.papers))
+        if effective_k < self.k:
+            _msg(
+                f"Warning: k capped at {effective_k} "
+                f"(fewer papers than requested clusters)."
+            )
 
-        self.clusters = []
-        for cid in sorted(clusters):
-            top_terms = self._top_terms_for_cluster(cid, n=10)
-            self.clusters.append(Cluster(cluster_id=cid, papers=clusters[cid], top_terms=top_terms))
+        _msg(f"Running k-means (k={effective_k}, max_iter={self.max_iter})…")
+        self._labels = _kmeans(
+            self._vectors, effective_k, self.max_iter, self.seed
+        )
+
+        cluster_map: Dict[int, List[Paper]] = {}
+        for paper, lbl in zip(self.papers, self._labels):
+            cluster_map.setdefault(lbl, []).append(paper)
+
+        self.clusters = [
+            Cluster(
+                cluster_id=cid,
+                papers=cluster_map[cid],
+                top_terms=self._top_terms_for_cluster(cid),
+            )
+            for cid in sorted(cluster_map)
+        ]
+        _msg(f"Done — {len(self.clusters)} clusters formed.")
         return self
 
     def _top_terms_for_cluster(self, cid: int, n: int = 10) -> List[str]:
-        member_vecs = [self._vectors[i] for i, l in enumerate(self._labels) if l == cid]
+        member_vecs = [
+            self._vectors[i]
+            for i, lbl in enumerate(self._labels)
+            if lbl == cid
+        ]
         if not member_vecs:
             return []
         scores: Dict[str, float] = {}
@@ -300,23 +475,139 @@ class LitCluster:
                 scores[t] = scores.get(t, 0.0) + v
         return sorted(scores, key=lambda t: -scores[t])[:n]
 
+    # ------------------------------------------------------------------
+    # Exporters
+    # ------------------------------------------------------------------
+
     def export_csv(self, path: Path) -> None:
+        """Write cluster assignments to a CSV file."""
         with path.open("w", newline="", encoding="utf-8") as fh:
             w = csv.writer(fh)
-            w.writerow(["cluster_id","cluster_label","paper_id","title","authors","year","venue","doi"])
+            w.writerow([
+                "cluster_id", "cluster_label", "paper_id",
+                "title", "authors", "year", "venue", "doi",
+            ])
             for cluster in self.clusters:
                 for p in cluster.papers:
-                    w.writerow([cluster.cluster_id, cluster.label, p.paper_id,
-                                p.title, p.authors, p.year, p.venue, p.doi])
+                    w.writerow([
+                        cluster.cluster_id, cluster.label, p.paper_id,
+                        p.title, p.authors, p.year, p.venue, p.doi,
+                    ])
 
     def export_json(self, path: Path) -> None:
+        """Write clusters and paper metadata to a JSON file."""
         with path.open("w", encoding="utf-8") as fh:
-            json.dump([c.to_dict() for c in self.clusters], fh, indent=2, ensure_ascii=False)
+            json.dump(
+                [c.to_dict() for c in self.clusters],
+                fh,
+                indent=2,
+                ensure_ascii=False,
+            )
+
+    def export_html(self, path: Path) -> None:
+        """Generate a self-contained HTML report of cluster results."""
+        _COLOURS = [
+            "#4e79a7", "#f28e2b", "#e15759", "#76b7b2", "#59a14f",
+            "#edc948", "#b07aa1", "#ff9da7", "#9c755f", "#bab0ac",
+        ]
+        cluster_html = ""
+        for c in self.clusters:
+            colour = _COLOURS[c.cluster_id % len(_COLOURS)]
+            terms_html = " ".join(
+                f'<span class="tag">{t}</span>' for t in c.top_terms
+            )
+            paper_rows = ""
+            for p in c.papers:
+                doi_link = (
+                    f'<a href="https://doi.org/{p.doi}" target="_blank">'
+                    f"{p.doi}</a>"
+                    if p.doi
+                    else "—"
+                )
+                paper_rows += (
+                    f"<tr>"
+                    f"<td>{p.paper_id}</td>"
+                    f"<td>{p.title}</td>"
+                    f"<td>{p.authors}</td>"
+                    f"<td>{p.year}</td>"
+                    f"<td>{p.venue}</td>"
+                    f"<td>{doi_link}</td>"
+                    f"</tr>\n"
+                )
+            cluster_html += f"""
+<details open>
+  <summary style="background:{colour}">
+    <strong>Cluster {c.cluster_id}</strong>
+    &mdash; {len(c.papers)} papers
+    &mdash; {terms_html}
+  </summary>
+  <table>
+    <thead><tr>
+      <th>ID</th><th>Title</th><th>Authors</th>
+      <th>Year</th><th>Venue</th><th>DOI</th>
+    </tr></thead>
+    <tbody>{paper_rows}</tbody>
+  </table>
+</details>
+"""
+        html = f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>litcluster Report</title>
+<style>
+  body {{
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    max-width: 1200px; margin: 2rem auto; padding: 0 1.5rem;
+    color: #222; background: #fff;
+  }}
+  h1 {{ color: #333; margin-bottom: .25rem; }}
+  .meta {{ color: #666; margin-bottom: 1.5rem; }}
+  details {{ margin-bottom: 1rem; border: 1px solid #ddd; border-radius: 6px;
+             overflow: hidden; }}
+  summary {{
+    list-style: none; padding: 10px 14px; cursor: pointer;
+    color: #fff; user-select: none;
+  }}
+  summary::-webkit-details-marker {{ display: none; }}
+  table {{ width: 100%; border-collapse: collapse; }}
+  th, td {{
+    text-align: left; padding: 7px 12px;
+    border-bottom: 1px solid #eee; font-size: .88em;
+  }}
+  th {{ background: #f8f8f8; font-weight: 600; }}
+  tr:last-child td {{ border-bottom: none; }}
+  .tag {{
+    display: inline-block; background: rgba(255,255,255,.25);
+    border-radius: 3px; padding: 1px 6px; font-size: .82em;
+    margin-right: 3px;
+  }}
+  a {{ color: #4e79a7; }}
+</style>
+</head>
+<body>
+<h1>litcluster Report</h1>
+<p class="meta">
+  {len(self.papers)} papers &middot; {len(self.clusters)} clusters
+  &middot; generated by litcluster {__version__}
+</p>
+{cluster_html}
+</body>
+</html>
+"""
+        path.write_text(html, encoding="utf-8")
 
     def summary(self) -> str:
-        lines = [f"LitCluster: {len(self.papers)} papers in {len(self.clusters)} clusters", ""]
+        """Return a human-readable text summary of the clustering."""
+        lines = [
+            f"LitCluster: {len(self.papers)} papers "
+            f"→ {len(self.clusters)} clusters",
+            "",
+        ]
         for c in self.clusters:
-            lines.append(f"  [{c.cluster_id}] {c.label} ({len(c.papers)} papers)")
+            lines.append(
+                f"  [{c.cluster_id:2d}]  {c.label}  ({len(c.papers)} papers)"
+            )
         return "\n".join(lines)
 
 
@@ -325,17 +616,33 @@ class LitCluster:
 # ---------------------------------------------------------------------------
 
 def _parse_args(argv=None):
-    p = argparse.ArgumentParser(prog="litcluster",
-                                description="Cluster academic papers by topic using TF-IDF + k-means.")
-    p.add_argument("input", help="Input file: CSV, JSONL, or .bib")
-    p.add_argument("-k", "--clusters", type=int, default=5, dest="k",
-                   help="Number of clusters (default: 5)")
-    p.add_argument("--format", choices=["csv","json","summary"], default="summary")
-    p.add_argument("--output", "-o", default=None, help="Output file (default: stdout/auto)")
-    p.add_argument("--seed", type=int, default=42)
-    p.add_argument("--max-iter", type=int, default=100)
-    p.add_argument("--min-freq", type=int, default=2,
-                   help="Minimum term frequency to include in vocabulary (default: 2)")
+    p = argparse.ArgumentParser(
+        prog="litcluster",
+        description="Cluster academic papers by topic using TF-IDF + k-means.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    p.add_argument("input", help="Input file (.bib, .csv, or .jsonl)")
+    p.add_argument(
+        "-k", "--clusters",
+        type=int, default=5, dest="k",
+        help="Number of clusters",
+    )
+    p.add_argument(
+        "--format",
+        choices=["csv", "json", "html", "summary"],
+        default="summary",
+        help="Output format",
+    )
+    p.add_argument(
+        "--output", "-o", default=None,
+        help="Output file path (auto-named next to input if omitted)",
+    )
+    p.add_argument("--seed", type=int, default=42, help="Random seed")
+    p.add_argument("--max-iter", type=int, default=100, help="K-means iteration cap")
+    p.add_argument(
+        "--min-freq", type=int, default=2,
+        help="Minimum document frequency for vocabulary inclusion",
+    )
     return p.parse_args(argv)
 
 
@@ -343,11 +650,17 @@ def main(argv=None) -> int:
     args = _parse_args(argv)
     path = Path(args.input)
     if not path.is_file():
-        print(f"Error: {path} not found", file=sys.stderr)
+        print(f"Error: '{path}' not found.", file=sys.stderr)
         return 1
 
     suffix = path.suffix.lower()
-    kwargs = dict(k=args.k, max_iter=args.max_iter, seed=args.seed, min_term_freq=args.min_freq)
+    kwargs = dict(
+        k=args.k,
+        max_iter=args.max_iter,
+        seed=args.seed,
+        min_term_freq=args.min_freq,
+    )
+
     if suffix == ".bib":
         lc = LitCluster.from_bibtex(path, **kwargs)
     elif suffix == ".jsonl":
@@ -355,7 +668,7 @@ def main(argv=None) -> int:
     else:
         lc = LitCluster.from_csv(path, **kwargs)
 
-    lc.fit()
+    lc.fit(progress=lambda s: print(s, file=sys.stderr))
 
     if args.format == "summary":
         output = lc.summary()
@@ -371,6 +684,10 @@ def main(argv=None) -> int:
         out = Path(args.output) if args.output else path.with_suffix(".clusters.json")
         lc.export_json(out)
         print(f"Clusters written to {out}")
+    elif args.format == "html":
+        out = Path(args.output) if args.output else path.with_suffix(".clusters.html")
+        lc.export_html(out)
+        print(f"Report written to {out}")
 
     return 0
 

--- a/paper.bib
+++ b/paper.bib
@@ -1,9 +1,31 @@
-@misc{nist2015sha,
-  author       = {{National Institute of Standards and Technology}},
-  title        = {{FIPS PUB 180-4: Secure Hash Standard (SHS)}},
-  year         = {2015},
-  howpublished = {\url{https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf}},
-  institution  = {National Institute of Standards and Technology}
+@article{salton1988term,
+  author  = {Salton, Gerard and Buckley, Christopher},
+  title   = {Term-weighting approaches in automatic text retrieval},
+  journal = {Information Processing \& Management},
+  volume  = {24},
+  number  = {5},
+  pages   = {513--523},
+  year    = {1988},
+  doi     = {10.1016/0306-4573(88)90021-0}
+}
+
+@article{lloyd1982least,
+  author  = {Lloyd, Stuart P.},
+  title   = {Least squares quantization in {PCM}},
+  journal = {IEEE Transactions on Information Theory},
+  volume  = {28},
+  number  = {2},
+  pages   = {129--137},
+  year    = {1982},
+  doi     = {10.1109/TIT.1982.1056489}
+}
+
+@book{manning2008introduction,
+  author    = {Manning, Christopher D. and Raghavan, Prabhakar and Sch{\"u}tze, Hinrich},
+  title     = {Introduction to Information Retrieval},
+  publisher = {Cambridge University Press},
+  year      = {2008},
+  doi       = {10.1017/CBO9780511809071}
 }
 
 @article{gundersen2018state,
@@ -17,7 +39,7 @@
 
 @article{pineau2021improving,
   author  = {Pineau, Joelle and Vincent-Lamarre, Philippe and Sinha, Koustuv and
-             Lariviere, Vincent and Beygelzimer, Alina and d'Alche-Buc, Florence and
+             Lariviere, Vincent and Beygelzimer, Alina and d'Alch{\'e}-Buc, Florence and
              Fox, Emily and Larochelle, Hugo},
   title   = {Improving Reproducibility in Machine Learning Research},
   journal = {Journal of Machine Learning Research},
@@ -27,86 +49,33 @@
   year    = {2021}
 }
 
-@article{stodden2016enhancing,
-  author  = {Stodden, Victoria and McNutt, Marcia and Bailey, David H. and Deelman, Ewa and
-             Gil, Yolanda and Hanson, Brooks and Heroux, Michael A. and Ioannidis, John P. A. and
-             Taufer, Michela},
-  title   = {Enhancing Reproducibility for Computational Methods},
-  journal = {Science},
-  volume  = {354},
-  number  = {6317},
-  pages   = {1240--1241},
-  year    = {2016},
-  doi     = {10.1126/science.aah6168}
-}
-
-@article{gebru2021datasheets,
-  author  = {Gebru, Timnit and Morgenstern, Jamie and Vecchione, Briana and
-             Vaughan, Jennifer Wortman and Wallach, Hanna and Daume, Hal and Crawford, Kate},
-  title   = {Datasheets for Datasets},
-  journal = {Communications of the ACM},
-  volume  = {64},
-  number  = {12},
-  pages   = {86--92},
+@article{page2021prisma,
+  author  = {Page, Matthew J. and McKenzie, Joanne E. and Bossuyt, Patrick M. and
+             Boutron, Isabelle and Hoffmann, Tammy C. and Mulrow, Cynthia D. and
+             Shamseer, Larissa and Tetzlaff, Jennifer M. and Akl, Elie A. and
+             Brennan, Sue E. and others},
+  title   = {The {PRISMA} 2020 statement: an updated guideline for reporting systematic reviews},
+  journal = {BMJ},
+  volume  = {372},
+  pages   = {n71},
   year    = {2021},
-  doi     = {10.1145/3458723}
+  doi     = {10.1136/bmj.n71}
 }
 
-@article{adadi2018peeking,
-  author  = {Adadi, Amina and Berrada, Mohammed},
-  title   = {Peeking Inside the Black-Box: A Survey on Explainable Artificial Intelligence (XAI)},
-  journal = {IEEE Access},
-  volume  = {6},
-  pages   = {52138--52160},
-  year    = {2018},
-  doi     = {10.1109/ACCESS.2018.2870052}
+@article{blei2003latent,
+  author  = {Blei, David M. and Ng, Andrew Y. and Jordan, Michael I.},
+  title   = {Latent {Dirichlet} Allocation},
+  journal = {Journal of Machine Learning Research},
+  volume  = {3},
+  pages   = {993--1022},
+  year    = {2003}
 }
 
-@article{wei2022chain,
-  author  = {Wei, Jason and Wang, Xuezhi and Schuurmans, Dale and Bosma, Maarten and
-             Ichter, Brian and Xia, Fei and Chi, Ed and Le, Quoc and Zhou, Denny},
-  title   = {Chain-of-Thought Prompting Elicits Reasoning in Large Language Models},
-  journal = {Advances in Neural Information Processing Systems},
-  volume  = {35},
-  pages   = {24824--24837},
-  year    = {2022}
-}
-
-@article{kung2023chatgpt,
-  author  = {Kung, Tiffany H. and Cheatham, Morgan and Medenilla, Ariel and Sillos, Czarina and
-             De Leon, Lorie and Elepano, Camille and Madriaga, Maria and Aggabao, Rimel and
-             Diaz-Candido, Gerdine and Maningo, James and Tseng, Victor},
-  title   = {Performance of ChatGPT on USMLE: Potential for AI-Assisted Medical Education
-             Using Large Language Models},
-  journal = {PLOS Digital Health},
-  volume  = {2},
-  number  = {2},
-  pages   = {e0000198},
-  year    = {2023},
-  doi     = {10.1371/journal.pdig.0000198}
-}
-
-@article{gao2023reproducibility,
-  author  = {Gao, Luyu and Biderman, Stella and Black, Sid and Golding, Laurence and Hoppe, Travis and
-             Foster, Charles and Phang, Jason and He, Horace and Thite, Anish and Nabeshima, Noa and
-             Presser, Shawn and Leahy, Connor},
-  title   = {The Pile: An 800GB Dataset of Diverse Text for Language Modeling},
-  journal = {arXiv preprint arXiv:2101.00027},
-  year    = {2023}
-}
-
-@article{perez2022ignore,
-  author  = {Perez, Fabio and Ribeiro, Ian},
-  title   = {Ignore Previous Prompt: Attack Techniques For Language Models},
-  journal = {arXiv preprint arXiv:2211.09527},
-  year    = {2022}
-}
-
-@article{greshake2023not,
-  author  = {Greshake, Kai and Abdelnabi, Sahar and Mishra, Shailesh and Endres, Christoph and
-             Holz, Thorsten and Fritz, Mario},
-  title   = {Not What You've Signed Up For: Compromising Real-World LLM-Integrated Applications
-             with Indirect Prompt Injection},
-  journal = {arXiv preprint arXiv:2302.12173},
-  year    = {2023}
+@article{cohan2020specter,
+  author  = {Cohan, Arman and Feldman, Sergey and Beltagy, Iz and Downey, Doug and Weld, Daniel S.},
+  title   = {{SPECTER}: Document-level Representation Learning using Citation-informed Transformers},
+  journal = {Proceedings of the 58th Annual Meeting of the Association for Computational Linguistics},
+  pages   = {2270--2282},
+  year    = {2020},
+  doi     = {10.18653/v1/2020.acl-main.207}
 }

--- a/paper.md
+++ b/paper.md
@@ -1,5 +1,5 @@
 ---
-title: 'litcluster: Topic modelling and semantic clustering of scientific literature from BibTeX or DOI lists'
+title: 'litcluster: Topic-based clustering of scientific literature using TF-IDF and k-means'
 tags:
   - Python
   - NLP
@@ -20,14 +20,90 @@ bibliography: paper.bib
 
 # Summary
 
-`litcluster` is a Python tool for semantic clustering and topic modelling of scientific literature. Given a BibTeX file, a list of DOIs, or a directory of PDF abstracts, `litcluster` fetches or extracts abstract text, embeds papers using pre-trained sentence transformers, applies dimensionality reduction (UMAP), and clusters the resulting embedding space (HDBSCAN). It outputs an interactive HTML visualisation of the literature landscape and a Markdown summary table labelling each cluster with automatically extracted topic keywords. `litcluster` is designed for researchers beginning a new domain survey or tracking how a field has evolved over time.
+`litcluster` is a pure-Python command-line tool and library for automatic
+topic clustering of scientific literature collections.  Given a BibTeX file,
+a CSV, or a JSON Lines file containing paper titles, abstracts, and keywords,
+`litcluster` (1) tokenises and filters the text, (2) computes smoothed
+TF-IDF (term-frequency–inverse-document-frequency) vectors [@salton1988term]
+for each paper, and (3) partitions the papers into $k$ topic clusters using
+Lloyd's k-means algorithm with cosine similarity [@lloyd1982least].  The tool
+outputs a plain-text summary, structured CSV or JSON exports, a self-contained
+interactive HTML report, and a Tkinter graphical interface for exploratory
+use.  No external dependencies are required: the entire implementation relies
+exclusively on the Python standard library, making it trivially portable and
+reproducible.
 
 # Statement of Need
 
-Systematic and scoping reviews require researchers to organise large collections of papers into thematic groups — a task typically done manually or with expensive proprietary tools. `litcluster` automates this using modern sentence embeddings and density-based clustering, requiring only a BibTeX file as input. Unlike keyword-based approaches, semantic clustering groups papers by meaning rather than surface vocabulary, surfacing connections that term-based methods miss [@wei2022chain]. The interactive output helps researchers quickly identify core topics, niche sub-areas, and potential gaps in a literature collection, accelerating the early stages of a systematic review.
+Systematic and scoping literature reviews require researchers to organise
+large collections of papers into thematic groups — a task typically performed
+manually or with expensive proprietary software.  Free alternatives often
+require complex dependency stacks (PyTorch, sentence-transformers, UMAP,
+HDBSCAN) whose installation and version management create reproducibility
+barriers [@gundersen2018state; @pineau2021improving].
+
+`litcluster` is designed for researchers who need a *lightweight, zero-dependency
+entry point* into computational literature organisation.  The entire pipeline
+runs with `pip install litcluster` and a single command:
+
+```bash
+litcluster refs.bib -k 8 --format html -o report.html
+```
+
+Unlike black-box neural embedding approaches, TF-IDF vectors are fully
+interpretable: each dimension corresponds to a specific term, and per-cluster
+top terms immediately explain the thematic content of each group.  This
+transparency supports the methodological accountability expected in systematic
+reviews [@page2021prisma].
+
+`litcluster` accepts BibTeX files exported directly from Zotero, Mendeley,
+JabRef, or any reference manager, requiring no additional data preparation.
+It also accepts CSV and JSON Lines formats to support programmatic pipelines.
+
+# Implementation
+
+## Text representation
+
+Each paper is represented as the concatenation of its title, abstract, and
+author-supplied keywords.  Tokenisation applies a regular-expression-based
+word boundary split, discards English stopwords and tokens shorter than three
+characters, and yields a bag-of-words token list.  A vocabulary-level minimum
+document frequency filter (configurable, default 2) removes rare terms that
+would add noise without discriminative value.
+
+TF-IDF weighting uses the smoothed formulation:
+
+$$\text{TF-IDF}(t, d) = \frac{f_{t,d}}{|d|} \cdot \left(\log\frac{N+1}{\mathrm{df}(t)+1} + 1\right)$$
+
+where $f_{t,d}$ is the raw term frequency in document $d$, $|d|$ is the
+document length in tokens, $N$ is the total number of documents, and
+$\mathrm{df}(t)$ is the number of documents containing term $t$.  Vectors
+are stored as sparse Python dictionaries to keep memory usage proportional to
+the non-zero entries.
+
+## Clustering
+
+Lloyd's k-means algorithm is applied with cosine similarity as the distance
+metric, which is standard practice for sparse TF-IDF vectors [@manning2008introduction].
+Centroid initialisation uses a seeded random sample; the random seed is fully
+configurable, guaranteeing reproducible results across runs.  If the
+requested $k$ exceeds the number of papers, it is silently capped.
+
+## Outputs
+
+The `summary` format prints a human-readable cluster table to standard output.
+The `csv` format writes one row per paper with cluster assignment.
+The `json` format produces a nested structure suitable for downstream
+programmatic processing.
+The `html` format generates a self-contained, zero-dependency HTML report
+with collapsible cluster sections, colour-coded by cluster index, and DOI
+hyperlinks for each paper.  The graphical interface (`litcluster-gui`)
+provides interactive file loading, parameter adjustment, cluster browsing,
+and one-click export.
 
 # Acknowledgements
 
-The author used Claude (Anthropic) for drafting portions of this manuscript. All scientific claims and design decisions are the author's own.
+The author used Claude (Anthropic) for drafting portions of this manuscript.
+All scientific claims and design decisions are the author's own.
 
 # References

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,10 @@ readme = "README.md"
 license = {file = "LICENSE"}
 authors = [{name = "Vaibhav Deshmukh", email = "vdeshmukh203@gmail.com"}]
 requires-python = ">=3.8"
-keywords = ["literature", "clustering", "bibtex", "topic-modelling", "tfidf", "research"]
+keywords = [
+    "literature", "clustering", "bibtex", "topic-modelling",
+    "tfidf", "research", "bibliometrics",
+]
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Science/Research",
@@ -21,7 +24,8 @@ classifiers = [
 ]
 
 [project.scripts]
-litcluster = "litcluster:_cli"
+litcluster     = "litcluster:main"
+litcluster-gui = "gui:run_gui"
 
 [tool.setuptools]
-py-modules = ["litcluster"]
+py-modules = ["litcluster", "gui"]

--- a/src/litcluster/__init__.py
+++ b/src/litcluster/__init__.py
@@ -1,18 +1,44 @@
 """
-litcluster: Semantic clustering and topic modelling of scientific literature.
+litcluster: Topic-based clustering of scientific literature using TF-IDF and k-means.
 
-Ingests collections of scientific abstracts or full papers (via DOI lists,
-BibTeX files, or arXiv IDs), embeds them using sentence-transformers, and
-applies hierarchical clustering and topic modelling to produce interactive
-visualisations and structured cluster summaries for systematic literature
-reviews.
+The canonical module is the root ``litcluster.py`` installed via
+``pyproject.toml`` (``py-modules = ["litcluster"]``).  This package stub
+re-exports the public API so that both ``import litcluster`` and
+``from litcluster import LitCluster`` work regardless of how the package
+is discovered.
 """
+
+from __future__ import annotations
+
+import os
+import sys
 
 __version__ = "0.1.0"
 __author__ = "Vaibhav Deshmukh"
 __license__ = "MIT"
 
-from .cluster import LitCluster
-from .embed import PaperEmbedder
+# Ensure the repo root (containing litcluster.py) is importable.
+_ROOT = os.path.normpath(os.path.join(os.path.dirname(__file__), "..", ".."))
+if _ROOT not in sys.path:
+    sys.path.insert(0, _ROOT)
 
-__all__ = ["LitCluster", "PaperEmbedder"]
+# Re-export the full public API from the root module.
+from litcluster import (  # noqa: E402, F401
+    LitCluster,
+    Paper,
+    Cluster,
+    _tokenise,
+    _tfidf,
+    _cosine,
+    _kmeans,
+    _parse_bibtex_field,
+)
+
+__all__ = [
+    "LitCluster",
+    "Paper",
+    "Cluster",
+    "__version__",
+    "__author__",
+    "__license__",
+]

--- a/tests/test_litcluster.py
+++ b/tests/test_litcluster.py
@@ -1,19 +1,818 @@
-import sys, pathlib
+"""
+Comprehensive test suite for litcluster.
+Covers tokenisation, TF-IDF, cosine similarity, k-means, BibTeX parsing,
+data structures, loaders, fit(), exporters, and edge cases.
+"""
+
+from __future__ import annotations
+
+import csv
+import json
+import pathlib
+import sys
+import tempfile
+import textwrap
+
+# Ensure repo root is importable
 sys.path.insert(0, str(pathlib.Path(__file__).parent.parent))
 
-def test_import():
-    import litcluster as lc
-    assert hasattr(lc, 'LitCluster')
+import litcluster as lc_mod
+from litcluster import (
+    LitCluster,
+    Paper,
+    Cluster,
+    _tokenise,
+    _tfidf,
+    _cosine,
+    _kmeans,
+    _parse_bibtex_field,
+)
 
-def test_paper():
-    import litcluster as lc
-    assert hasattr(lc, 'Paper')
+# ---------------------------------------------------------------------------
+# Fixtures / shared data
+# ---------------------------------------------------------------------------
 
-def test_cluster():
-    import litcluster as lc
-    assert hasattr(lc, 'Cluster')
+SAMPLE_BIB = textwrap.dedent("""\
+    @article{smith2023deep,
+      author   = {Smith, John and Doe, Jane},
+      title    = {Deep Learning for Natural Language Processing},
+      abstract = {We study deep neural networks for text classification tasks.},
+      year     = {2023},
+      journal  = {Machine Learning Journal},
+      doi      = {10.1234/mlj.2023},
+      keywords = {deep learning, neural networks, NLP},
+    }
+    @article{jones2023graph,
+      author   = {Jones, Alice},
+      title    = {Graph Neural Networks in Computer Vision},
+      abstract = {We apply graph neural networks to image recognition tasks.},
+      year     = {2023},
+      journal  = {Vision Conference},
+      keywords = {graph neural networks, computer vision, images},
+    }
+    @article{lee2022transformers,
+      author   = {Lee, Bob},
+      title    = {Transformers for Machine Translation},
+      abstract = {Transformer architectures achieve state of the art results.},
+      year     = {2022},
+      journal  = {NLP Symposium},
+      keywords = {transformer, machine translation, attention},
+    }
+    @comment{this should be skipped entirely}
+    @string{conf = {Some Conference}}
+""")
 
-def test_tokenise():
-    import litcluster as lc
-    tokens = lc._tokenise('hello world test foo bar')
-    assert isinstance(tokens, list) and len(tokens) > 0
+SAMPLE_CSV = (
+    "paper_id,title,abstract,authors,year,venue,doi,keywords\n"
+    "p1,Deep Learning,Study of neural networks,Smith J.,2023,MLJ,,"
+    "deep learning\n"
+    "p2,NLP Methods,Text processing and classification,Jones A.,2022,ACL,,"
+    "nlp text\n"
+    "p3,Vision Models,Image classification with convolutional networks,Lee B.,"
+    "2021,CVPR,,computer vision\n"
+)
+
+SAMPLE_JSONL = (
+    '{"paper_id":"p1","title":"Deep Learning",'
+    '"abstract":"Neural network study for text","year":"2023"}\n'
+    '{"paper_id":"p2","title":"NLP Research",'
+    '"abstract":"Text classification methods","year":"2022"}\n'
+    '{"paper_id":"p3","title":"Computer Vision",'
+    '"abstract":"Image recognition using deep convolutional models","year":"2021"}\n'
+)
+
+
+def _bib_tmpfile():
+    """Write SAMPLE_BIB to a temp file and return its Path."""
+    f = tempfile.NamedTemporaryFile(
+        suffix=".bib", mode="w", delete=False, encoding="utf-8"
+    )
+    f.write(SAMPLE_BIB)
+    f.close()
+    return pathlib.Path(f.name)
+
+
+def _csv_tmpfile():
+    f = tempfile.NamedTemporaryFile(
+        suffix=".csv", mode="w", delete=False, encoding="utf-8"
+    )
+    f.write(SAMPLE_CSV)
+    f.close()
+    return pathlib.Path(f.name)
+
+
+def _jsonl_tmpfile():
+    f = tempfile.NamedTemporaryFile(
+        suffix=".jsonl", mode="w", delete=False, encoding="utf-8"
+    )
+    f.write(SAMPLE_JSONL)
+    f.close()
+    return pathlib.Path(f.name)
+
+
+# ===========================================================================
+# 1. Tokenisation
+# ===========================================================================
+
+def test_tokenise_returns_list():
+    assert isinstance(_tokenise("Hello World Test"), list)
+
+
+def test_tokenise_lowercases():
+    tokens = _tokenise("Neural Networks Deep")
+    assert "neural" in tokens
+    assert "networks" in tokens
+    assert "deep" in tokens
+
+
+def test_tokenise_removes_stopwords():
+    tokens = _tokenise("the and or but with for of")
+    assert tokens == []
+
+
+def test_tokenise_min_length_three():
+    tokens = _tokenise("a ab abc abcd")
+    assert "a" not in tokens
+    assert "ab" not in tokens
+    assert "abc" in tokens
+    assert "abcd" in tokens
+
+
+def test_tokenise_only_alpha():
+    # Regex r"[a-zA-Z]{3,}" extracts the alpha run from mixed strings
+    tokens = _tokenise("word123 abc! test_case")
+    assert "word" in tokens    # alpha run extracted from "word123"
+    assert "abc" in tokens     # alpha run from "abc!"
+    assert "test" in tokens    # first run from "test_case"
+    assert "case" in tokens    # second run from "test_case"
+
+
+def test_tokenise_empty_string():
+    assert _tokenise("") == []
+
+
+def test_tokenise_non_alpha_filtered():
+    tokens = _tokenise("123 456 !@#")
+    assert tokens == []
+
+
+# ===========================================================================
+# 2. TF-IDF
+# ===========================================================================
+
+def test_tfidf_empty_input():
+    vecs, vocab = _tfidf([])
+    assert vecs == []
+    assert vocab == []
+
+
+def test_tfidf_single_document():
+    vecs, vocab = _tfidf([["machine", "learning"]])
+    assert len(vecs) == 1
+    assert set(vocab) == {"learning", "machine"}
+    assert vecs[0]["machine"] > 0
+    assert vecs[0]["learning"] > 0
+
+
+def test_tfidf_multiple_documents():
+    docs = [["neural", "networks"], ["deep", "learning"], ["neural", "deep"]]
+    vecs, vocab = _tfidf(docs)
+    assert len(vecs) == 3
+    assert len(vocab) == 4
+    assert vecs[0]["neural"] > 0
+    assert vecs[1]["deep"] > 0
+
+
+def test_tfidf_vectors_are_sparse_dicts():
+    vecs, _ = _tfidf([["alpha"], ["beta"]])
+    assert isinstance(vecs[0], dict)
+    # Each doc only has its own term
+    assert "alpha" in vecs[0]
+    assert "beta" not in vecs[0]
+
+
+def test_tfidf_rare_term_has_higher_idf():
+    # "rare" appears in 1 of 3 docs; "common" appears in all 3
+    docs = [
+        ["common", "rare"],
+        ["common"],
+        ["common"],
+    ]
+    vecs, _ = _tfidf(docs)
+    assert vecs[0]["rare"] > vecs[0]["common"]
+
+
+def test_tfidf_empty_token_list_per_doc():
+    vecs, vocab = _tfidf([[], ["word"]])
+    assert len(vecs) == 2
+    assert vecs[0] == {}
+    assert "word" in vecs[1]
+
+
+# ===========================================================================
+# 3. Cosine similarity
+# ===========================================================================
+
+def test_cosine_identical_vectors():
+    v = {"a": 1.0, "b": 2.0}
+    assert abs(_cosine(v, v) - 1.0) < 1e-9
+
+
+def test_cosine_orthogonal_vectors():
+    assert _cosine({"a": 1.0}, {"b": 1.0}) == 0.0
+
+
+def test_cosine_empty_vectors():
+    assert _cosine({}, {"a": 1.0}) == 0.0
+    assert _cosine({"a": 1.0}, {}) == 0.0
+    assert _cosine({}, {}) == 0.0
+
+
+def test_cosine_in_unit_interval():
+    v1 = {"a": 0.8, "b": 0.5}
+    v2 = {"a": 0.3, "b": 0.9, "c": 0.1}
+    sim = _cosine(v1, v2)
+    assert 0.0 <= sim <= 1.0
+
+
+def test_cosine_symmetry():
+    v1 = {"x": 1.0, "y": 2.0}
+    v2 = {"x": 3.0, "z": 1.0}
+    assert abs(_cosine(v1, v2) - _cosine(v2, v1)) < 1e-12
+
+
+# ===========================================================================
+# 4. K-means
+# ===========================================================================
+
+def test_kmeans_empty():
+    assert _kmeans([], k=3) == []
+
+
+def test_kmeans_single_vector():
+    labels = _kmeans([{"a": 1.0}], k=1)
+    assert labels == [0]
+
+
+def test_kmeans_k_gt_n_capped():
+    vecs = [{"a": 1.0}, {"b": 1.0}]
+    labels = _kmeans(vecs, k=10)
+    assert len(labels) == 2
+    assert all(0 <= lbl < 2 for lbl in labels)
+
+
+def test_kmeans_labels_count_matches_input():
+    vecs = [{"a": float(i)} for i in range(8)]
+    labels = _kmeans(vecs, k=3)
+    assert len(labels) == 8
+
+
+def test_kmeans_labels_in_valid_range():
+    vecs = [{"a": float(i), "b": float(i % 2)} for i in range(12)]
+    labels = _kmeans(vecs, k=4)
+    assert all(0 <= lbl < 4 for lbl in labels)
+
+
+def test_kmeans_deterministic_with_seed():
+    vecs = [{"a": float(i), "b": float(i * 3)} for i in range(20)]
+    assert _kmeans(vecs, k=3, seed=7) == _kmeans(vecs, k=3, seed=7)
+
+
+def test_kmeans_different_seeds_may_differ():
+    vecs = [{"t": float(i)} for i in range(30)]
+    l1 = _kmeans(vecs, k=5, seed=1)
+    l2 = _kmeans(vecs, k=5, seed=999)
+    # Can't guarantee they differ, but structure must be valid
+    assert len(l1) == len(l2) == 30
+
+
+# ===========================================================================
+# 5. BibTeX field parser
+# ===========================================================================
+
+def test_parse_brace_field():
+    entry = "title = {Neural Networks and Deep Learning},"
+    assert _parse_bibtex_field(entry, "title") == "Neural Networks and Deep Learning"
+
+
+def test_parse_quote_field():
+    entry = 'year = "2023",'
+    assert _parse_bibtex_field(entry, "year") == "2023"
+
+
+def test_parse_bare_number():
+    entry = "year = 2023,"
+    assert _parse_bibtex_field(entry, "year") == "2023"
+
+
+def test_parse_nested_braces():
+    entry = "title = {A Study of {NLP} Methods},"
+    result = _parse_bibtex_field(entry, "title")
+    assert result == "A Study of {NLP} Methods"
+
+
+def test_parse_missing_field_returns_empty():
+    entry = "author = {Smith, John},"
+    assert _parse_bibtex_field(entry, "title") == ""
+
+
+def test_parse_multiline_abstract():
+    entry = "abstract = {This is a long\n  multiline\n  abstract.},"
+    result = _parse_bibtex_field(entry, "abstract")
+    assert "multiline" in result
+    assert "abstract" in result
+
+
+def test_parse_case_insensitive():
+    entry = "TITLE = {Case Test},"
+    assert _parse_bibtex_field(entry, "title") == "Case Test"
+
+
+# ===========================================================================
+# 6. Paper dataclass
+# ===========================================================================
+
+def test_paper_text_concatenation():
+    p = Paper(paper_id="1", title="Deep Learning",
+               abstract="Neural nets.", keywords="ml ai")
+    assert "Deep Learning" in p.text
+    assert "Neural nets." in p.text
+    assert "ml ai" in p.text
+
+
+def test_paper_to_dict_keys():
+    p = Paper(paper_id="p1", title="T", abstract="A", year="2023")
+    d = p.to_dict()
+    for key in ("paper_id", "title", "abstract", "authors", "year",
+                "venue", "doi", "keywords"):
+        assert key in d
+
+
+def test_paper_repr():
+    p = Paper(paper_id="x", title="Some Title")
+    assert "Some Title" in repr(p)
+
+
+def test_paper_defaults():
+    p = Paper(paper_id="1", title="T")
+    assert p.abstract == ""
+    assert p.doi == ""
+
+
+# ===========================================================================
+# 7. Cluster dataclass
+# ===========================================================================
+
+def test_cluster_label_contains_id():
+    c = Cluster(cluster_id=3, top_terms=["alpha", "beta"])
+    assert "3" in c.label
+    assert "alpha" in c.label
+
+
+def test_cluster_label_empty_terms():
+    c = Cluster(cluster_id=0)
+    assert "Cluster 0" in c.label
+
+
+def test_cluster_to_dict_structure():
+    p = Paper(paper_id="p1", title="T")
+    c = Cluster(cluster_id=2, papers=[p], top_terms=["x", "y"])
+    d = c.to_dict()
+    assert d["cluster_id"] == 2
+    assert d["size"] == 1
+    assert len(d["papers"]) == 1
+    assert d["top_terms"] == ["x", "y"]
+
+
+def test_cluster_repr():
+    c = Cluster(cluster_id=1, papers=[Paper("p1", "T")], top_terms=["a"])
+    r = repr(c)
+    assert "1" in r
+    assert "size=1" in r
+
+
+# ===========================================================================
+# 8. LitCluster construction and validation
+# ===========================================================================
+
+def test_litcluster_invalid_k():
+    raised = False
+    try:
+        LitCluster(k=0)
+    except ValueError:
+        raised = True
+    assert raised, "Expected ValueError for k=0"
+
+
+def test_litcluster_invalid_max_iter():
+    raised = False
+    try:
+        LitCluster(max_iter=0)
+    except ValueError:
+        raised = True
+    assert raised
+
+
+def test_litcluster_invalid_min_term_freq():
+    raised = False
+    try:
+        LitCluster(min_term_freq=0)
+    except ValueError:
+        raised = True
+    assert raised
+
+
+def test_litcluster_defaults():
+    lc = LitCluster()
+    assert lc.k == 5
+    assert lc.seed == 42
+    assert lc.max_iter == 100
+    assert lc.min_term_freq == 2
+
+
+# ===========================================================================
+# 9. Paper management methods
+# ===========================================================================
+
+def test_add_paper():
+    lc = LitCluster(k=1)
+    lc.add_paper(Paper("p1", "Test"))
+    assert len(lc.papers) == 1
+
+
+def test_add_paper_clears_clusters():
+    bib = _bib_tmpfile()
+    try:
+        lc = LitCluster.from_bibtex(bib, k=2, min_term_freq=1).fit()
+        assert len(lc.clusters) > 0
+        lc.add_paper(Paper("new", "New paper"))
+        assert len(lc.clusters) == 0  # invalidated
+    finally:
+        bib.unlink()
+
+
+def test_clear():
+    lc = LitCluster(k=2)
+    lc.papers.append(Paper("p1", "Test"))
+    lc.clear()
+    assert len(lc.papers) == 0
+    assert len(lc.clusters) == 0
+
+
+# ===========================================================================
+# 10. Loaders
+# ===========================================================================
+
+def test_from_bibtex_paper_count():
+    bib = _bib_tmpfile()
+    try:
+        lc = LitCluster.from_bibtex(bib)
+        assert len(lc.papers) == 3  # @comment and @string skipped
+    finally:
+        bib.unlink()
+
+
+def test_from_bibtex_fields():
+    bib = _bib_tmpfile()
+    try:
+        lc = LitCluster.from_bibtex(bib)
+        p = lc.papers[0]
+        assert p.paper_id == "smith2023deep"
+        assert "Deep Learning" in p.title
+        assert "Smith" in p.authors
+        assert p.year == "2023"
+        assert p.doi == "10.1234/mlj.2023"
+    finally:
+        bib.unlink()
+
+
+def test_from_csv_paper_count():
+    csv_path = _csv_tmpfile()
+    try:
+        lc = LitCluster.from_csv(csv_path)
+        assert len(lc.papers) == 3
+    finally:
+        csv_path.unlink()
+
+
+def test_from_csv_fields():
+    csv_path = _csv_tmpfile()
+    try:
+        lc = LitCluster.from_csv(csv_path)
+        p = lc.papers[0]
+        assert p.paper_id == "p1"
+        assert "Deep Learning" in p.title
+        assert p.year == "2023"
+    finally:
+        csv_path.unlink()
+
+
+def test_from_jsonl_paper_count():
+    jl = _jsonl_tmpfile()
+    try:
+        lc = LitCluster.from_jsonl(jl)
+        assert len(lc.papers) == 3
+    finally:
+        jl.unlink()
+
+
+def test_from_jsonl_fields():
+    jl = _jsonl_tmpfile()
+    try:
+        lc = LitCluster.from_jsonl(jl)
+        p = lc.papers[0]
+        assert p.paper_id == "p1"
+        assert "Deep Learning" in p.title
+    finally:
+        jl.unlink()
+
+
+def test_from_jsonl_skips_blank_lines():
+    f = tempfile.NamedTemporaryFile(
+        suffix=".jsonl", mode="w", delete=False, encoding="utf-8"
+    )
+    f.write('{"paper_id":"a","title":"A"}\n\n{"paper_id":"b","title":"B"}\n')
+    f.close()
+    path = pathlib.Path(f.name)
+    try:
+        lc = LitCluster.from_jsonl(path)
+        assert len(lc.papers) == 2
+    finally:
+        path.unlink()
+
+
+# ===========================================================================
+# 11. fit()
+# ===========================================================================
+
+def test_fit_raises_on_empty():
+    lc = LitCluster(k=3)
+    raised = False
+    try:
+        lc.fit()
+    except ValueError:
+        raised = True
+    assert raised
+
+
+def test_fit_produces_clusters():
+    bib = _bib_tmpfile()
+    try:
+        lc = LitCluster.from_bibtex(bib, k=2, min_term_freq=1).fit()
+        assert len(lc.clusters) >= 1
+        assert len(lc.clusters) <= 2
+    finally:
+        bib.unlink()
+
+
+def test_fit_all_papers_assigned():
+    bib = _bib_tmpfile()
+    try:
+        lc = LitCluster.from_bibtex(bib, k=2, min_term_freq=1).fit()
+        assigned = sum(len(c.papers) for c in lc.clusters)
+        assert assigned == len(lc.papers)
+    finally:
+        bib.unlink()
+
+
+def test_fit_k_gt_n_capped():
+    csv_path = _csv_tmpfile()
+    try:
+        lc = LitCluster.from_csv(csv_path, k=100, min_term_freq=1).fit()
+        assert len(lc.clusters) <= 3
+    finally:
+        csv_path.unlink()
+
+
+def test_fit_deterministic():
+    bib = _bib_tmpfile()
+    try:
+        lc1 = LitCluster.from_bibtex(bib, k=2, seed=42, min_term_freq=1).fit()
+        lc2 = LitCluster.from_bibtex(bib, k=2, seed=42, min_term_freq=1).fit()
+        labels1 = sorted(
+            (p.paper_id, c.cluster_id)
+            for c in lc1.clusters for p in c.papers
+        )
+        labels2 = sorted(
+            (p.paper_id, c.cluster_id)
+            for c in lc2.clusters for p in c.papers
+        )
+        assert labels1 == labels2
+    finally:
+        bib.unlink()
+
+
+def test_fit_progress_callback():
+    bib = _bib_tmpfile()
+    messages = []
+    try:
+        LitCluster.from_bibtex(bib, k=2, min_term_freq=1).fit(
+            progress=messages.append
+        )
+    finally:
+        bib.unlink()
+    assert len(messages) > 0
+    assert any("Done" in m for m in messages)
+
+
+def test_fit_top_terms():
+    bib = _bib_tmpfile()
+    try:
+        lc = LitCluster.from_bibtex(bib, k=2, min_term_freq=1).fit()
+        for c in lc.clusters:
+            assert isinstance(c.top_terms, list)
+            assert all(isinstance(t, str) for t in c.top_terms)
+    finally:
+        bib.unlink()
+
+
+def test_fit_min_freq_filtering():
+    bib = _bib_tmpfile()
+    try:
+        # min_term_freq=1: all terms kept
+        lc1 = LitCluster.from_bibtex(bib, k=2, min_term_freq=1).fit()
+        # min_term_freq=10: almost all terms filtered (rare corpus)
+        lc2 = LitCluster.from_bibtex(bib, k=2, min_term_freq=10).fit()
+        # Both should produce valid clusters regardless
+        assert len(lc1.clusters) >= 1
+        assert len(lc2.clusters) >= 1
+    finally:
+        bib.unlink()
+
+
+# ===========================================================================
+# 12. summary()
+# ===========================================================================
+
+def test_summary_contains_paper_count():
+    bib = _bib_tmpfile()
+    try:
+        lc = LitCluster.from_bibtex(bib, k=2, min_term_freq=1).fit()
+        s = lc.summary()
+        assert "3" in s  # 3 papers
+    finally:
+        bib.unlink()
+
+
+def test_summary_contains_cluster_label():
+    bib = _bib_tmpfile()
+    try:
+        lc = LitCluster.from_bibtex(bib, k=2, min_term_freq=1).fit()
+        s = lc.summary()
+        assert "Cluster" in s
+    finally:
+        bib.unlink()
+
+
+# ===========================================================================
+# 13. export_csv()
+# ===========================================================================
+
+def test_export_csv_creates_file(tmp_path):
+    bib = _bib_tmpfile()
+    try:
+        lc = LitCluster.from_bibtex(bib, k=2, min_term_freq=1).fit()
+        out = tmp_path / "out.csv"
+        lc.export_csv(out)
+        assert out.exists()
+    finally:
+        bib.unlink()
+
+
+def test_export_csv_row_count(tmp_path):
+    bib = _bib_tmpfile()
+    try:
+        lc = LitCluster.from_bibtex(bib, k=2, min_term_freq=1).fit()
+        out = tmp_path / "out.csv"
+        lc.export_csv(out)
+        rows = list(csv.DictReader(out.read_text(encoding="utf-8").splitlines()))
+        assert len(rows) == 3  # one row per paper
+    finally:
+        bib.unlink()
+
+
+def test_export_csv_required_columns(tmp_path):
+    csv_path = _csv_tmpfile()
+    try:
+        lc = LitCluster.from_csv(csv_path, k=2, min_term_freq=1).fit()
+        out = tmp_path / "out.csv"
+        lc.export_csv(out)
+        rows = list(csv.DictReader(out.read_text(encoding="utf-8").splitlines()))
+        for col in ("cluster_id", "cluster_label", "paper_id", "title"):
+            assert col in rows[0], f"Missing column: {col}"
+    finally:
+        csv_path.unlink()
+
+
+# ===========================================================================
+# 14. export_json()
+# ===========================================================================
+
+def test_export_json_creates_file(tmp_path):
+    bib = _bib_tmpfile()
+    try:
+        lc = LitCluster.from_bibtex(bib, k=2, min_term_freq=1).fit()
+        out = tmp_path / "out.json"
+        lc.export_json(out)
+        assert out.exists()
+    finally:
+        bib.unlink()
+
+
+def test_export_json_valid_structure(tmp_path):
+    bib = _bib_tmpfile()
+    try:
+        lc = LitCluster.from_bibtex(bib, k=2, min_term_freq=1).fit()
+        out = tmp_path / "out.json"
+        lc.export_json(out)
+        data = json.loads(out.read_text(encoding="utf-8"))
+        assert isinstance(data, list)
+        assert "cluster_id" in data[0]
+        assert "papers" in data[0]
+        assert "top_terms" in data[0]
+    finally:
+        bib.unlink()
+
+
+def test_export_json_paper_count(tmp_path):
+    bib = _bib_tmpfile()
+    try:
+        lc = LitCluster.from_bibtex(bib, k=2, min_term_freq=1).fit()
+        out = tmp_path / "out.json"
+        lc.export_json(out)
+        data = json.loads(out.read_text(encoding="utf-8"))
+        total = sum(d["size"] for d in data)
+        assert total == 3
+    finally:
+        bib.unlink()
+
+
+# ===========================================================================
+# 15. export_html()
+# ===========================================================================
+
+def test_export_html_creates_file(tmp_path):
+    bib = _bib_tmpfile()
+    try:
+        lc = LitCluster.from_bibtex(bib, k=2, min_term_freq=1).fit()
+        out = tmp_path / "out.html"
+        lc.export_html(out)
+        assert out.exists()
+    finally:
+        bib.unlink()
+
+
+def test_export_html_is_valid_html(tmp_path):
+    bib = _bib_tmpfile()
+    try:
+        lc = LitCluster.from_bibtex(bib, k=2, min_term_freq=1).fit()
+        out = tmp_path / "out.html"
+        lc.export_html(out)
+        html = out.read_text(encoding="utf-8")
+        assert "<!DOCTYPE html>" in html
+        assert "<html" in html
+        assert "</html>" in html
+    finally:
+        bib.unlink()
+
+
+def test_export_html_contains_cluster_info(tmp_path):
+    bib = _bib_tmpfile()
+    try:
+        lc = LitCluster.from_bibtex(bib, k=2, min_term_freq=1).fit()
+        out = tmp_path / "out.html"
+        lc.export_html(out)
+        html = out.read_text(encoding="utf-8")
+        assert "Cluster" in html
+        assert "3 papers" in html
+    finally:
+        bib.unlink()
+
+
+def test_export_html_doi_links(tmp_path):
+    bib = _bib_tmpfile()
+    try:
+        lc = LitCluster.from_bibtex(bib, k=2, min_term_freq=1).fit()
+        out = tmp_path / "out.html"
+        lc.export_html(out)
+        html = out.read_text(encoding="utf-8")
+        # smith2023deep has DOI 10.1234/mlj.2023
+        assert "10.1234/mlj.2023" in html
+    finally:
+        bib.unlink()
+
+
+# ===========================================================================
+# 16. Module-level attributes
+# ===========================================================================
+
+def test_version_attribute():
+    assert hasattr(lc_mod, "__version__")
+    assert isinstance(lc_mod.__version__, str)
+    parts = lc_mod.__version__.split(".")
+    assert len(parts) == 3
+
+
+def test_public_api_exports():
+    for name in ("LitCluster", "Paper", "Cluster"):
+        assert hasattr(lc_mod, name), f"Missing public symbol: {name}"


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Bug fixes** across `litcluster.py`, `pyproject.toml`, and `src/litcluster/__init__.py`
- **New GUI** (`gui.py`) — full Tkinter graphical interface, zero extra deps
- **76-test suite** covering every public API method and edge case
- **JOSS paper and references** rewritten to accurately reflect the TF-IDF + k-means implementation

## Bug fixes

| File | Issue | Fix |
|------|-------|-----|
| `pyproject.toml` | Entry point called `litcluster:_cli` (function didn't exist) | Changed to `litcluster:main` |
| `src/litcluster/__init__.py` | Imported `.cluster` and `.embed` modules that don't exist | Fixed to re-export from root `litcluster` module |
| `litcluster.py` | BibTeX parser broke on nested braces and multi-line fields | Rewritten with depth-counting brace handler |
| `litcluster.py` | k-means sentinel `labels=[0]*n` caused false convergence for k=1 | Changed to `labels=[-1]*n` |
| `paper.md` | Described UMAP/HDBSCAN/sentence-transformers (none implemented) | Rewrote to accurately describe TF-IDF + k-means |
| `paper.bib` | References unrelated to the tool (SHA-256, ChatGPT on USMLE) | Replaced with TF-IDF, k-means, IR, PRISMA, reproducibility refs |
| `CHANGELOG.md` | v0.1.0 listed SPECTER2/HDBSCAN/UMAP/HTML as shipped | Corrected to match what was actually built |

## New features

### `litcluster.py`
- `export_html()` — self-contained interactive HTML report with colour-coded collapsible clusters and DOI hyperlinks
- `progress` callback on `fit()` for GUI/TUI status reporting
- `add_paper()` and `clear()` convenience methods
- `fit()` now raises `ValueError` with a clear message when called on empty paper list
- `__repr__` on `Paper` and `Cluster`
- Extended stopword list (academic filler words)
- `__version__`, `__author__`, `__license__` at module level
- `@comment` / `@preamble` / `@string` BibTeX meta-entries are now skipped

### `gui.py` (new)
- Toolbar: file browser, k/seed/max-iter/min-freq spinboxes, Cluster button, Export buttons
- Left panel: two-level `Treeview` (cluster → papers)
- Right panel: scrollable detail view showing abstract, authors, DOI per paper
- Background threading so the UI stays responsive during clustering
- `litcluster-gui` entry point in `pyproject.toml`

## Tests

76 tests, all passing:

- Tokenisation, TF-IDF, cosine similarity, k-means unit tests
- BibTeX field parser (nested braces, multi-line, case-insensitive, bare numbers)
- `Paper` / `Cluster` dataclass tests
- `LitCluster` validation, all three loaders, `fit()`, `summary()`, all three exporters
- Edge cases: empty input, k > n, min-freq filtering, determinism, progress callback

## Test plan

- [ ] `python -m pytest tests/ -v` → 76 passed
- [ ] `litcluster paper.bib --format html -o /tmp/report.html` opens a valid HTML report
- [ ] `litcluster-gui` launches the Tkinter window (requires display)
- [ ] CI workflow passes on push

https://claude.ai/code/session_01Ac27XBzrG28PgJyqsKD6sv
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ac27XBzrG28PgJyqsKD6sv)_