### PR TITLE
JOSS-quality polish, comprehensive tests, and tkinter GUI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,32 @@
+# Python
+__pycache__/
+*.py[cod]
+*.pyo
+*.pyd
+
+# Packaging / build
+*.egg-info/
+*.egg
+dist/
+build/
+.eggs/
+
+# Virtual environments
+.venv/
+venv/
+env/
+
+# Testing / coverage
+.pytest_cache/
+.coverage
+htmlcov/
+
+# Editors
+.vscode/
+.idea/
+*.swp
+*~
+
+# OS
+.DS_Store
+Thumbs.db

--- a/README.md
+++ b/README.md
@@ -1,1 +1,167 @@
 # litcluster
+
+**Topic-based clustering of scientific literature using TF-IDF and k-means.**
+
+`litcluster` groups a collection of academic papers into thematic clusters.
+It works entirely with the Python standard library — no external dependencies
+are required.  Input can be a **CSV file**, **JSONL file**, or **BibTeX file**;
+output can be a text summary, a CSV, or a JSON file.
+A **tkinter GUI** is also provided for interactive exploration.
+
+---
+
+## Installation
+
+```bash
+pip install .
+```
+
+Or run directly from the repository without installing:
+
+```bash
+python litcluster.py papers.bib -k 5
+```
+
+---
+
+## Quick start
+
+### Command-line interface
+
+```bash
+# Print a cluster summary (default)
+litcluster refs.bib -k 5
+
+# Write cluster assignments to CSV
+litcluster papers.csv -k 6 --format csv --output clusters.csv
+
+# Write full cluster data (with abstracts) to JSON
+litcluster papers.jsonl -k 4 --format json -o clusters.json
+```
+
+All options:
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `-k`, `--clusters` | `5` | Number of clusters |
+| `--format` | `summary` | Output format: `summary`, `csv`, `json` |
+| `-o`, `--output` | — | Output file (stdout for summary if omitted) |
+| `--seed` | `42` | Random seed for reproducibility |
+| `--max-iter` | `100` | Maximum k-means iterations |
+| `--min-freq` | `2` | Minimum document frequency for vocabulary terms |
+
+### Graphical user interface
+
+```bash
+python litcluster_gui.py
+```
+
+The GUI lets you open a file, adjust parameters, run clustering, browse
+clusters and papers, read abstracts, and export results — all without
+touching the command line.
+
+### Python API
+
+```python
+from litcluster import LitCluster
+
+# Load from CSV (columns: paper_id, title, abstract, authors, year, venue, doi, keywords)
+lc = LitCluster.from_csv("papers.csv", k=5)
+lc.fit()
+print(lc.summary())
+
+# Load from BibTeX
+lc = LitCluster.from_bibtex("refs.bib", k=4, min_term_freq=1)
+lc.fit()
+lc.export_json("clusters.json")
+
+# Load from JSONL
+lc = LitCluster.from_jsonl("papers.jsonl", k=3, seed=0)
+lc.fit()
+lc.export_csv("clusters.csv")
+
+# Inspect results programmatically
+for cluster in lc.clusters:
+    print(cluster.label, "—", len(cluster.papers), "papers")
+    print("Top terms:", cluster.top_terms[:5])
+    for paper in cluster.papers:
+        print(" •", paper.title)
+```
+
+---
+
+## Input formats
+
+### CSV
+
+Required column: `title`.  All other columns are optional.
+
+```csv
+paper_id,title,abstract,authors,year,venue,doi,keywords
+1,Deep Learning for NLP,"...",Smith A.,2021,ACL,,neural;transformers
+```
+
+### JSONL
+
+One JSON object per line with the same fields as CSV.
+
+```jsonl
+{"paper_id": "1", "title": "Deep Learning for NLP", "abstract": "..."}
+{"paper_id": "2", "title": "BERT: Pre-training...", "abstract": "..."}
+```
+
+### BibTeX
+
+Standard `.bib` files; `title`, `abstract`, `author`, `year`, `journal`,
+`booktitle`, `doi`, and `keywords` fields are extracted automatically.
+
+> **Note**: The BibTeX parser uses regular expressions and supports flat
+> field values only.  Nested braces inside field values may be truncated.
+
+---
+
+## Algorithm
+
+1. **Tokenisation** — Lower-case, alphabetic tokens of length ≥ 3, with a
+   built-in English stopword list applied.
+2. **TF-IDF vectorisation** — Smooth IDF weighting (sklearn-compatible).
+   Terms below `--min-freq` document frequency are discarded to reduce noise.
+3. **k-means clustering** — Lloyd's algorithm with cosine similarity.
+   Centroids are reinitialised if a cluster becomes empty.
+4. **Top-term extraction** — Each cluster is labelled with its highest-scoring
+   TF-IDF terms across member papers.
+
+---
+
+## Running tests
+
+```bash
+pip install pytest
+pytest tests/ -v
+```
+
+---
+
+## Project structure
+
+```
+litcluster/
+├── litcluster.py        # Core library and CLI
+├── litcluster_gui.py    # Tkinter GUI (stdlib only)
+├── tests/
+│   └── test_litcluster.py
+├── paper.md             # JOSS manuscript
+├── paper.bib
+└── pyproject.toml
+```
+
+---
+
+## License
+
+MIT — see [LICENSE](LICENSE).
+
+## Citation
+
+If you use `litcluster` in research, please cite the accompanying JOSS paper
+(see [CITATION.cff](CITATION.cff)).

--- a/litcluster.py
+++ b/litcluster.py
@@ -1,8 +1,26 @@
 #!/usr/bin/env python3
 """
-litcluster.py — Literature Clustering Tool
-Clusters academic papers by topic using TF-IDF + k-means (pure stdlib).
-Stdlib-only. No external dependencies.
+litcluster — Literature Clustering Tool
+
+Clusters academic papers by topic using TF-IDF + k-means (pure Python stdlib).
+No external dependencies required.
+
+Usage
+-----
+As a script::
+
+    python litcluster.py papers.bib -k 5 --format summary
+
+Via the installed CLI::
+
+    litcluster papers.bib -k 5 --format summary
+
+Via the Python API::
+
+    from litcluster import LitCluster
+    lc = LitCluster.from_csv("papers.csv", k=5)
+    lc.fit()
+    print(lc.summary())
 """
 
 from __future__ import annotations
@@ -11,11 +29,14 @@ import argparse
 import csv
 import json
 import math
+import random
 import re
 import sys
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Tuple
+
+__all__ = ["Paper", "Cluster", "LitCluster"]
 
 
 # ---------------------------------------------------------------------------
@@ -23,31 +44,39 @@ from typing import Dict, List, Optional, Tuple
 # ---------------------------------------------------------------------------
 
 _STOPWORDS = {
-    'a','an','the','and','or','but','in','on','at','to','for','of','with',
-    'by','from','is','was','are','were','be','been','being','have','has',
-    'had','do','does','did','will','would','could','should','may','might',
-    'this','that','these','those','it','its','we','our','they','their',
-    'as','if','not','no','nor','so','yet','both','either','whether',
-    'each','few','more','most','other','some','such','than','too','very',
-    'just','also','only','then','here','there','when','where','who','which',
-    'how','all','any','can','into','through','during','before','after',
-    'above','below','between','out','off','over','under','again','further',
-    'once','i','my','me','he','she','his','her','him','you','your',
+    'a', 'an', 'the', 'and', 'or', 'but', 'in', 'on', 'at', 'to', 'for',
+    'of', 'with', 'by', 'from', 'is', 'was', 'are', 'were', 'be', 'been',
+    'being', 'have', 'has', 'had', 'do', 'does', 'did', 'will', 'would',
+    'could', 'should', 'may', 'might', 'this', 'that', 'these', 'those',
+    'it', 'its', 'we', 'our', 'they', 'their', 'as', 'if', 'not', 'no',
+    'nor', 'so', 'yet', 'both', 'either', 'whether', 'each', 'few', 'more',
+    'most', 'other', 'some', 'such', 'than', 'too', 'very', 'just', 'also',
+    'only', 'then', 'here', 'there', 'when', 'where', 'who', 'which', 'how',
+    'all', 'any', 'can', 'into', 'through', 'during', 'before', 'after',
+    'above', 'below', 'between', 'out', 'off', 'over', 'under', 'again',
+    'further', 'once', 'i', 'my', 'me', 'he', 'she', 'his', 'her', 'him',
+    'you', 'your',
 }
 
 
 def _tokenise(text: str) -> List[str]:
+    """Return lower-cased alphabetic tokens of length >= 3, stopwords removed."""
     tokens = re.findall(r"[a-zA-Z]{3,}", text.lower())
     return [t for t in tokens if t not in _STOPWORDS]
 
 
-def _tfidf(documents: List[List[str]]) -> Tuple[List[Dict[str,float]], List[str]]:
-    """Compute TF-IDF vectors. Returns (vectors, vocab)."""
+def _tfidf(documents: List[List[str]]) -> Tuple[List[Dict[str, float]], List[str]]:
+    """Compute TF-IDF vectors (sklearn-style smooth IDF).
+
+    Returns
+    -------
+    vectors : list of sparse dicts mapping term -> weight
+    vocab   : sorted list of all terms across the corpus
+    """
     n = len(documents)
     if n == 0:
         return [], []
 
-    # Build vocab
     vocab_set: set = set()
     for doc in documents:
         vocab_set.update(doc)
@@ -55,15 +84,12 @@ def _tfidf(documents: List[List[str]]) -> Tuple[List[Dict[str,float]], List[str]
     term_idx = {t: i for i, t in enumerate(vocab)}
     V = len(vocab)
 
-    # Document frequency
     df = [0] * V
     for doc in documents:
-        doc_set = set(doc)
-        for t in doc_set:
+        for t in set(doc):
             if t in term_idx:
                 df[term_idx[t]] += 1
 
-    # TF-IDF
     vectors: List[Dict[str, float]] = []
     for doc in documents:
         tf: Dict[int, int] = {}
@@ -83,10 +109,11 @@ def _tfidf(documents: List[List[str]]) -> Tuple[List[Dict[str,float]], List[str]
 
 
 def _cosine(a: Dict[str, float], b: Dict[str, float]) -> float:
-    dot = sum(a.get(t, 0.0) * b.get(t, 0.0) for t in b)
-    norm_a = math.sqrt(sum(v*v for v in a.values()))
-    norm_b = math.sqrt(sum(v*v for v in b.values()))
-    if norm_a == 0 or norm_b == 0:
+    """Cosine similarity between two sparse TF-IDF vectors."""
+    dot = sum(a.get(t, 0.0) * v for t, v in b.items())
+    norm_a = math.sqrt(sum(v * v for v in a.values()))
+    norm_b = math.sqrt(sum(v * v for v in b.values()))
+    if norm_a == 0.0 or norm_b == 0.0:
         return 0.0
     return dot / (norm_a * norm_b)
 
@@ -97,42 +124,38 @@ def _kmeans(
     max_iter: int = 100,
     seed: int = 42,
 ) -> List[int]:
-    """Lloyd's k-means on sparse TF-IDF vectors."""
+    """Lloyd's k-means on sparse TF-IDF vectors using cosine similarity."""
     n = len(vectors)
     if n == 0:
         return []
     k = min(k, n)
 
-    # Seeded centroid initialisation (evenly spaced)
-    import random
     rng = random.Random(seed)
     centroid_indices = rng.sample(range(n), k)
     centroids = [dict(vectors[i]) for i in centroid_indices]
     labels = [0] * n
 
     for _ in range(max_iter):
-        # Assignment
-        new_labels = []
-        for vec in vectors:
-            best = max(range(k), key=lambda c: _cosine(vec, centroids[c]))
-            new_labels.append(best)
-
+        new_labels = [
+            max(range(k), key=lambda c, vec=vec: _cosine(vec, centroids[c]))
+            for vec in vectors
+        ]
         if new_labels == labels:
             break
         labels = new_labels
 
-        # Update centroids
         for c in range(k):
-            members = [vectors[i] for i, l in enumerate(labels) if l == c]
+            members = [vectors[i] for i, lbl in enumerate(labels) if lbl == c]
             if not members:
-                centroids[c] = dict(vectors[rng.randint(0, n-1)])
+                # Reinitialise empty cluster to a random point
+                centroids[c] = dict(vectors[rng.randint(0, n - 1)])
                 continue
             new_centroid: Dict[str, float] = {}
             for vec in members:
                 for t, v in vec.items():
                     new_centroid[t] = new_centroid.get(t, 0.0) + v
-            total = len(members)
-            centroids[c] = {t: v/total for t, v in new_centroid.items()}
+            m = len(members)
+            centroids[c] = {t: v / m for t, v in new_centroid.items()}
 
     return labels
 
@@ -143,6 +166,8 @@ def _kmeans(
 
 @dataclass
 class Paper:
+    """A single academic paper with bibliographic metadata."""
+
     paper_id: str
     title: str
     abstract: str = ""
@@ -154,25 +179,34 @@ class Paper:
 
     @property
     def text(self) -> str:
+        """Combined text used for vectorisation (title + abstract + keywords)."""
         return f"{self.title} {self.abstract} {self.keywords}"
 
     def to_dict(self) -> dict:
         return {
-            "paper_id": self.paper_id, "title": self.title, "abstract": self.abstract,
-            "authors": self.authors, "year": self.year, "venue": self.venue,
-            "doi": self.doi, "keywords": self.keywords,
+            "paper_id": self.paper_id,
+            "title": self.title,
+            "abstract": self.abstract,
+            "authors": self.authors,
+            "year": self.year,
+            "venue": self.venue,
+            "doi": self.doi,
+            "keywords": self.keywords,
         }
 
 
 @dataclass
 class Cluster:
+    """A group of thematically related papers."""
+
     cluster_id: int
     papers: List[Paper] = field(default_factory=list)
     top_terms: List[str] = field(default_factory=list)
 
     @property
     def label(self) -> str:
-        return f"Cluster {self.cluster_id}: {', '.join(self.top_terms[:3])}"
+        terms = ", ".join(self.top_terms[:3]) if self.top_terms else "—"
+        return f"Cluster {self.cluster_id}: {terms}"
 
     def to_dict(self) -> dict:
         return {
@@ -189,8 +223,38 @@ class Cluster:
 # ---------------------------------------------------------------------------
 
 class LitCluster:
-    def __init__(self, k: int = 5, max_iter: int = 100, seed: int = 42,
-                 min_term_freq: int = 2):
+    """Topic-based clusterer for collections of academic literature.
+
+    Parameters
+    ----------
+    k             : number of clusters (default 5)
+    max_iter      : maximum k-means iterations (default 100)
+    seed          : random seed for reproducibility (default 42)
+    min_term_freq : discard vocabulary terms that appear in fewer than this
+                    many documents; reduces noise in small corpora (default 2)
+
+    Examples
+    --------
+    >>> lc = LitCluster.from_csv("papers.csv", k=3)
+    >>> lc.fit()
+    >>> print(lc.summary())
+
+    >>> lc = LitCluster.from_bibtex("refs.bib", k=5, min_term_freq=1)
+    >>> lc.fit()
+    >>> lc.export_json("clusters.json")
+    """
+
+    def __init__(
+        self,
+        k: int = 5,
+        max_iter: int = 100,
+        seed: int = 42,
+        min_term_freq: int = 2,
+    ):
+        if k < 1:
+            raise ValueError(f"k must be >= 1, got {k}")
+        if max_iter < 1:
+            raise ValueError(f"max_iter must be >= 1, got {max_iter}")
         self.k = k
         self.max_iter = max_iter
         self.seed = seed
@@ -201,10 +265,20 @@ class LitCluster:
         self._vectors: List[Dict[str, float]] = []
         self._vocab: List[str] = []
 
+    # ------------------------------------------------------------------
+    # Loaders
+    # ------------------------------------------------------------------
+
     @classmethod
-    def from_csv(cls, path: Path, **kwargs) -> "LitCluster":
+    def from_csv(cls, path, **kwargs) -> "LitCluster":
+        """Load papers from a CSV file.
+
+        Expected columns: ``paper_id``, ``title``, ``abstract``, ``authors``,
+        ``year``, ``venue``, ``doi``, ``keywords``.  Only ``title`` is
+        required; all other columns fall back to empty strings if absent.
+        """
         obj = cls(**kwargs)
-        with path.open(encoding="utf-8", errors="replace", newline="") as fh:
+        with Path(path).open(encoding="utf-8", errors="replace", newline="") as fh:
             reader = csv.DictReader(fh)
             for i, row in enumerate(reader):
                 obj.papers.append(Paper(
@@ -220,9 +294,13 @@ class LitCluster:
         return obj
 
     @classmethod
-    def from_jsonl(cls, path: Path, **kwargs) -> "LitCluster":
+    def from_jsonl(cls, path, **kwargs) -> "LitCluster":
+        """Load papers from a JSONL file (one JSON object per line).
+
+        Each object may contain the same keys as the CSV loader.
+        """
         obj = cls(**kwargs)
-        with path.open(encoding="utf-8") as fh:
+        with Path(path).open(encoding="utf-8") as fh:
             for i, line in enumerate(fh):
                 line = line.strip()
                 if not line:
@@ -241,57 +319,87 @@ class LitCluster:
         return obj
 
     @classmethod
-    def from_bibtex(cls, path: Path, **kwargs) -> "LitCluster":
-        """Parse a BibTeX file for titles, abstracts, keywords."""
+    def from_bibtex(cls, path, **kwargs) -> "LitCluster":
+        """Parse a BibTeX file for titles, abstracts, and keywords.
+
+        .. note::
+            The parser uses regular expressions and supports flat field values
+            only.  Nested braces inside field values may cause truncation.
+        """
         obj = cls(**kwargs)
-        text = path.read_text(encoding="utf-8", errors="replace")
+        text = Path(path).read_text(encoding="utf-8", errors="replace")
         entries = re.split(r'(?=@\w+\s*\{)', text)
         for i, entry in enumerate(entries):
             if not entry.strip() or not entry.startswith('@'):
                 continue
-            def _get(field):
-                m = re.search(rf'{field}\s*=\s*[{{"](.*?)[}}"\,]', entry, re.IGNORECASE | re.DOTALL)
+
+            def _field(fname: str, _entry: str = entry) -> str:
+                m = re.search(
+                    rf'{fname}\s*=\s*[{{"](.*?)[}}"\,]',
+                    _entry, re.IGNORECASE | re.DOTALL,
+                )
                 return m.group(1).strip() if m else ""
+
             m_key = re.match(r'@\w+\s*\{\s*(\S+?)[,}]', entry)
             key = m_key.group(1) if m_key else str(i)
             obj.papers.append(Paper(
-                paper_id=key, title=_get('title'), abstract=_get('abstract'),
-                authors=_get('author'), year=_get('year'),
-                venue=_get('journal') or _get('booktitle'),
-                doi=_get('doi'), keywords=_get('keywords'),
+                paper_id=key,
+                title=_field('title'),
+                abstract=_field('abstract'),
+                authors=_field('author'),
+                year=_field('year'),
+                venue=_field('journal') or _field('booktitle'),
+                doi=_field('doi'),
+                keywords=_field('keywords'),
             ))
         return obj
 
+    # ------------------------------------------------------------------
+    # Fitting
+    # ------------------------------------------------------------------
+
     def fit(self) -> "LitCluster":
+        """Vectorise papers with TF-IDF and cluster with k-means.
+
+        Returns
+        -------
+        self
+            Enables method chaining.
+        """
         if not self.papers:
             return self
+
         tokens_list = [_tokenise(p.text) for p in self.papers]
 
-        # Filter rare terms
         if self.min_term_freq > 1:
             freq: Dict[str, int] = {}
             for tokens in tokens_list:
                 for t in set(tokens):
                     freq[t] = freq.get(t, 0) + 1
-            tokens_list = [[t for t in tokens if freq.get(t, 0) >= self.min_term_freq]
-                           for tokens in tokens_list]
+            tokens_list = [
+                [t for t in tokens if freq.get(t, 0) >= self.min_term_freq]
+                for tokens in tokens_list
+            ]
 
         self._vectors, self._vocab = _tfidf(tokens_list)
         self._labels = _kmeans(self._vectors, self.k, self.max_iter, self.seed)
 
-        # Build cluster objects
-        clusters: Dict[int, List] = {}
-        for paper, label in zip(self.papers, self._labels):
-            clusters.setdefault(label, []).append(paper)
+        clusters_map: Dict[int, List[Paper]] = {}
+        for paper, lbl in zip(self.papers, self._labels):
+            clusters_map.setdefault(lbl, []).append(paper)
 
         self.clusters = []
-        for cid in sorted(clusters):
+        for cid in sorted(clusters_map):
             top_terms = self._top_terms_for_cluster(cid, n=10)
-            self.clusters.append(Cluster(cluster_id=cid, papers=clusters[cid], top_terms=top_terms))
+            self.clusters.append(
+                Cluster(cluster_id=cid, papers=clusters_map[cid], top_terms=top_terms)
+            )
         return self
 
     def _top_terms_for_cluster(self, cid: int, n: int = 10) -> List[str]:
-        member_vecs = [self._vectors[i] for i, l in enumerate(self._labels) if l == cid]
+        member_vecs = [
+            self._vectors[i] for i, lbl in enumerate(self._labels) if lbl == cid
+        ]
         if not member_vecs:
             return []
         scores: Dict[str, float] = {}
@@ -300,23 +408,43 @@ class LitCluster:
                 scores[t] = scores.get(t, 0.0) + v
         return sorted(scores, key=lambda t: -scores[t])[:n]
 
-    def export_csv(self, path: Path) -> None:
-        with path.open("w", newline="", encoding="utf-8") as fh:
+    # ------------------------------------------------------------------
+    # Export
+    # ------------------------------------------------------------------
+
+    def export_csv(self, path) -> None:
+        """Write cluster assignments to a CSV file."""
+        with Path(path).open("w", newline="", encoding="utf-8") as fh:
             w = csv.writer(fh)
-            w.writerow(["cluster_id","cluster_label","paper_id","title","authors","year","venue","doi"])
+            w.writerow([
+                "cluster_id", "cluster_label", "paper_id",
+                "title", "authors", "year", "venue", "doi",
+            ])
             for cluster in self.clusters:
                 for p in cluster.papers:
-                    w.writerow([cluster.cluster_id, cluster.label, p.paper_id,
-                                p.title, p.authors, p.year, p.venue, p.doi])
+                    w.writerow([
+                        cluster.cluster_id, cluster.label, p.paper_id,
+                        p.title, p.authors, p.year, p.venue, p.doi,
+                    ])
 
-    def export_json(self, path: Path) -> None:
-        with path.open("w", encoding="utf-8") as fh:
-            json.dump([c.to_dict() for c in self.clusters], fh, indent=2, ensure_ascii=False)
+    def export_json(self, path) -> None:
+        """Write full cluster data (including abstracts) to a JSON file."""
+        with Path(path).open("w", encoding="utf-8") as fh:
+            json.dump(
+                [c.to_dict() for c in self.clusters],
+                fh, indent=2, ensure_ascii=False,
+            )
 
     def summary(self) -> str:
-        lines = [f"LitCluster: {len(self.papers)} papers in {len(self.clusters)} clusters", ""]
+        """Return a plain-text summary of clustering results."""
+        lines = [
+            f"LitCluster: {len(self.papers)} papers → {len(self.clusters)} clusters",
+            "",
+        ]
         for c in self.clusters:
-            lines.append(f"  [{c.cluster_id}] {c.label} ({len(c.papers)} papers)")
+            lines.append(
+                f"  [{c.cluster_id:2d}] {c.label}  ({len(c.papers)} papers)"
+            )
         return "\n".join(lines)
 
 
@@ -325,37 +453,59 @@ class LitCluster:
 # ---------------------------------------------------------------------------
 
 def _parse_args(argv=None):
-    p = argparse.ArgumentParser(prog="litcluster",
-                                description="Cluster academic papers by topic using TF-IDF + k-means.")
+    p = argparse.ArgumentParser(
+        prog="litcluster",
+        description="Cluster academic papers by topic using TF-IDF + k-means.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
     p.add_argument("input", help="Input file: CSV, JSONL, or .bib")
-    p.add_argument("-k", "--clusters", type=int, default=5, dest="k",
-                   help="Number of clusters (default: 5)")
-    p.add_argument("--format", choices=["csv","json","summary"], default="summary")
-    p.add_argument("--output", "-o", default=None, help="Output file (default: stdout/auto)")
-    p.add_argument("--seed", type=int, default=42)
-    p.add_argument("--max-iter", type=int, default=100)
-    p.add_argument("--min-freq", type=int, default=2,
-                   help="Minimum term frequency to include in vocabulary (default: 2)")
+    p.add_argument(
+        "-k", "--clusters", type=int, default=5, dest="k",
+        help="Number of clusters",
+    )
+    p.add_argument(
+        "--format", choices=["csv", "json", "summary"], default="summary",
+        help="Output format",
+    )
+    p.add_argument(
+        "--output", "-o", default=None,
+        help="Output file path (default: stdout for summary, auto-named otherwise)",
+    )
+    p.add_argument("--seed", type=int, default=42, help="Random seed")
+    p.add_argument("--max-iter", type=int, default=100, help="Max k-means iterations")
+    p.add_argument(
+        "--min-freq", type=int, default=2,
+        help="Minimum document frequency for vocabulary terms",
+    )
     return p.parse_args(argv)
 
 
 def main(argv=None) -> int:
+    """CLI entry point."""
     args = _parse_args(argv)
     path = Path(args.input)
     if not path.is_file():
-        print(f"Error: {path} not found", file=sys.stderr)
+        print(f"Error: '{path}' not found.", file=sys.stderr)
         return 1
 
-    suffix = path.suffix.lower()
-    kwargs = dict(k=args.k, max_iter=args.max_iter, seed=args.seed, min_term_freq=args.min_freq)
-    if suffix == ".bib":
-        lc = LitCluster.from_bibtex(path, **kwargs)
-    elif suffix == ".jsonl":
-        lc = LitCluster.from_jsonl(path, **kwargs)
-    else:
-        lc = LitCluster.from_csv(path, **kwargs)
-
-    lc.fit()
+    try:
+        kwargs = dict(
+            k=args.k,
+            max_iter=args.max_iter,
+            seed=args.seed,
+            min_term_freq=args.min_freq,
+        )
+        suffix = path.suffix.lower()
+        if suffix == ".bib":
+            lc = LitCluster.from_bibtex(path, **kwargs)
+        elif suffix == ".jsonl":
+            lc = LitCluster.from_jsonl(path, **kwargs)
+        else:
+            lc = LitCluster.from_csv(path, **kwargs)
+        lc.fit()
+    except (OSError, json.JSONDecodeError, ValueError) as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
 
     if args.format == "summary":
         output = lc.summary()
@@ -373,6 +523,10 @@ def main(argv=None) -> int:
         print(f"Clusters written to {out}")
 
     return 0
+
+
+# Alias kept for backward compatibility with any external references
+_cli = main
 
 
 if __name__ == "__main__":

--- a/litcluster_gui.py
+++ b/litcluster_gui.py
@@ -1,0 +1,345 @@
+#!/usr/bin/env python3
+"""
+litcluster_gui.py — Tkinter GUI for the litcluster literature-clustering tool.
+
+Launch
+------
+    python litcluster_gui.py
+
+Requires only the Python standard library (tkinter is included in CPython).
+"""
+
+from __future__ import annotations
+
+import sys
+import threading
+from pathlib import Path
+from tkinter import filedialog, messagebox, ttk
+import tkinter as tk
+from typing import Optional
+
+# Allow running from the repository root without a full install
+sys.path.insert(0, str(Path(__file__).parent))
+from litcluster import LitCluster, Cluster, Paper
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _truncate(text: str, max_len: int = 80) -> str:
+    return text if len(text) <= max_len else text[: max_len - 1] + "…"
+
+
+# ---------------------------------------------------------------------------
+# Main window
+# ---------------------------------------------------------------------------
+
+class LitClusterApp(tk.Tk):
+    """Top-level application window."""
+
+    # ---- construction ------------------------------------------------------
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.title("LitCluster — Literature Clustering Tool")
+        self.minsize(820, 560)
+        self._lc: Optional[LitCluster] = None
+        self._build_menu()
+        self._build_ui()
+        self.columnconfigure(0, weight=1)
+        self.rowconfigure(2, weight=1)
+
+    def _build_menu(self) -> None:
+        menubar = tk.Menu(self)
+        self.config(menu=menubar)
+
+        file_menu = tk.Menu(menubar, tearoff=False)
+        menubar.add_cascade(label="File", menu=file_menu)
+        file_menu.add_command(label="Open…", accelerator="Ctrl+O",
+                              command=self._browse)
+        file_menu.add_separator()
+        file_menu.add_command(label="Export CSV…", command=self._export_csv)
+        file_menu.add_command(label="Export JSON…", command=self._export_json)
+        file_menu.add_separator()
+        file_menu.add_command(label="Quit", command=self.destroy)
+        self.bind_all("<Control-o>", lambda _e: self._browse())
+
+        help_menu = tk.Menu(menubar, tearoff=False)
+        menubar.add_cascade(label="Help", menu=help_menu)
+        help_menu.add_command(label="About", command=self._show_about)
+
+    def _build_ui(self) -> None:
+        pad = {"padx": 8, "pady": 4}
+
+        # ---- Input row -------------------------------------------------------
+        input_frame = ttk.LabelFrame(self, text="Input file", padding=6)
+        input_frame.grid(row=0, column=0, sticky="ew", **pad)
+        input_frame.columnconfigure(1, weight=1)
+
+        ttk.Label(input_frame, text="Path:").grid(row=0, column=0, sticky="w")
+        self._path_var = tk.StringVar()
+        ttk.Entry(input_frame, textvariable=self._path_var).grid(
+            row=0, column=1, sticky="ew", padx=(6, 6))
+        ttk.Button(input_frame, text="Browse…", command=self._browse).grid(
+            row=0, column=2)
+
+        # ---- Parameters + actions -------------------------------------------
+        ctrl_frame = ttk.Frame(self)
+        ctrl_frame.grid(row=1, column=0, sticky="ew", **pad)
+        ctrl_frame.columnconfigure(4, weight=1)
+
+        param_defs = [
+            ("Clusters (k):", "_k_var", 1, 999, 5),
+            ("Min term freq:", "_minfreq_var", 1, 999, 2),
+            ("Seed:", "_seed_var", 0, 99999, 42),
+            ("Max iterations:", "_maxiter_var", 1, 9999, 100),
+        ]
+        for col, (label, attr, lo, hi, default) in enumerate(param_defs):
+            ttk.Label(ctrl_frame, text=label).grid(
+                row=0, column=col * 2, sticky="e", padx=(8, 2))
+            var = tk.IntVar(value=default)
+            setattr(self, attr, var)
+            ttk.Spinbox(ctrl_frame, textvariable=var, from_=lo, to=hi,
+                        width=7).grid(row=0, column=col * 2 + 1, sticky="w")
+
+        btn_frame = ttk.Frame(ctrl_frame)
+        btn_frame.grid(row=0, column=9, sticky="e", padx=(16, 0))
+        self._run_btn = ttk.Button(btn_frame, text="▶  Run", command=self._run,
+                                   width=10)
+        self._run_btn.pack(side="left", padx=4)
+        ttk.Button(btn_frame, text="Export CSV", command=self._export_csv,
+                   width=12).pack(side="left", padx=4)
+        ttk.Button(btn_frame, text="Export JSON", command=self._export_json,
+                   width=12).pack(side="left", padx=4)
+
+        # ---- Status bar ------------------------------------------------------
+        self._status_var = tk.StringVar(value="Ready. Open a CSV, JSONL, or .bib file.")
+        status_bar = ttk.Label(self, textvariable=self._status_var,
+                               relief="sunken", anchor="w")
+        status_bar.grid(row=3, column=0, sticky="ew", padx=0, pady=(2, 0))
+
+        # ---- Results pane ----------------------------------------------------
+        pane = ttk.PanedWindow(self, orient="horizontal")
+        pane.grid(row=2, column=0, sticky="nsew", **pad)
+
+        # Left: cluster list
+        left = ttk.LabelFrame(pane, text="Clusters", padding=4)
+        pane.add(left, weight=1)
+        left.rowconfigure(0, weight=1)
+        left.columnconfigure(0, weight=1)
+
+        self._cluster_box = tk.Listbox(left, selectmode="single",
+                                       activestyle="dotbox", width=32)
+        self._cluster_box.grid(row=0, column=0, sticky="nsew")
+        self._cluster_box.bind("<<ListboxSelect>>", self._on_cluster_select)
+        _vsb(left, self._cluster_box).grid(row=0, column=1, sticky="ns")
+
+        # Right: papers + abstract
+        right = ttk.Frame(pane)
+        pane.add(right, weight=3)
+        right.columnconfigure(0, weight=1)
+        right.rowconfigure(1, weight=1)
+
+        ttk.Label(right, text="Papers in selected cluster:").grid(
+            row=0, column=0, sticky="w")
+
+        self._paper_tree = ttk.Treeview(
+            right,
+            columns=("title", "authors", "year"),
+            show="headings",
+            selectmode="browse",
+        )
+        col_widths = {"title": 340, "authors": 160, "year": 55}
+        for col, w in col_widths.items():
+            self._paper_tree.heading(col, text=col.capitalize())
+            self._paper_tree.column(col, width=w, minwidth=40, stretch=(col == "title"))
+        self._paper_tree.grid(row=1, column=0, sticky="nsew")
+        self._paper_tree.bind("<<TreeviewSelect>>", self._on_paper_select)
+        _vsb(right, self._paper_tree).grid(row=1, column=1, sticky="ns")
+
+        ttk.Label(right, text="Abstract / keywords:").grid(
+            row=2, column=0, sticky="w", pady=(4, 0))
+        self._abstract_box = tk.Text(
+            right, height=5, wrap="word", state="disabled",
+            relief="flat", background=self.cget("background"),
+        )
+        self._abstract_box.grid(row=3, column=0, columnspan=2,
+                                sticky="ew", pady=(2, 4))
+
+    # ---- event handlers ----------------------------------------------------
+
+    def _browse(self) -> None:
+        path = filedialog.askopenfilename(
+            title="Select literature file",
+            filetypes=[
+                ("All supported", "*.csv *.jsonl *.bib"),
+                ("CSV", "*.csv"),
+                ("JSONL", "*.jsonl"),
+                ("BibTeX", "*.bib"),
+                ("All files", "*"),
+            ],
+        )
+        if path:
+            self._path_var.set(path)
+
+    def _run(self) -> None:
+        path_str = self._path_var.get().strip()
+        if not path_str:
+            messagebox.showwarning("No file selected",
+                                   "Please select an input file first.")
+            return
+        path = Path(path_str)
+        if not path.is_file():
+            messagebox.showerror("File not found",
+                                 f"Cannot open:\n{path}")
+            return
+
+        self._run_btn.configure(state="disabled")
+        self._set_status("Running clustering…")
+        self.update_idletasks()
+        threading.Thread(target=self._do_clustering, args=(path,),
+                         daemon=True).start()
+
+    def _do_clustering(self, path: Path) -> None:
+        try:
+            kwargs = dict(
+                k=self._k_var.get(),
+                min_term_freq=self._minfreq_var.get(),
+                seed=self._seed_var.get(),
+                max_iter=self._maxiter_var.get(),
+            )
+            suffix = path.suffix.lower()
+            if suffix == ".bib":
+                lc = LitCluster.from_bibtex(path, **kwargs)
+            elif suffix == ".jsonl":
+                lc = LitCluster.from_jsonl(path, **kwargs)
+            else:
+                lc = LitCluster.from_csv(path, **kwargs)
+            lc.fit()
+            self._lc = lc
+            self.after(0, self._populate_results)
+        except Exception as exc:
+            self.after(0, lambda: messagebox.showerror("Clustering error", str(exc)))
+            self.after(0, lambda: self._set_status("Error — see popup."))
+        finally:
+            self.after(0, lambda: self._run_btn.configure(state="normal"))
+
+    def _populate_results(self) -> None:
+        lc = self._lc
+        self._cluster_box.delete(0, "end")
+        self._paper_tree.delete(*self._paper_tree.get_children())
+        self._set_abstract("")
+
+        for c in lc.clusters:
+            terms = ", ".join(c.top_terms[:4]) if c.top_terms else "—"
+            self._cluster_box.insert(
+                "end",
+                f"[{c.cluster_id}] {_truncate(terms, 26)} ({len(c.papers)})",
+            )
+
+        n = sum(len(c.papers) for c in lc.clusters)
+        self._set_status(
+            f"Clustering complete — {n} papers across {len(lc.clusters)} clusters."
+        )
+
+    def _on_cluster_select(self, _event=None) -> None:
+        if not self._lc:
+            return
+        sel = self._cluster_box.curselection()
+        if not sel:
+            return
+        cluster: Cluster = self._lc.clusters[sel[0]]
+        self._paper_tree.delete(*self._paper_tree.get_children())
+        self._set_abstract("")
+        for p in cluster.papers:
+            self._paper_tree.insert(
+                "", "end", iid=p.paper_id,
+                values=(_truncate(p.title, 70), _truncate(p.authors, 30), p.year),
+                tags=(p.abstract, p.keywords),
+            )
+
+    def _on_paper_select(self, _event=None) -> None:
+        sel = self._paper_tree.selection()
+        if not sel:
+            return
+        tags = self._paper_tree.item(sel[0], "tags")
+        abstract = tags[0] if tags else ""
+        keywords = tags[1] if len(tags) > 1 else ""
+        parts = []
+        if abstract:
+            parts.append(abstract)
+        if keywords:
+            parts.append(f"Keywords: {keywords}")
+        self._set_abstract("\n\n".join(parts) if parts else "(no abstract)")
+
+    # ---- utilities ---------------------------------------------------------
+
+    def _set_abstract(self, text: str) -> None:
+        self._abstract_box.configure(state="normal")
+        self._abstract_box.delete("1.0", "end")
+        if text:
+            self._abstract_box.insert("end", text)
+        self._abstract_box.configure(state="disabled")
+
+    def _set_status(self, msg: str) -> None:
+        self._status_var.set(msg)
+
+    def _export_csv(self) -> None:
+        if not self._lc:
+            messagebox.showwarning("No results", "Run clustering first.")
+            return
+        path = filedialog.asksaveasfilename(
+            title="Save cluster assignments",
+            defaultextension=".csv",
+            filetypes=[("CSV", "*.csv"), ("All files", "*")],
+        )
+        if path:
+            self._lc.export_csv(Path(path))
+            self._set_status(f"Exported CSV → {path}")
+
+    def _export_json(self) -> None:
+        if not self._lc:
+            messagebox.showwarning("No results", "Run clustering first.")
+            return
+        path = filedialog.asksaveasfilename(
+            title="Save cluster data",
+            defaultextension=".json",
+            filetypes=[("JSON", "*.json"), ("All files", "*")],
+        )
+        if path:
+            self._lc.export_json(Path(path))
+            self._set_status(f"Exported JSON → {path}")
+
+    def _show_about(self) -> None:
+        messagebox.showinfo(
+            "About LitCluster",
+            "LitCluster v0.1.0\n\n"
+            "Topic-based clustering of scientific literature\n"
+            "using TF-IDF + k-means (pure Python stdlib).\n\n"
+            "Author: Vaibhav Deshmukh\n"
+            "License: MIT",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Widget helpers
+# ---------------------------------------------------------------------------
+
+def _vsb(parent, widget) -> ttk.Scrollbar:
+    sb = ttk.Scrollbar(parent, orient="vertical", command=widget.yview)
+    widget.configure(yscrollcommand=sb.set)
+    return sb
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    app = LitClusterApp()
+    app.mainloop()
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
 ]
 
 [project.scripts]
-litcluster = "litcluster:_cli"
+litcluster = "litcluster:main"
 
 [tool.setuptools]
-py-modules = ["litcluster"]
+py-modules = ["litcluster", "litcluster_gui"]

--- a/src/litcluster/__init__.py
+++ b/src/litcluster/__init__.py
@@ -1,18 +1,30 @@
 """
-litcluster: Semantic clustering and topic modelling of scientific literature.
+litcluster: Topic-based clustering of scientific literature.
 
-Ingests collections of scientific abstracts or full papers (via DOI lists,
-BibTeX files, or arXiv IDs), embeds them using sentence-transformers, and
-applies hierarchical clustering and topic modelling to produce interactive
-visualisations and structured cluster summaries for systematic literature
-reviews.
+This package stub re-exports the public API from the canonical
+``litcluster`` module (``litcluster.py`` at the repository root).
+
+Note
+----
+The installed package is built from ``litcluster.py`` directly
+(``py-modules = ["litcluster"]`` in *pyproject.toml*).  This
+``src/litcluster/`` directory is retained for IDE discoverability and
+future restructuring to a full src-layout.
 """
+
+from litcluster import (  # noqa: F401
+    Cluster,
+    LitCluster,
+    Paper,
+    _cosine,
+    _kmeans,
+    _tfidf,
+    _tokenise,
+    main,
+)
 
 __version__ = "0.1.0"
 __author__ = "Vaibhav Deshmukh"
 __license__ = "MIT"
 
-from .cluster import LitCluster
-from .embed import PaperEmbedder
-
-__all__ = ["LitCluster", "PaperEmbedder"]
+__all__ = ["LitCluster", "Paper", "Cluster"]

--- a/tests/test_litcluster.py
+++ b/tests/test_litcluster.py
@@ -1,19 +1,522 @@
-import sys, pathlib
+"""Tests for litcluster.py.
+
+Run with:  pytest tests/ -v
+"""
+from __future__ import annotations
+
+import csv
+import json
+import pathlib
+import sys
+import tempfile
+
+import pytest
+
 sys.path.insert(0, str(pathlib.Path(__file__).parent.parent))
+import litcluster as lc
 
-def test_import():
-    import litcluster as lc
-    assert hasattr(lc, 'LitCluster')
 
-def test_paper():
-    import litcluster as lc
-    assert hasattr(lc, 'Paper')
+# ---------------------------------------------------------------------------
+# Helper: minimal synthetic corpus
+# ---------------------------------------------------------------------------
 
-def test_cluster():
-    import litcluster as lc
-    assert hasattr(lc, 'Cluster')
+_CSV_CONTENT = """\
+paper_id,title,abstract,authors,year,venue,doi,keywords
+1,Deep Neural Networks,Using neural networks for image classification,A. Smith,2020,NeurIPS,,deep learning
+2,Convolutional Architectures,CNN architectures for visual recognition tasks,B. Jones,2021,CVPR,,CNN vision
+3,Linear Regression Analysis,Statistical regression methods for prediction,C. Lee,2019,JMLR,,statistics
+4,Logistic Regression Methods,Binary classification using logistic models,D. Kim,2020,ICML,,regression
+5,Bayesian Inference,Probabilistic models and Bayesian theorem,E. Patel,2021,NeurIPS,,bayesian
+6,Random Forest Ensemble,Tree ensemble methods for classification tasks,F. Wang,2020,ICML,,ensemble trees
+"""
 
-def test_tokenise():
-    import litcluster as lc
-    tokens = lc._tokenise('hello world test foo bar')
-    assert isinstance(tokens, list) and len(tokens) > 0
+_JSONL_CONTENT = "\n".join(
+    json.dumps({"paper_id": str(i), "title": f"Paper {i}",
+                "abstract": f"Research abstract discussing topic {i}"})
+    for i in range(5)
+)
+
+_BIB_CONTENT = r"""
+@article{smith2020,
+  author  = {Smith, A.},
+  title   = {Neural Network Methods},
+  journal = {NeurIPS},
+  year    = {2020},
+  abstract = {Deep learning with neural networks},
+}
+@inproceedings{lee2019,
+  author    = {Lee, C.},
+  title     = {Statistical Regression},
+  booktitle = {JMLR},
+  year      = {2019},
+  abstract  = {Linear and logistic regression methods},
+}
+"""
+
+
+def _write_tmp(content: str, suffix: str) -> pathlib.Path:
+    tmp = tempfile.NamedTemporaryFile(
+        mode="w", suffix=suffix, delete=False, encoding="utf-8", newline=""
+    )
+    tmp.write(content)
+    tmp.close()
+    return pathlib.Path(tmp.name)
+
+
+# ---------------------------------------------------------------------------
+# Public API surface
+# ---------------------------------------------------------------------------
+
+def test_module_exposes_litcluster():
+    assert hasattr(lc, "LitCluster")
+
+
+def test_module_exposes_paper():
+    assert hasattr(lc, "Paper")
+
+
+def test_module_exposes_cluster():
+    assert hasattr(lc, "Cluster")
+
+
+# ---------------------------------------------------------------------------
+# _tokenise
+# ---------------------------------------------------------------------------
+
+def test_tokenise_returns_list():
+    assert isinstance(lc._tokenise("hello world"), list)
+
+
+def test_tokenise_min_length():
+    tokens = lc._tokenise("a ab abc abcd")
+    assert "a" not in tokens
+    assert "ab" not in tokens
+    assert "abc" in tokens
+    assert "abcd" in tokens
+
+
+def test_tokenise_removes_stopwords():
+    tokens = lc._tokenise("the quick brown fox")
+    assert "the" not in tokens
+    assert "fox" in tokens
+
+
+def test_tokenise_lowercases():
+    tokens = lc._tokenise("Neural Network")
+    assert "neural" in tokens
+    assert "network" in tokens
+
+
+def test_tokenise_empty_string():
+    assert lc._tokenise("") == []
+
+
+# ---------------------------------------------------------------------------
+# _tfidf
+# ---------------------------------------------------------------------------
+
+def test_tfidf_empty():
+    vectors, vocab = lc._tfidf([])
+    assert vectors == []
+    assert vocab == []
+
+
+def test_tfidf_single_doc():
+    vectors, vocab = lc._tfidf([["machine", "learning"]])
+    assert len(vectors) == 1
+    assert "machine" in vectors[0]
+    assert "learning" in vectors[0]
+
+
+def test_tfidf_weights_positive():
+    docs = [["neural", "network"], ["linear", "regression"]]
+    vectors, _ = lc._tfidf(docs)
+    for vec in vectors:
+        assert all(v > 0 for v in vec.values())
+
+
+def test_tfidf_vocab_sorted():
+    docs = [["zebra", "apple"], ["mango"]]
+    _, vocab = lc._tfidf(docs)
+    assert vocab == sorted(vocab)
+
+
+# ---------------------------------------------------------------------------
+# _cosine
+# ---------------------------------------------------------------------------
+
+def test_cosine_identical():
+    v = {"a": 1.0, "b": 2.0}
+    assert abs(lc._cosine(v, v) - 1.0) < 1e-9
+
+
+def test_cosine_orthogonal():
+    assert lc._cosine({"x": 1.0}, {"y": 1.0}) == 0.0
+
+
+def test_cosine_empty_vectors():
+    assert lc._cosine({}, {"a": 1.0}) == 0.0
+    assert lc._cosine({"a": 1.0}, {}) == 0.0
+
+
+def test_cosine_symmetry():
+    a = {"x": 1.0, "y": 2.0}
+    b = {"y": 1.0, "z": 3.0}
+    assert abs(lc._cosine(a, b) - lc._cosine(b, a)) < 1e-9
+
+
+# ---------------------------------------------------------------------------
+# _kmeans
+# ---------------------------------------------------------------------------
+
+def test_kmeans_empty():
+    assert lc._kmeans([], k=3) == []
+
+
+def test_kmeans_single_point():
+    assert lc._kmeans([{"a": 1.0}], k=1) == [0]
+
+
+def test_kmeans_label_count():
+    vecs = [{"a": float(i)} for i in range(6)]
+    labels = lc._kmeans(vecs, k=3)
+    assert len(labels) == 6
+
+
+def test_kmeans_k_capped_at_n():
+    vecs = [{"a": 1.0}, {"b": 1.0}]
+    labels = lc._kmeans(vecs, k=100)
+    assert len(set(labels)) <= 2
+
+
+def test_kmeans_reproducible():
+    vecs = [{"a": float(i), "b": float(i % 3)} for i in range(10)]
+    assert lc._kmeans(vecs, k=3, seed=0) == lc._kmeans(vecs, k=3, seed=0)
+
+
+# ---------------------------------------------------------------------------
+# Paper dataclass
+# ---------------------------------------------------------------------------
+
+def test_paper_text_combines_fields():
+    p = lc.Paper(paper_id="1", title="Deep Learning",
+                 abstract="Neural networks", keywords="DL")
+    assert "Deep Learning" in p.text
+    assert "Neural networks" in p.text
+    assert "DL" in p.text
+
+
+def test_paper_to_dict_keys():
+    p = lc.Paper(paper_id="p1", title="Test")
+    d = p.to_dict()
+    for key in ("paper_id", "title", "abstract", "authors", "year", "venue", "doi", "keywords"):
+        assert key in d
+
+
+def test_paper_defaults():
+    p = lc.Paper(paper_id="x", title="T")
+    assert p.abstract == ""
+    assert p.year == ""
+
+
+# ---------------------------------------------------------------------------
+# Cluster dataclass
+# ---------------------------------------------------------------------------
+
+def test_cluster_label_contains_id():
+    c = lc.Cluster(cluster_id=3, top_terms=["alpha", "beta"])
+    assert "3" in c.label
+
+
+def test_cluster_label_shows_top_terms():
+    c = lc.Cluster(cluster_id=0, top_terms=["neural", "network", "deep"])
+    assert "neural" in c.label
+
+
+def test_cluster_to_dict():
+    c = lc.Cluster(cluster_id=1, papers=[], top_terms=["foo"])
+    d = c.to_dict()
+    assert d["cluster_id"] == 1
+    assert d["size"] == 0
+    assert "papers" in d
+
+
+# ---------------------------------------------------------------------------
+# LitCluster validation
+# ---------------------------------------------------------------------------
+
+def test_litcluster_k_zero_raises():
+    with pytest.raises(ValueError):
+        lc.LitCluster(k=0)
+
+
+def test_litcluster_k_negative_raises():
+    with pytest.raises(ValueError):
+        lc.LitCluster(k=-1)
+
+
+def test_litcluster_max_iter_zero_raises():
+    with pytest.raises(ValueError):
+        lc.LitCluster(k=1, max_iter=0)
+
+
+# ---------------------------------------------------------------------------
+# LitCluster.from_csv
+# ---------------------------------------------------------------------------
+
+def test_from_csv_paper_count():
+    path = _write_tmp(_CSV_CONTENT, ".csv")
+    try:
+        obj = lc.LitCluster.from_csv(path, k=2, min_term_freq=1)
+        assert len(obj.papers) == 6
+    finally:
+        path.unlink()
+
+
+def test_from_csv_paper_fields():
+    path = _write_tmp(_CSV_CONTENT, ".csv")
+    try:
+        obj = lc.LitCluster.from_csv(path, k=2, min_term_freq=1)
+        p = obj.papers[0]
+        assert p.paper_id == "1"
+        assert "Neural" in p.title
+        assert p.year == "2020"
+    finally:
+        path.unlink()
+
+
+# ---------------------------------------------------------------------------
+# LitCluster.from_jsonl
+# ---------------------------------------------------------------------------
+
+def test_from_jsonl_paper_count():
+    path = _write_tmp(_JSONL_CONTENT, ".jsonl")
+    try:
+        obj = lc.LitCluster.from_jsonl(path, k=2, min_term_freq=1)
+        assert len(obj.papers) == 5
+    finally:
+        path.unlink()
+
+
+def test_from_jsonl_skips_blank_lines():
+    content = _JSONL_CONTENT + "\n\n"
+    path = _write_tmp(content, ".jsonl")
+    try:
+        obj = lc.LitCluster.from_jsonl(path, k=2, min_term_freq=1)
+        assert len(obj.papers) == 5
+    finally:
+        path.unlink()
+
+
+# ---------------------------------------------------------------------------
+# LitCluster.from_bibtex
+# ---------------------------------------------------------------------------
+
+def test_from_bibtex_paper_count():
+    path = _write_tmp(_BIB_CONTENT, ".bib")
+    try:
+        obj = lc.LitCluster.from_bibtex(path, k=2, min_term_freq=1)
+        assert len(obj.papers) == 2
+    finally:
+        path.unlink()
+
+
+def test_from_bibtex_field_extraction():
+    path = _write_tmp(_BIB_CONTENT, ".bib")
+    try:
+        obj = lc.LitCluster.from_bibtex(path, k=2, min_term_freq=1)
+        ids = {p.paper_id for p in obj.papers}
+        assert "smith2020" in ids
+    finally:
+        path.unlink()
+
+
+# ---------------------------------------------------------------------------
+# LitCluster.fit
+# ---------------------------------------------------------------------------
+
+def test_fit_empty_corpus():
+    obj = lc.LitCluster(k=3)
+    obj.fit()
+    assert obj.clusters == []
+
+
+def test_fit_accounts_for_all_papers():
+    path = _write_tmp(_CSV_CONTENT, ".csv")
+    try:
+        obj = lc.LitCluster.from_csv(path, k=2, min_term_freq=1)
+        obj.fit()
+        total = sum(len(c.papers) for c in obj.clusters)
+        assert total == 6
+    finally:
+        path.unlink()
+
+
+def test_fit_cluster_count():
+    path = _write_tmp(_CSV_CONTENT, ".csv")
+    try:
+        obj = lc.LitCluster.from_csv(path, k=3, min_term_freq=1)
+        obj.fit()
+        assert 1 <= len(obj.clusters) <= 3
+    finally:
+        path.unlink()
+
+
+def test_fit_top_terms_populated():
+    path = _write_tmp(_CSV_CONTENT, ".csv")
+    try:
+        obj = lc.LitCluster.from_csv(path, k=2, min_term_freq=1)
+        obj.fit()
+        for c in obj.clusters:
+            assert isinstance(c.top_terms, list)
+            assert len(c.top_terms) > 0
+    finally:
+        path.unlink()
+
+
+def test_fit_reproducible():
+    path = _write_tmp(_CSV_CONTENT, ".csv")
+    try:
+        obj1 = lc.LitCluster.from_csv(path, k=2, min_term_freq=1, seed=7)
+        obj1.fit()
+        obj2 = lc.LitCluster.from_csv(path, k=2, min_term_freq=1, seed=7)
+        obj2.fit()
+        labels1 = [p.paper_id for c in obj1.clusters for p in c.papers]
+        labels2 = [p.paper_id for c in obj2.clusters for p in c.papers]
+        assert labels1 == labels2
+    finally:
+        path.unlink()
+
+
+# ---------------------------------------------------------------------------
+# LitCluster.summary
+# ---------------------------------------------------------------------------
+
+def test_summary_contains_paper_count():
+    path = _write_tmp(_CSV_CONTENT, ".csv")
+    try:
+        obj = lc.LitCluster.from_csv(path, k=2, min_term_freq=1)
+        obj.fit()
+        s = obj.summary()
+        assert "6 papers" in s
+    finally:
+        path.unlink()
+
+
+def test_summary_empty_corpus():
+    obj = lc.LitCluster(k=2)
+    obj.fit()
+    s = obj.summary()
+    assert "0 papers" in s
+
+
+# ---------------------------------------------------------------------------
+# LitCluster.export_csv
+# ---------------------------------------------------------------------------
+
+def test_export_csv_creates_file():
+    inp = _write_tmp(_CSV_CONTENT, ".csv")
+    out = pathlib.Path(tempfile.mktemp(suffix=".csv"))
+    try:
+        obj = lc.LitCluster.from_csv(inp, k=2, min_term_freq=1)
+        obj.fit()
+        obj.export_csv(out)
+        assert out.exists()
+    finally:
+        inp.unlink()
+        out.unlink(missing_ok=True)
+
+
+def test_export_csv_header():
+    inp = _write_tmp(_CSV_CONTENT, ".csv")
+    out = pathlib.Path(tempfile.mktemp(suffix=".csv"))
+    try:
+        obj = lc.LitCluster.from_csv(inp, k=2, min_term_freq=1)
+        obj.fit()
+        obj.export_csv(out)
+        rows = list(csv.reader(out.open(encoding="utf-8")))
+        assert rows[0][0] == "cluster_id"
+        assert len(rows) == 7  # 1 header + 6 papers
+    finally:
+        inp.unlink()
+        out.unlink(missing_ok=True)
+
+
+# ---------------------------------------------------------------------------
+# LitCluster.export_json
+# ---------------------------------------------------------------------------
+
+def test_export_json_creates_file():
+    inp = _write_tmp(_CSV_CONTENT, ".csv")
+    out = pathlib.Path(tempfile.mktemp(suffix=".json"))
+    try:
+        obj = lc.LitCluster.from_csv(inp, k=2, min_term_freq=1)
+        obj.fit()
+        obj.export_json(out)
+        assert out.exists()
+    finally:
+        inp.unlink()
+        out.unlink(missing_ok=True)
+
+
+def test_export_json_structure():
+    inp = _write_tmp(_CSV_CONTENT, ".csv")
+    out = pathlib.Path(tempfile.mktemp(suffix=".json"))
+    try:
+        obj = lc.LitCluster.from_csv(inp, k=2, min_term_freq=1)
+        obj.fit()
+        obj.export_json(out)
+        data = json.loads(out.read_text(encoding="utf-8"))
+        assert isinstance(data, list)
+        assert "cluster_id" in data[0]
+        assert "papers" in data[0]
+        assert "top_terms" in data[0]
+    finally:
+        inp.unlink()
+        out.unlink(missing_ok=True)
+
+
+# ---------------------------------------------------------------------------
+# CLI (main)
+# ---------------------------------------------------------------------------
+
+def test_cli_summary(capsys):
+    path = _write_tmp(_CSV_CONTENT, ".csv")
+    try:
+        rc = lc.main([str(path), "-k", "2", "--min-freq", "1"])
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "papers" in out
+    finally:
+        path.unlink()
+
+
+def test_cli_missing_file(capsys):
+    rc = lc.main(["nonexistent_file.csv"])
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "not found" in err.lower() or "error" in err.lower()
+
+
+def test_cli_export_csv(tmp_path):
+    inp = _write_tmp(_CSV_CONTENT, ".csv")
+    out = tmp_path / "out.csv"
+    try:
+        rc = lc.main([str(inp), "-k", "2", "--min-freq", "1",
+                      "--format", "csv", "--output", str(out)])
+        assert rc == 0
+        assert out.exists()
+    finally:
+        inp.unlink()
+
+
+def test_cli_export_json(tmp_path):
+    inp = _write_tmp(_CSV_CONTENT, ".csv")
+    out = tmp_path / "out.json"
+    try:
+        rc = lc.main([str(inp), "-k", "2", "--min-freq", "1",
+                      "--format", "json", "--output", str(out)])
+        assert rc == 0
+        assert out.exists()
+    finally:
+        inp.unlink()


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Bug fixes** in `litcluster.py`: broken CLI entry point (`_cli` → `main` alias added), `import random` moved to module level, ambiguous `l` loop variables renamed to `lbl`, BibTeX `_field()` helper no longer shadows the `field` import from `dataclasses`, input validation (`k < 1`, `max_iter < 1`) raises `ValueError`
- **Code quality**: `__all__` added, public-API docstrings with parameter descriptions and usage examples, `formatter_class=ArgumentDefaultsHelpFormatter` on the CLI parser, error handling wraps `OSError`/`JSONDecodeError`/`ValueError` with a clean stderr message
- **`pyproject.toml`**: corrected entry point (`litcluster:main`), added `litcluster_gui` to `py-modules`
- **`src/litcluster/__init__.py`**: replaced broken `.cluster`/`.embed` imports with re-exports from the canonical `litcluster.py` module
- **Tests**: expanded from 4 shallow `hasattr` checks to **51 tests** covering `_tokenise`, `_tfidf`, `_cosine`, `_kmeans`, `Paper`, `Cluster`, and `LitCluster` (CSV/JSONL/BibTeX loaders, `fit`, `export_csv`, `export_json`, CLI)
- **`litcluster_gui.py`** (new): stdlib-only tkinter GUI with file browser, parameter spinboxes, threaded clustering, cluster/paper/abstract panes, CSV+JSON export, menu bar, and `Ctrl+O` keyboard shortcut
- **`README.md`**: rewritten with installation instructions, CLI reference table, Python API examples, input format docs, algorithm description, and project structure overview

## Test plan

- [ ] `pip install -e . && pytest tests/ -v` — all 51 tests pass
- [ ] `litcluster --help` shows all flags with defaults
- [ ] `litcluster refs.bib -k 3` prints a cluster summary
- [ ] `litcluster papers.csv --format csv` writes a `.clusters.csv` file
- [ ] `python litcluster_gui.py` opens the GUI, loads a file, runs clustering, shows results, and exports

https://claude.ai/code/session_01GCspfczm8g5fpkTvGMaYYQ
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GCspfczm8g5fpkTvGMaYYQ)_