### PR TITLE
Refine code to JOSS quality and add Tkinter GUI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,27 @@
+# Python
+__pycache__/
+*.py[cod]
+*.pyo
+*.pyd
+*.egg-info/
+dist/
+build/
+*.egg
+.eggs/
+
+# Virtual environments
+.venv/
+venv/
+env/
+
+# Testing
+.pytest_cache/
+.coverage
+htmlcov/
+
+# Editors / OS
+.DS_Store
+*.swp
+*.swo
+.idea/
+.vscode/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,33 @@
 # Changelog
 
-## [Unreleased]
-- BERTopic backend for interpretable topic labels (#1)
-- Semantic Scholar API for bulk paper fetching (#2)
-- Per-cluster LLM-generated summaries (#3)
+All notable changes to litcluster are documented here.
+Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## [0.1.0] - 2026-04-23
+## [Unreleased]
+
+- SPECTER2 / sentence-transformer embedding backend
+- HDBSCAN density-based clustering backend
+- UMAP 2D projection for scatter-plot visualisation
+- BERTopic integration for interpretable topic labels
+- Semantic Scholar API for bulk abstract fetching
+
+## [0.1.0] — 2026-04-23
+
 ### Added
-- SPECTER2 sentence-transformer embeddings for scientific literature
-- HDBSCAN, k-means, and agglomerative clustering backends
-- UMAP 2D projection for visualisation
-- Interactive HTML report with cluster explorer
-- BibTeX input support
-- CLI: `litcluster cluster refs.bib`
-- Python API: `LitCluster`, `PaperEmbedder`
+
+- Smoothed TF-IDF vectorisation with configurable minimum term frequency
+- Lloyd's k-means clustering on cosine distance with seeded reproducibility
+- Mean silhouette-score quality metric (cosine distance)
+- Robust BibTeX parser handling nested braces and multi-line field values
+- CSV and JSON-Lines input parsers
+- Output formats: plain-text summary, CSV, JSON, interactive self-contained HTML
+- Tkinter graphical user interface (`litcluster-gui`) with:
+  - File browser, parameter spinboxes, background clustering thread
+  - Cluster and paper tree-views with single-cluster filtering
+  - Paper detail pop-up on double-click
+  - Export shortcuts for CSV, JSON, and HTML
+- CLI: `litcluster input.bib -k 5 --format html`
+- Python API: `LitCluster`, `Paper`, `Cluster`
+- Input validation with descriptive error messages
+- Comprehensive pytest test suite (unit, integration, and CLI tests)
+- `--version` flag on CLI

--- a/README.md
+++ b/README.md
@@ -1,1 +1,160 @@
 # litcluster
+
+[![CI](https://github.com/vdeshmukh203/litcluster/actions/workflows/ci.yml/badge.svg)](https://github.com/vdeshmukh203/litcluster/actions)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+[![Python ≥ 3.8](https://img.shields.io/badge/python-%E2%89%A53.8-blue.svg)](https://python.org)
+
+**litcluster** clusters scientific papers into thematic groups using TF-IDF
+vectorisation and k-means, helping researchers organise literature for
+systematic or scoping reviews.  It accepts BibTeX, CSV, or JSON-Lines input
+and has **zero external dependencies** — pure Python standard library.
+
+## Features
+
+- **Multiple input formats** — BibTeX (`.bib`), CSV, JSON-Lines (`.jsonl`)
+- **TF-IDF + k-means** — interpretable, fully reproducible clustering
+- **Multiple output formats** — plain-text summary, CSV table, JSON, interactive HTML report
+- **Silhouette-score quality metric** — helps choose the right number of clusters
+- **Graphical user interface** — Tkinter GUI for non-command-line users
+- **Pure stdlib** — zero dependencies, works anywhere Python 3.8+ is installed
+
+## Installation
+
+```bash
+git clone https://github.com/vdeshmukh203/litcluster.git
+cd litcluster
+pip install .
+```
+
+No additional packages are required.
+
+## Quick start
+
+### Command line
+
+```bash
+# Cluster a BibTeX file into 5 groups and print a summary
+litcluster refs.bib -k 5
+
+# Export an interactive HTML report
+litcluster refs.bib -k 5 --format html -o report.html
+
+# Export a CSV table of cluster assignments
+litcluster papers.csv -k 8 --format csv -o clusters.csv
+
+# Export a structured JSON file
+litcluster papers.jsonl -k 6 --format json -o clusters.json
+```
+
+### Graphical interface
+
+```bash
+litcluster-gui            # installed entry point
+python litcluster_gui.py  # run directly
+```
+
+The GUI lets you browse for an input file, configure clustering parameters,
+view cluster assignments interactively, and export results without typing
+a command.
+
+### Python API
+
+```python
+from litcluster import LitCluster
+
+lc = LitCluster.from_bibtex("refs.bib", k=5)
+lc.fit()
+
+print(lc.summary())
+print("Silhouette score:", lc.silhouette())
+
+lc.export_html("report.html")
+lc.export_csv("clusters.csv")
+lc.export_json("clusters.json")
+
+for cluster in lc.clusters:
+    print(cluster.label, "—", len(cluster.papers), "papers")
+```
+
+## CLI reference
+
+```
+usage: litcluster [-h] [-k K] [--format {csv,json,html,summary}]
+                  [--output OUTPUT] [--seed SEED] [--max-iter MAX_ITER]
+                  [--min-freq MIN_FREQ] [--version]
+                  input
+
+positional arguments:
+  input            Input file (.bib, .csv, or .jsonl)
+
+options:
+  -k, --clusters K    Number of clusters (default: 5)
+  --format            Output format: summary | csv | json | html (default: summary)
+  --output, -o        Output file path (default: auto-named next to input)
+  --seed              Random seed for reproducibility (default: 42)
+  --max-iter          Maximum k-means iterations (default: 100)
+  --min-freq          Minimum document frequency for vocabulary (default: 2)
+  --version           Show version and exit
+```
+
+## Input formats
+
+### BibTeX (`.bib`)
+
+Standard BibTeX files.  Fields used: `title`, `abstract`, `author`, `year`,
+`journal` / `booktitle`, `doi`, `keywords`.  Nested braces and multi-line
+field values are handled correctly.
+
+### CSV
+
+Must have a header row.  Recognised columns: `paper_id`, `title`, `abstract`,
+`authors`, `year`, `venue`, `doi`, `keywords`.  Missing columns default to
+empty strings.
+
+### JSON-Lines (`.jsonl`)
+
+One JSON object per line with the same fields as CSV.
+
+## Algorithm
+
+1. **Tokenisation** — title, abstract, and keywords are concatenated, split
+   into lowercase alphabetic tokens (≥ 3 characters), and filtered for
+   English stopwords.
+2. **TF-IDF vectorisation** — a sparse, smoothed TF-IDF vector is computed
+   for each paper; terms appearing in fewer than `min_freq` documents are
+   excluded.
+3. **K-means clustering** — Lloyd's algorithm on cosine distance groups
+   papers into *k* thematic clusters.  The random seed is fixed for
+   reproducibility.
+4. **Top-term extraction** — each cluster is labelled with its highest-scoring
+   TF-IDF terms aggregated across member papers.
+5. **Silhouette score** — the mean silhouette coefficient (cosine distance) is
+   reported as a clustering-quality indicator.
+
+## Running the tests
+
+```bash
+pip install pytest
+pytest tests/ -v
+```
+
+## Contributing
+
+Bug reports and pull requests are welcome at
+<https://github.com/vdeshmukh203/litcluster>.
+
+## Citation
+
+```bibtex
+@software{deshmukh2026litcluster,
+  author  = {Deshmukh, Vaibhav},
+  title   = {litcluster: Topic-based clustering of scientific literature},
+  year    = {2026},
+  url     = {https://github.com/vdeshmukh203/litcluster},
+  license = {MIT},
+}
+```
+
+## License
+
+MIT © Vaibhav Deshmukh. See [LICENSE](LICENSE).

--- a/litcluster.py
+++ b/litcluster.py
@@ -1,8 +1,14 @@
 #!/usr/bin/env python3
 """
-litcluster.py — Literature Clustering Tool
+litcluster — Literature Clustering Tool
+========================================
 Clusters academic papers by topic using TF-IDF + k-means (pure stdlib).
-Stdlib-only. No external dependencies.
+
+Usage
+-----
+  litcluster refs.bib -k 5 --format html -o report.html
+  litcluster papers.csv -k 8 --format csv
+  python -m litcluster refs.bib
 """
 
 from __future__ import annotations
@@ -11,11 +17,15 @@ import argparse
 import csv
 import json
 import math
+import random
 import re
 import sys
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Tuple
+
+__version__ = "0.1.0"
+__all__ = ["LitCluster", "Paper", "Cluster"]
 
 
 # ---------------------------------------------------------------------------
@@ -23,47 +33,61 @@ from typing import Dict, List, Optional, Tuple
 # ---------------------------------------------------------------------------
 
 _STOPWORDS = {
-    'a','an','the','and','or','but','in','on','at','to','for','of','with',
-    'by','from','is','was','are','were','be','been','being','have','has',
-    'had','do','does','did','will','would','could','should','may','might',
-    'this','that','these','those','it','its','we','our','they','their',
-    'as','if','not','no','nor','so','yet','both','either','whether',
-    'each','few','more','most','other','some','such','than','too','very',
-    'just','also','only','then','here','there','when','where','who','which',
-    'how','all','any','can','into','through','during','before','after',
-    'above','below','between','out','off','over','under','again','further',
-    'once','i','my','me','he','she','his','her','him','you','your',
+    "a", "an", "the", "and", "or", "but", "in", "on", "at", "to", "for",
+    "of", "with", "by", "from", "is", "was", "are", "were", "be", "been",
+    "being", "have", "has", "had", "do", "does", "did", "will", "would",
+    "could", "should", "may", "might", "this", "that", "these", "those",
+    "it", "its", "we", "our", "they", "their", "as", "if", "not", "no",
+    "nor", "so", "yet", "both", "either", "whether", "each", "few", "more",
+    "most", "other", "some", "such", "than", "too", "very", "just", "also",
+    "only", "then", "here", "there", "when", "where", "who", "which", "how",
+    "all", "any", "can", "into", "through", "during", "before", "after",
+    "above", "below", "between", "out", "off", "over", "under", "again",
+    "further", "once", "i", "my", "me", "he", "she", "his", "her", "him",
+    "you", "your",
 }
 
 
 def _tokenise(text: str) -> List[str]:
+    """Tokenise *text* into lowercase alphabetic tokens, removing stopwords."""
     tokens = re.findall(r"[a-zA-Z]{3,}", text.lower())
     return [t for t in tokens if t not in _STOPWORDS]
 
 
-def _tfidf(documents: List[List[str]]) -> Tuple[List[Dict[str,float]], List[str]]:
-    """Compute TF-IDF vectors. Returns (vectors, vocab)."""
+def _tfidf(
+    documents: List[List[str]],
+    min_freq: int = 1,
+) -> Tuple[List[Dict[str, float]], List[str]]:
+    """Compute smoothed TF-IDF vectors.
+
+    Parameters
+    ----------
+    documents:
+        Token lists, one per document.
+    min_freq:
+        Minimum document-frequency for a term to be included in the vocabulary.
+
+    Returns
+    -------
+    vectors:
+        Sparse TF-IDF vector per document (dict mapping term to weight).
+    vocab:
+        Sorted list of vocabulary terms.
+    """
     n = len(documents)
     if n == 0:
         return [], []
 
-    # Build vocab
-    vocab_set: set = set()
+    df: Dict[str, int] = {}
     for doc in documents:
-        vocab_set.update(doc)
-    vocab = sorted(vocab_set)
+        for t in set(doc):
+            df[t] = df.get(t, 0) + 1
+
+    vocab = sorted(t for t, c in df.items() if c >= min_freq)
+    if not vocab:
+        return [{} for _ in documents], []
     term_idx = {t: i for i, t in enumerate(vocab)}
-    V = len(vocab)
 
-    # Document frequency
-    df = [0] * V
-    for doc in documents:
-        doc_set = set(doc)
-        for t in doc_set:
-            if t in term_idx:
-                df[term_idx[t]] += 1
-
-    # TF-IDF
     vectors: List[Dict[str, float]] = []
     for doc in documents:
         tf: Dict[int, int] = {}
@@ -76,17 +100,20 @@ def _tfidf(documents: List[List[str]]) -> Tuple[List[Dict[str,float]], List[str]
         for idx, count in tf.items():
             term = vocab[idx]
             tf_val = count / doc_len
-            idf_val = math.log((n + 1) / (df[idx] + 1)) + 1.0
+            idf_val = math.log((n + 1) / (df[term] + 1)) + 1.0
             vec[term] = tf_val * idf_val
         vectors.append(vec)
     return vectors, vocab
 
 
 def _cosine(a: Dict[str, float], b: Dict[str, float]) -> float:
-    dot = sum(a.get(t, 0.0) * b.get(t, 0.0) for t in b)
-    norm_a = math.sqrt(sum(v*v for v in a.values()))
-    norm_b = math.sqrt(sum(v*v for v in b.values()))
-    if norm_a == 0 or norm_b == 0:
+    """Cosine similarity between two sparse vectors."""
+    if not a or not b:
+        return 0.0
+    dot = sum(a.get(t, 0.0) * v for t, v in b.items())
+    norm_a = math.sqrt(sum(v * v for v in a.values()))
+    norm_b = math.sqrt(sum(v * v for v in b.values()))
+    if norm_a == 0.0 or norm_b == 0.0:
         return 0.0
     return dot / (norm_a * norm_b)
 
@@ -97,44 +124,134 @@ def _kmeans(
     max_iter: int = 100,
     seed: int = 42,
 ) -> List[int]:
-    """Lloyd's k-means on sparse TF-IDF vectors."""
+    """Lloyd's k-means clustering on sparse cosine-distance vectors.
+
+    Parameters
+    ----------
+    vectors:
+        Sparse TF-IDF vectors, one per document.
+    k:
+        Desired number of clusters (clamped to ``len(vectors)``).
+    max_iter:
+        Maximum number of Lloyd iterations.
+    seed:
+        Random seed for reproducible centroid initialisation.
+
+    Returns
+    -------
+    labels : list[int]
+        Cluster index for each document.
+    """
     n = len(vectors)
     if n == 0:
         return []
     k = min(k, n)
 
-    # Seeded centroid initialisation (evenly spaced)
-    import random
     rng = random.Random(seed)
     centroid_indices = rng.sample(range(n), k)
     centroids = [dict(vectors[i]) for i in centroid_indices]
-    labels = [0] * n
+    labels: List[int] = [0] * n
 
     for _ in range(max_iter):
-        # Assignment
-        new_labels = []
-        for vec in vectors:
-            best = max(range(k), key=lambda c: _cosine(vec, centroids[c]))
-            new_labels.append(best)
-
+        new_labels = [
+            max(range(k), key=lambda c: _cosine(vec, centroids[c]))
+            for vec in vectors
+        ]
         if new_labels == labels:
             break
         labels = new_labels
 
-        # Update centroids
         for c in range(k):
-            members = [vectors[i] for i, l in enumerate(labels) if l == c]
+            members = [vectors[i] for i, lb in enumerate(labels) if lb == c]
             if not members:
-                centroids[c] = dict(vectors[rng.randint(0, n-1)])
+                centroids[c] = dict(vectors[rng.randint(0, n - 1)])
                 continue
             new_centroid: Dict[str, float] = {}
             for vec in members:
                 for t, v in vec.items():
                     new_centroid[t] = new_centroid.get(t, 0.0) + v
-            total = len(members)
-            centroids[c] = {t: v/total for t, v in new_centroid.items()}
+            m = len(members)
+            centroids[c] = {t: v / m for t, v in new_centroid.items()}
 
     return labels
+
+
+def _silhouette_score(
+    vectors: List[Dict[str, float]], labels: List[int]
+) -> float:
+    """Mean silhouette coefficient for a clustering result.
+
+    Computes pairwise cosine distances (O(n²)).  For corpora larger than a
+    few thousand papers, consider sampling before calling this function.
+
+    Returns a value in [-1, 1]; values close to +1 indicate well-separated
+    clusters.  Returns 0.0 when fewer than two distinct clusters are present.
+    """
+    n = len(vectors)
+    if n < 2:
+        return 0.0
+    cluster_ids = set(labels)
+    if len(cluster_ids) < 2:
+        return 0.0
+
+    cluster_members: Dict[int, List[int]] = {c: [] for c in cluster_ids}
+    for i, lb in enumerate(labels):
+        cluster_members[lb].append(i)
+
+    scores: List[float] = []
+    for i in range(n):
+        same = [j for j in cluster_members[labels[i]] if j != i]
+        if not same:
+            scores.append(0.0)
+            continue
+        a = sum(1.0 - _cosine(vectors[i], vectors[j]) for j in same) / len(same)
+        other = [
+            c for c in cluster_ids if c != labels[i] and cluster_members[c]
+        ]
+        if not other:
+            scores.append(0.0)
+            continue
+        b = min(
+            sum(1.0 - _cosine(vectors[i], vectors[j]) for j in cluster_members[c])
+            / len(cluster_members[c])
+            for c in other
+        )
+        denom = max(a, b)
+        scores.append((b - a) / denom if denom > 0.0 else 0.0)
+
+    return sum(scores) / len(scores) if scores else 0.0
+
+
+# ---------------------------------------------------------------------------
+# BibTeX field extractor
+# ---------------------------------------------------------------------------
+
+def _bibtex_field(entry: str, field_name: str) -> str:
+    """Extract a field value from a BibTeX entry.
+
+    Handles ``field = {braced value}``, ``field = "quoted value"``, and bare
+    numeric values.  Correctly handles nested braces inside ``{…}`` values.
+    """
+    pat = re.compile(rf"\b{re.escape(field_name)}\s*=\s*", re.IGNORECASE)
+    m = pat.search(entry)
+    if not m:
+        return ""
+    rest = entry[m.end():].lstrip()
+    if rest.startswith("{"):
+        depth = 0
+        for i, ch in enumerate(rest):
+            if ch == "{":
+                depth += 1
+            elif ch == "}":
+                depth -= 1
+                if depth == 0:
+                    return rest[1:i].strip()
+        return ""
+    if rest.startswith('"'):
+        end = rest.find('"', 1)
+        return rest[1:end].strip() if end != -1 else ""
+    m2 = re.match(r"(\w+)", rest)
+    return m2.group(1) if m2 else ""
 
 
 # ---------------------------------------------------------------------------
@@ -143,6 +260,8 @@ def _kmeans(
 
 @dataclass
 class Paper:
+    """A single scientific paper with bibliographic metadata."""
+
     paper_id: str
     title: str
     abstract: str = ""
@@ -154,25 +273,35 @@ class Paper:
 
     @property
     def text(self) -> str:
+        """Combined text used for vectorisation (title + abstract + keywords)."""
         return f"{self.title} {self.abstract} {self.keywords}"
 
     def to_dict(self) -> dict:
         return {
-            "paper_id": self.paper_id, "title": self.title, "abstract": self.abstract,
-            "authors": self.authors, "year": self.year, "venue": self.venue,
-            "doi": self.doi, "keywords": self.keywords,
+            "paper_id": self.paper_id,
+            "title": self.title,
+            "abstract": self.abstract,
+            "authors": self.authors,
+            "year": self.year,
+            "venue": self.venue,
+            "doi": self.doi,
+            "keywords": self.keywords,
         }
 
 
 @dataclass
 class Cluster:
+    """A thematic cluster of papers."""
+
     cluster_id: int
     papers: List[Paper] = field(default_factory=list)
     top_terms: List[str] = field(default_factory=list)
 
     @property
     def label(self) -> str:
-        return f"Cluster {self.cluster_id}: {', '.join(self.top_terms[:3])}"
+        """Short human-readable label derived from top terms."""
+        terms = ", ".join(self.top_terms[:3]) if self.top_terms else "uncategorised"
+        return f"Cluster {self.cluster_id}: {terms}"
 
     def to_dict(self) -> dict:
         return {
@@ -189,8 +318,41 @@ class Cluster:
 # ---------------------------------------------------------------------------
 
 class LitCluster:
-    def __init__(self, k: int = 5, max_iter: int = 100, seed: int = 42,
-                 min_term_freq: int = 2):
+    """Topic-based clustering of scientific papers.
+
+    Parameters
+    ----------
+    k:
+        Number of clusters.  Must be ≥ 1.
+    max_iter:
+        Maximum k-means iterations.
+    seed:
+        Random seed for reproducible results.
+    min_term_freq:
+        Minimum number of documents a term must appear in to be included in
+        the vocabulary.  Setting this to 1 includes all terms.
+
+    Examples
+    --------
+    >>> lc = LitCluster.from_bibtex("refs.bib", k=5)
+    >>> lc.fit()
+    >>> print(lc.summary())
+    >>> lc.export_html("report.html")
+    """
+
+    def __init__(
+        self,
+        k: int = 5,
+        max_iter: int = 100,
+        seed: int = 42,
+        min_term_freq: int = 2,
+    ) -> None:
+        if k < 1:
+            raise ValueError(f"k must be ≥ 1, got {k}")
+        if max_iter < 1:
+            raise ValueError(f"max_iter must be ≥ 1, got {max_iter}")
+        if min_term_freq < 1:
+            raise ValueError(f"min_term_freq must be ≥ 1, got {min_term_freq}")
         self.k = k
         self.max_iter = max_iter
         self.seed = seed
@@ -201,10 +363,20 @@ class LitCluster:
         self._vectors: List[Dict[str, float]] = []
         self._vocab: List[str] = []
 
+    # ------------------------------------------------------------------
+    # Loaders
+    # ------------------------------------------------------------------
+
     @classmethod
-    def from_csv(cls, path: Path, **kwargs) -> "LitCluster":
+    def from_csv(cls, path, **kwargs) -> "LitCluster":
+        """Load papers from a CSV file.
+
+        The CSV must have a header row.  Recognised columns: ``paper_id``,
+        ``title``, ``abstract``, ``authors``, ``year``, ``venue``, ``doi``,
+        ``keywords``.  Missing columns default to empty strings.
+        """
         obj = cls(**kwargs)
-        with path.open(encoding="utf-8", errors="replace", newline="") as fh:
+        with Path(path).open(encoding="utf-8", errors="replace", newline="") as fh:
             reader = csv.DictReader(fh)
             for i, row in enumerate(reader):
                 obj.papers.append(Paper(
@@ -220,9 +392,10 @@ class LitCluster:
         return obj
 
     @classmethod
-    def from_jsonl(cls, path: Path, **kwargs) -> "LitCluster":
+    def from_jsonl(cls, path, **kwargs) -> "LitCluster":
+        """Load papers from a JSON-Lines file (one JSON object per line)."""
         obj = cls(**kwargs)
-        with path.open(encoding="utf-8") as fh:
+        with Path(path).open(encoding="utf-8") as fh:
             for i, line in enumerate(fh):
                 line = line.strip()
                 if not line:
@@ -241,57 +414,72 @@ class LitCluster:
         return obj
 
     @classmethod
-    def from_bibtex(cls, path: Path, **kwargs) -> "LitCluster":
-        """Parse a BibTeX file for titles, abstracts, keywords."""
+    def from_bibtex(cls, path, **kwargs) -> "LitCluster":
+        """Load papers from a BibTeX (.bib) file.
+
+        Parses ``title``, ``abstract``, ``author``, ``year``,
+        ``journal``/``booktitle``, ``doi``, and ``keywords`` fields.
+        Correctly handles nested braces and multi-line field values.
+        """
         obj = cls(**kwargs)
-        text = path.read_text(encoding="utf-8", errors="replace")
-        entries = re.split(r'(?=@\w+\s*\{)', text)
+        text = Path(path).read_text(encoding="utf-8", errors="replace")
+        entries = re.split(r"(?=@\w+\s*\{)", text)
         for i, entry in enumerate(entries):
-            if not entry.strip() or not entry.startswith('@'):
+            entry = entry.strip()
+            if not entry or not entry.startswith("@"):
                 continue
-            def _get(field):
-                m = re.search(rf'{field}\s*=\s*[{{"](.*?)[}}"\,]', entry, re.IGNORECASE | re.DOTALL)
-                return m.group(1).strip() if m else ""
-            m_key = re.match(r'@\w+\s*\{\s*(\S+?)[,}]', entry)
+            m_key = re.match(r"@\w+\s*\{\s*(\S+?)\s*[,}]", entry)
             key = m_key.group(1) if m_key else str(i)
             obj.papers.append(Paper(
-                paper_id=key, title=_get('title'), abstract=_get('abstract'),
-                authors=_get('author'), year=_get('year'),
-                venue=_get('journal') or _get('booktitle'),
-                doi=_get('doi'), keywords=_get('keywords'),
+                paper_id=key,
+                title=_bibtex_field(entry, "title"),
+                abstract=_bibtex_field(entry, "abstract"),
+                authors=_bibtex_field(entry, "author"),
+                year=_bibtex_field(entry, "year"),
+                venue=(
+                    _bibtex_field(entry, "journal")
+                    or _bibtex_field(entry, "booktitle")
+                ),
+                doi=_bibtex_field(entry, "doi"),
+                keywords=_bibtex_field(entry, "keywords"),
             ))
         return obj
 
+    # ------------------------------------------------------------------
+    # Fit
+    # ------------------------------------------------------------------
+
     def fit(self) -> "LitCluster":
+        """Vectorise papers and assign them to clusters.
+
+        Applies TF-IDF vectorisation followed by Lloyd's k-means on
+        cosine distance to group papers by topic.
+
+        Returns
+        -------
+        self : LitCluster
+            Enables method chaining.
+        """
         if not self.papers:
             return self
         tokens_list = [_tokenise(p.text) for p in self.papers]
-
-        # Filter rare terms
-        if self.min_term_freq > 1:
-            freq: Dict[str, int] = {}
-            for tokens in tokens_list:
-                for t in set(tokens):
-                    freq[t] = freq.get(t, 0) + 1
-            tokens_list = [[t for t in tokens if freq.get(t, 0) >= self.min_term_freq]
-                           for tokens in tokens_list]
-
-        self._vectors, self._vocab = _tfidf(tokens_list)
+        self._vectors, self._vocab = _tfidf(tokens_list, min_freq=self.min_term_freq)
         self._labels = _kmeans(self._vectors, self.k, self.max_iter, self.seed)
 
-        # Build cluster objects
-        clusters: Dict[int, List] = {}
+        clusters_map: Dict[int, List[Paper]] = {}
         for paper, label in zip(self.papers, self._labels):
-            clusters.setdefault(label, []).append(paper)
+            clusters_map.setdefault(label, []).append(paper)
 
         self.clusters = []
-        for cid in sorted(clusters):
+        for cid in sorted(clusters_map):
             top_terms = self._top_terms_for_cluster(cid, n=10)
-            self.clusters.append(Cluster(cluster_id=cid, papers=clusters[cid], top_terms=top_terms))
+            self.clusters.append(
+                Cluster(cluster_id=cid, papers=clusters_map[cid], top_terms=top_terms)
+            )
         return self
 
     def _top_terms_for_cluster(self, cid: int, n: int = 10) -> List[str]:
-        member_vecs = [self._vectors[i] for i, l in enumerate(self._labels) if l == cid]
+        member_vecs = [self._vectors[i] for i, lb in enumerate(self._labels) if lb == cid]
         if not member_vecs:
             return []
         scores: Dict[str, float] = {}
@@ -300,24 +488,159 @@ class LitCluster:
                 scores[t] = scores.get(t, 0.0) + v
         return sorted(scores, key=lambda t: -scores[t])[:n]
 
-    def export_csv(self, path: Path) -> None:
-        with path.open("w", newline="", encoding="utf-8") as fh:
+    # ------------------------------------------------------------------
+    # Quality
+    # ------------------------------------------------------------------
+
+    def silhouette(self) -> float:
+        """Mean silhouette coefficient of the current clustering.
+
+        Requires :meth:`fit` to have been called first.
+        Returns a value in [-1, 1]; values close to +1 indicate
+        well-separated clusters.  Returns 0.0 when fewer than two
+        distinct clusters exist.
+        """
+        return _silhouette_score(self._vectors, self._labels)
+
+    # ------------------------------------------------------------------
+    # Export
+    # ------------------------------------------------------------------
+
+    def export_csv(self, path) -> None:
+        """Write cluster assignments to a CSV file."""
+        with Path(path).open("w", newline="", encoding="utf-8") as fh:
             w = csv.writer(fh)
-            w.writerow(["cluster_id","cluster_label","paper_id","title","authors","year","venue","doi"])
+            w.writerow([
+                "cluster_id", "cluster_label", "paper_id",
+                "title", "authors", "year", "venue", "doi",
+            ])
             for cluster in self.clusters:
                 for p in cluster.papers:
-                    w.writerow([cluster.cluster_id, cluster.label, p.paper_id,
-                                p.title, p.authors, p.year, p.venue, p.doi])
+                    w.writerow([
+                        cluster.cluster_id, cluster.label, p.paper_id,
+                        p.title, p.authors, p.year, p.venue, p.doi,
+                    ])
 
-    def export_json(self, path: Path) -> None:
-        with path.open("w", encoding="utf-8") as fh:
-            json.dump([c.to_dict() for c in self.clusters], fh, indent=2, ensure_ascii=False)
+    def export_json(self, path) -> None:
+        """Write full cluster data (including abstracts) to a JSON file."""
+        with Path(path).open("w", encoding="utf-8") as fh:
+            json.dump(
+                [c.to_dict() for c in self.clusters],
+                fh, indent=2, ensure_ascii=False,
+            )
+
+    def export_html(self, path) -> None:
+        """Write a self-contained interactive HTML report to *path*.
+
+        Each cluster is presented as a collapsible section listing its top
+        discriminative terms and a table of the constituent papers with
+        clickable DOI links.
+        """
+        rows = []
+        for c in self.clusters:
+            paper_rows = "".join(_paper_row(p) for p in c.papers)
+            rows.append(f"""
+  <details open>
+    <summary><strong>{_he(c.label)}</strong> &nbsp;({len(c.papers)} papers)</summary>
+    <p><em>Top terms:</em> {_he(", ".join(c.top_terms))}</p>
+    <table>
+      <thead>
+        <tr><th>Title</th><th>Authors</th><th>Year</th><th>Venue</th><th>DOI</th></tr>
+      </thead>
+      <tbody>{paper_rows}</tbody>
+    </table>
+  </details>""")
+
+        title = f"litcluster — {len(self.papers)} papers, {len(self.clusters)} clusters"
+        Path(path).write_text(
+            _HTML_TEMPLATE.format(title=_he(title), body="\n".join(rows)),
+            encoding="utf-8",
+        )
 
     def summary(self) -> str:
-        lines = [f"LitCluster: {len(self.papers)} papers in {len(self.clusters)} clusters", ""]
+        """Return a human-readable plain-text summary of the clustering."""
+        if not self.clusters:
+            return "No clusters found. Did you call fit()?"
+        lines = [
+            f"litcluster v{__version__}",
+            f"{len(self.papers)} papers → {len(self.clusters)} clusters",
+            "",
+        ]
         for c in self.clusters:
-            lines.append(f"  [{c.cluster_id}] {c.label} ({len(c.papers)} papers)")
+            lines.append(f"  [{c.cluster_id:2d}] {c.label}  ({len(c.papers)} papers)")
         return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# HTML helpers
+# ---------------------------------------------------------------------------
+
+def _he(text: str) -> str:
+    """Minimal HTML entity escaping."""
+    return (
+        text.replace("&", "&amp;")
+            .replace("<", "&lt;")
+            .replace(">", "&gt;")
+            .replace('"', "&quot;")
+    )
+
+
+def _paper_row(p: Paper) -> str:
+    doi_cell = (
+        f'<a href="https://doi.org/{_he(p.doi)}">{_he(p.doi)}</a>'
+        if p.doi else ""
+    )
+    return (
+        f"<tr>"
+        f"<td>{_he(p.title)}</td>"
+        f"<td>{_he(p.authors)}</td>"
+        f"<td>{_he(p.year)}</td>"
+        f"<td>{_he(p.venue)}</td>"
+        f"<td>{doi_cell}</td>"
+        f"</tr>"
+    )
+
+
+_HTML_TEMPLATE = """\
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>{title}</title>
+  <style>
+    body {{
+      font-family: system-ui, -apple-system, sans-serif;
+      max-width: 1100px; margin: auto; padding: 1.5rem;
+      color: #222;
+    }}
+    h1 {{ font-size: 1.35rem; margin-bottom: .25rem; }}
+    p.meta {{ color: #666; font-size: .9rem; margin-top: 0; }}
+    details {{
+      margin-bottom: 1rem; border: 1px solid #ddd;
+      padding: .6rem 1rem; border-radius: 6px;
+    }}
+    summary {{ cursor: pointer; font-size: 1.05rem; user-select: none; }}
+    summary:hover {{ color: #0055cc; }}
+    table {{
+      border-collapse: collapse; width: 100%;
+      margin-top: .6rem; font-size: .875rem;
+    }}
+    th, td {{ border: 1px solid #ccc; padding: .35rem .6rem; text-align: left; }}
+    th {{ background: #f5f5f5; font-weight: 600; }}
+    tr:hover td {{ background: #fafafa; }}
+    a {{ color: #0066cc; text-decoration: none; }}
+    a:hover {{ text-decoration: underline; }}
+  </style>
+</head>
+<body>
+  <h1>{title}</h1>
+  <p class="meta">
+    Generated by <a href="https://github.com/vdeshmukh203/litcluster">litcluster</a>.
+  </p>
+{body}
+</body>
+</html>"""
 
 
 # ---------------------------------------------------------------------------
@@ -325,35 +648,66 @@ class LitCluster:
 # ---------------------------------------------------------------------------
 
 def _parse_args(argv=None):
-    p = argparse.ArgumentParser(prog="litcluster",
-                                description="Cluster academic papers by topic using TF-IDF + k-means.")
-    p.add_argument("input", help="Input file: CSV, JSONL, or .bib")
-    p.add_argument("-k", "--clusters", type=int, default=5, dest="k",
-                   help="Number of clusters (default: 5)")
-    p.add_argument("--format", choices=["csv","json","summary"], default="summary")
-    p.add_argument("--output", "-o", default=None, help="Output file (default: stdout/auto)")
-    p.add_argument("--seed", type=int, default=42)
-    p.add_argument("--max-iter", type=int, default=100)
-    p.add_argument("--min-freq", type=int, default=2,
-                   help="Minimum term frequency to include in vocabulary (default: 2)")
+    p = argparse.ArgumentParser(
+        prog="litcluster",
+        description=(
+            "Cluster academic papers by topic using TF-IDF + k-means.\n"
+            "Accepts BibTeX (.bib), CSV, or JSON-Lines (.jsonl) input."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    p.add_argument("input", help="Input file (.bib, .csv, or .jsonl)")
+    p.add_argument(
+        "-k", "--clusters", type=int, default=5, dest="k",
+        help="Number of clusters (default: 5)",
+    )
+    p.add_argument(
+        "--format",
+        choices=["csv", "json", "html", "summary"],
+        default="summary",
+        help="Output format (default: summary)",
+    )
+    p.add_argument(
+        "--output", "-o", default=None,
+        help="Output file path (default: auto-named next to input file)",
+    )
+    p.add_argument("--seed", type=int, default=42,
+                   help="Random seed for reproducibility (default: 42)")
+    p.add_argument("--max-iter", type=int, default=100,
+                   help="Maximum k-means iterations (default: 100)")
+    p.add_argument(
+        "--min-freq", type=int, default=2,
+        help="Minimum document frequency for vocabulary inclusion (default: 2)",
+    )
+    p.add_argument("--version", action="version", version=f"%(prog)s {__version__}")
     return p.parse_args(argv)
 
 
 def main(argv=None) -> int:
+    """CLI entry point.  Returns 0 on success, 1 on error."""
     args = _parse_args(argv)
     path = Path(args.input)
     if not path.is_file():
-        print(f"Error: {path} not found", file=sys.stderr)
+        print(f"Error: '{path}' not found.", file=sys.stderr)
         return 1
 
+    kwargs = dict(
+        k=args.k,
+        max_iter=args.max_iter,
+        seed=args.seed,
+        min_term_freq=args.min_freq,
+    )
     suffix = path.suffix.lower()
-    kwargs = dict(k=args.k, max_iter=args.max_iter, seed=args.seed, min_term_freq=args.min_freq)
     if suffix == ".bib":
         lc = LitCluster.from_bibtex(path, **kwargs)
     elif suffix == ".jsonl":
         lc = LitCluster.from_jsonl(path, **kwargs)
     else:
         lc = LitCluster.from_csv(path, **kwargs)
+
+    if not lc.papers:
+        print("Error: no papers found in input file.", file=sys.stderr)
+        return 1
 
     lc.fit()
 
@@ -371,8 +725,17 @@ def main(argv=None) -> int:
         out = Path(args.output) if args.output else path.with_suffix(".clusters.json")
         lc.export_json(out)
         print(f"Clusters written to {out}")
+    elif args.format == "html":
+        out = Path(args.output) if args.output else path.with_suffix(".clusters.html")
+        lc.export_html(out)
+        print(f"HTML report written to {out}")
 
     return 0
+
+
+# Alias kept for backwards compatibility with any ``pyproject.toml`` that
+# still references ``litcluster:_cli``.
+_cli = main
 
 
 if __name__ == "__main__":

--- a/litcluster_gui.py
+++ b/litcluster_gui.py
@@ -1,0 +1,407 @@
+#!/usr/bin/env python3
+"""
+litcluster_gui.py — Tkinter graphical front-end for litcluster.
+
+Launch with:
+    litcluster-gui          (if installed via pip)
+    python litcluster_gui.py
+"""
+
+from __future__ import annotations
+
+import sys
+import threading
+import tkinter as tk
+from pathlib import Path
+from tkinter import filedialog, messagebox, ttk
+
+# Allow running as a standalone script without installing the package.
+sys.path.insert(0, str(Path(__file__).parent))
+
+from litcluster import LitCluster, __version__  # noqa: E402
+
+
+class _App(tk.Tk):
+    """Main application window."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.title(f"litcluster {__version__}")
+        self.minsize(780, 540)
+        self._lc: LitCluster | None = None
+        self._build_menu()
+        self._build_body()
+        self._build_status()
+
+    # ------------------------------------------------------------------
+    # UI construction
+    # ------------------------------------------------------------------
+
+    def _build_menu(self) -> None:
+        mb = tk.Menu(self)
+
+        fm = tk.Menu(mb, tearoff=0)
+        fm.add_command(label="Open…",       accelerator="Ctrl+O", command=self._browse)
+        fm.add_separator()
+        fm.add_command(label="Export CSV…",  command=lambda: self._export("csv"))
+        fm.add_command(label="Export JSON…", command=lambda: self._export("json"))
+        fm.add_command(label="Export HTML…", command=lambda: self._export("html"))
+        fm.add_separator()
+        fm.add_command(label="Exit", command=self.quit)
+        mb.add_cascade(label="File", menu=fm)
+
+        hm = tk.Menu(mb, tearoff=0)
+        hm.add_command(label="About", command=self._about)
+        mb.add_cascade(label="Help", menu=hm)
+
+        self.config(menu=mb)
+        self.bind_all("<Control-o>", lambda _e: self._browse())
+
+    def _build_body(self) -> None:
+        pw = ttk.PanedWindow(self, orient=tk.HORIZONTAL)
+        pw.pack(fill=tk.BOTH, expand=True, padx=6, pady=6)
+
+        # ---- left panel ------------------------------------------------
+        left = ttk.Frame(pw, padding=6)
+        pw.add(left, weight=1)
+
+        # File chooser
+        ttk.Label(left, text="Input file", font=("", 9, "bold")).pack(anchor="w")
+        ff = ttk.Frame(left)
+        ff.pack(fill=tk.X, pady=(0, 10))
+        self._file_var = tk.StringVar()
+        ttk.Entry(ff, textvariable=self._file_var).pack(
+            side=tk.LEFT, fill=tk.X, expand=True
+        )
+        ttk.Button(ff, text="Browse…", command=self._browse).pack(
+            side=tk.LEFT, padx=(4, 0)
+        )
+
+        # Parameters
+        ttk.Label(left, text="Parameters", font=("", 9, "bold")).pack(anchor="w")
+        pf = ttk.Frame(left)
+        pf.pack(fill=tk.X, pady=(0, 10))
+
+        param_rows = [
+            ("Clusters (k):",     "_k_var",    5,   1,   500),
+            ("Seed:",             "_seed_var",  42,  0,   99999),
+            ("Max iterations:",   "_iter_var",  100, 1,   9999),
+            ("Min term freq:",    "_freq_var",  2,   1,   100),
+        ]
+        for label, attr, default, lo, hi in param_rows:
+            row = ttk.Frame(pf)
+            row.pack(fill=tk.X, pady=2)
+            ttk.Label(row, text=label, width=17, anchor="w").pack(side=tk.LEFT)
+            var = tk.IntVar(value=default)
+            setattr(self, attr, var)
+            ttk.Spinbox(row, textvariable=var, from_=lo, to=hi, width=8).pack(
+                side=tk.LEFT
+            )
+
+        # Run button + progress
+        self._run_btn = ttk.Button(
+            left, text="▶  Run Clustering", command=self._run
+        )
+        self._run_btn.pack(fill=tk.X, pady=(4, 2))
+        self._progress = ttk.Progressbar(left, mode="indeterminate")
+        self._progress.pack(fill=tk.X, pady=(0, 10))
+
+        # Statistics
+        ttk.Label(left, text="Statistics", font=("", 9, "bold")).pack(anchor="w")
+        self._stats_var = tk.StringVar(value="—")
+        ttk.Label(
+            left, textvariable=self._stats_var,
+            wraplength=200, justify="left", foreground="#444",
+        ).pack(anchor="w", pady=(0, 10))
+
+        # Export shortcuts
+        ttk.Label(left, text="Export", font=("", 9, "bold")).pack(anchor="w")
+        for fmt, label in [
+            ("csv",  "Export CSV"),
+            ("json", "Export JSON"),
+            ("html", "Export HTML"),
+        ]:
+            ttk.Button(
+                left, text=label, command=lambda f=fmt: self._export(f)
+            ).pack(fill=tk.X, pady=2)
+
+        # ---- right panel -----------------------------------------------
+        right = ttk.Frame(pw, padding=6)
+        pw.add(right, weight=3)
+
+        nb = ttk.Notebook(right)
+        nb.pack(fill=tk.BOTH, expand=True)
+        self._nb = nb
+
+        # Clusters tab
+        cf = ttk.Frame(nb)
+        nb.add(cf, text="Clusters")
+        self._cluster_tree = self._scrolled_tree(
+            cf,
+            columns=("size", "top_terms"),
+            headings={"size": ("Papers", 70), "top_terms": ("Top terms", 450)},
+        )
+        self._cluster_tree.bind("<<TreeviewSelect>>", self._on_cluster_select)
+
+        # Papers tab
+        pf2 = ttk.Frame(nb)
+        nb.add(pf2, text="Papers")
+        self._paper_tree = self._scrolled_tree(
+            pf2,
+            columns=("cluster", "title", "authors", "year"),
+            headings={
+                "cluster": ("Cluster", 70),
+                "title":   ("Title",   320),
+                "authors": ("Authors", 180),
+                "year":    ("Year",     55),
+            },
+        )
+        self._paper_tree.bind("<Double-1>", self._on_paper_dbl)
+
+    def _scrolled_tree(
+        self, parent, *, columns: list, headings: dict
+    ) -> ttk.Treeview:
+        frame = ttk.Frame(parent)
+        frame.pack(fill=tk.BOTH, expand=True)
+        tree = ttk.Treeview(frame, columns=columns, show="headings")
+        for col, (head, width) in headings.items():
+            tree.heading(col, text=head)
+            tree.column(col, width=width, minwidth=40)
+        vsb = ttk.Scrollbar(frame, orient="vertical", command=tree.yview)
+        hsb = ttk.Scrollbar(frame, orient="horizontal", command=tree.xview)
+        tree.configure(yscrollcommand=vsb.set, xscrollcommand=hsb.set)
+        vsb.pack(side=tk.RIGHT,  fill=tk.Y)
+        hsb.pack(side=tk.BOTTOM, fill=tk.X)
+        tree.pack(fill=tk.BOTH, expand=True)
+        return tree
+
+    def _build_status(self) -> None:
+        self._status_var = tk.StringVar(value="Ready")
+        ttk.Label(
+            self, textvariable=self._status_var,
+            relief="sunken", anchor="w", padding=(4, 2),
+        ).pack(side=tk.BOTTOM, fill=tk.X)
+
+    # ------------------------------------------------------------------
+    # Event handlers
+    # ------------------------------------------------------------------
+
+    def _browse(self) -> None:
+        path = filedialog.askopenfilename(
+            title="Open literature file",
+            filetypes=[
+                ("All supported", "*.bib *.csv *.jsonl"),
+                ("BibTeX",        "*.bib"),
+                ("CSV",           "*.csv"),
+                ("JSON Lines",    "*.jsonl"),
+                ("All files",     "*.*"),
+            ],
+        )
+        if path:
+            self._file_var.set(path)
+            self._status(f"Loaded: {Path(path).name}")
+
+    def _run(self) -> None:
+        path_str = self._file_var.get().strip()
+        if not path_str:
+            messagebox.showwarning("No file", "Please select an input file first.")
+            return
+        path = Path(path_str)
+        if not path.is_file():
+            messagebox.showerror("File not found", f"Cannot find:\n{path}")
+            return
+        self._run_btn.config(state="disabled")
+        self._progress.start(10)
+        self._status("Clustering…")
+        threading.Thread(
+            target=self._do_cluster, args=(path,), daemon=True
+        ).start()
+
+    def _do_cluster(self, path: Path) -> None:
+        try:
+            kwargs = dict(
+                k=self._k_var.get(),
+                seed=self._seed_var.get(),
+                max_iter=self._iter_var.get(),
+                min_term_freq=self._freq_var.get(),
+            )
+            suffix = path.suffix.lower()
+            if suffix == ".bib":
+                lc = LitCluster.from_bibtex(path, **kwargs)
+            elif suffix == ".jsonl":
+                lc = LitCluster.from_jsonl(path, **kwargs)
+            else:
+                lc = LitCluster.from_csv(path, **kwargs)
+
+            if not lc.papers:
+                self.after(
+                    0, lambda: messagebox.showerror("Empty", "No papers found in file.")
+                )
+                return
+            lc.fit()
+            self._lc = lc
+            self.after(0, self._refresh_results)
+        except Exception as exc:
+            msg = str(exc)
+            self.after(0, lambda: messagebox.showerror("Error", msg))
+        finally:
+            self.after(0, self._stop_progress)
+
+    def _stop_progress(self) -> None:
+        self._progress.stop()
+        self._run_btn.config(state="normal")
+
+    def _refresh_results(self) -> None:
+        lc = self._lc
+        if lc is None:
+            return
+
+        sil = lc.silhouette()
+        self._stats_var.set(
+            f"Papers:     {len(lc.papers)}\n"
+            f"Clusters:   {len(lc.clusters)}\n"
+            f"Vocab size: {len(lc._vocab)}\n"
+            f"Silhouette: {sil:.3f}"
+        )
+        self._status(
+            f"Done — {len(lc.papers)} papers in {len(lc.clusters)} clusters "
+            f"(silhouette={sil:.3f})"
+        )
+
+        self._cluster_tree.delete(*self._cluster_tree.get_children())
+        for c in lc.clusters:
+            self._cluster_tree.insert(
+                "", "end",
+                iid=str(c.cluster_id),
+                values=(len(c.papers), ", ".join(c.top_terms[:7])),
+            )
+
+        self._populate_papers(lc.clusters)
+
+    def _populate_papers(self, clusters) -> None:
+        self._paper_tree.delete(*self._paper_tree.get_children())
+        for c in clusters:
+            for p in c.papers:
+                self._paper_tree.insert(
+                    "", "end",
+                    values=(c.cluster_id, p.title[:100], p.authors[:50], p.year),
+                    tags=(str(c.cluster_id),),
+                )
+
+    def _on_cluster_select(self, _event) -> None:
+        if self._lc is None:
+            return
+        sel = self._cluster_tree.selection()
+        if not sel:
+            self._populate_papers(self._lc.clusters)
+            return
+        cid = int(sel[0])
+        filtered = [c for c in self._lc.clusters if c.cluster_id == cid]
+        self._populate_papers(filtered)
+        self._nb.select(1)  # switch to Papers tab
+
+    def _on_paper_dbl(self, _event) -> None:
+        """Show full paper details in a pop-up on double-click."""
+        if self._lc is None:
+            return
+        sel = self._paper_tree.selection()
+        if not sel:
+            return
+        vals = self._paper_tree.item(sel[0], "values")
+        if not vals:
+            return
+        # Find the paper object by cluster_id and title match
+        cid, title_prefix = int(vals[0]), vals[1]
+        paper = None
+        for c in self._lc.clusters:
+            if c.cluster_id == cid:
+                for p in c.papers:
+                    if p.title[:100] == title_prefix:
+                        paper = p
+                        break
+            if paper:
+                break
+        if paper is None:
+            return
+
+        dlg = tk.Toplevel(self)
+        dlg.title("Paper details")
+        dlg.resizable(True, True)
+        dlg.minsize(500, 300)
+        text = tk.Text(dlg, wrap="word", padx=10, pady=10, relief="flat")
+        sb = ttk.Scrollbar(dlg, orient="vertical", command=text.yview)
+        text.configure(yscrollcommand=sb.set)
+        sb.pack(side=tk.RIGHT, fill=tk.Y)
+        text.pack(fill=tk.BOTH, expand=True)
+
+        for label, val in [
+            ("Title",    paper.title),
+            ("Authors",  paper.authors),
+            ("Year",     paper.year),
+            ("Venue",    paper.venue),
+            ("DOI",      paper.doi),
+            ("Keywords", paper.keywords),
+            ("Abstract", paper.abstract),
+        ]:
+            text.insert("end", f"{label}:\n", "bold")
+            text.insert("end", f"  {val or '—'}\n\n")
+        text.tag_configure("bold", font=("", 9, "bold"))
+        text.config(state="disabled")
+
+        ttk.Button(dlg, text="Close", command=dlg.destroy).pack(pady=6)
+
+    def _export(self, fmt: str) -> None:
+        if self._lc is None:
+            messagebox.showwarning("No results", "Run clustering first.")
+            return
+        ext = {"csv": ".csv", "json": ".json", "html": ".html"}[fmt]
+        ftypes = {
+            "csv":  [("CSV files",  "*.csv")],
+            "json": [("JSON files", "*.json")],
+            "html": [("HTML files", "*.html")],
+        }[fmt]
+        dest = filedialog.asksaveasfilename(
+            title=f"Export as {fmt.upper()}",
+            defaultextension=ext,
+            filetypes=ftypes,
+        )
+        if not dest:
+            return
+        try:
+            if fmt == "csv":
+                self._lc.export_csv(dest)
+            elif fmt == "json":
+                self._lc.export_json(dest)
+            elif fmt == "html":
+                self._lc.export_html(dest)
+            self._status(f"Exported {fmt.upper()} → {dest}")
+        except Exception as exc:
+            messagebox.showerror("Export failed", str(exc))
+
+    def _about(self) -> None:
+        messagebox.showinfo(
+            "About litcluster",
+            f"litcluster  {__version__}\n\n"
+            "Topic-based clustering of scientific literature.\n"
+            "Pure Python standard library — no external dependencies.\n\n"
+            "Author: Vaibhav Deshmukh\n"
+            "License: MIT\n"
+            "https://github.com/vdeshmukh203/litcluster",
+        )
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _status(self, msg: str) -> None:
+        self._status_var.set(msg)
+
+
+def main() -> None:
+    """Launch the litcluster GUI."""
+    app = _App()
+    app.mainloop()
+
+
+if __name__ == "__main__":
+    main()

--- a/paper.md
+++ b/paper.md
@@ -1,5 +1,5 @@
 ---
-title: 'litcluster: Topic modelling and semantic clustering of scientific literature from BibTeX or DOI lists'
+title: 'litcluster: Topic-based clustering of scientific literature from BibTeX or CSV'
 tags:
   - Python
   - NLP
@@ -20,14 +20,40 @@ bibliography: paper.bib
 
 # Summary
 
-`litcluster` is a Python tool for semantic clustering and topic modelling of scientific literature. Given a BibTeX file, a list of DOIs, or a directory of PDF abstracts, `litcluster` fetches or extracts abstract text, embeds papers using pre-trained sentence transformers, applies dimensionality reduction (UMAP), and clusters the resulting embedding space (HDBSCAN). It outputs an interactive HTML visualisation of the literature landscape and a Markdown summary table labelling each cluster with automatically extracted topic keywords. `litcluster` is designed for researchers beginning a new domain survey or tracking how a field has evolved over time.
+`litcluster` is a pure-Python tool for automated topic-based clustering of
+scientific literature.  Given a BibTeX file, a CSV spreadsheet, or a
+JSON-Lines collection of paper abstracts, `litcluster` vectorises the text
+using smoothed TF-IDF, groups papers into thematic clusters with Lloyd's
+k-means algorithm on cosine distance, and reports a silhouette-score quality
+estimate for the chosen number of clusters.  Results can be exported as a
+plain-text summary, a CSV assignment table, a structured JSON file, or a
+self-contained interactive HTML report.  A companion Tkinter graphical user
+interface (GUI) makes the tool accessible to researchers who prefer not to
+use the command line.  `litcluster` has no external dependencies beyond the
+Python standard library and runs on any platform where Python 3.8 or later is
+installed.
 
 # Statement of Need
 
-Systematic and scoping reviews require researchers to organise large collections of papers into thematic groups — a task typically done manually or with expensive proprietary tools. `litcluster` automates this using modern sentence embeddings and density-based clustering, requiring only a BibTeX file as input. Unlike keyword-based approaches, semantic clustering groups papers by meaning rather than surface vocabulary, surfacing connections that term-based methods miss [@wei2022chain]. The interactive output helps researchers quickly identify core topics, niche sub-areas, and potential gaps in a literature collection, accelerating the early stages of a systematic review.
+Systematic and scoping reviews require researchers to organise large
+collections of papers into thematic groups — a task typically done manually
+or with expensive proprietary tools such as Covidence or Rayyan.
+`litcluster` automates thematic grouping using TF-IDF vectorisation and
+k-means clustering, requiring only a BibTeX file as input.  Unlike fully
+manual approaches, `litcluster` provides a reproducible, quantitative
+starting point for thematic organisation and reports the most discriminative
+vocabulary terms for each cluster, helping researchers label and interpret
+the groups.  The silhouette-score quality metric guides the choice of the
+number of clusters.  The interactive HTML report and Tkinter GUI lower the
+barrier for researchers with limited programming experience.  Because the
+tool is a single Python file with no external dependencies, it can be
+deployed in any Python environment without complex installation steps,
+making it suitable for use in institutional computing environments with
+restricted package access.
 
 # Acknowledgements
 
-The author used Claude (Anthropic) for drafting portions of this manuscript. All scientific claims and design decisions are the author's own.
+The author used Claude (Anthropic) for drafting portions of this manuscript.
+All scientific claims and design decisions are the author's own.
 
 # References

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,8 +20,13 @@ classifiers = [
     "Topic :: Text Processing",
 ]
 
+[project.urls]
+Homepage = "https://github.com/vdeshmukh203/litcluster"
+"Bug Tracker" = "https://github.com/vdeshmukh203/litcluster/issues"
+
 [project.scripts]
-litcluster = "litcluster:_cli"
+litcluster     = "litcluster:main"
+litcluster-gui = "litcluster_gui:main"
 
 [tool.setuptools]
-py-modules = ["litcluster"]
+py-modules = ["litcluster", "litcluster_gui"]

--- a/src/litcluster/__init__.py
+++ b/src/litcluster/__init__.py
@@ -1,18 +1,24 @@
 """
-litcluster: Semantic clustering and topic modelling of scientific literature.
+litcluster: Topic-based clustering of scientific literature.
 
-Ingests collections of scientific abstracts or full papers (via DOI lists,
-BibTeX files, or arXiv IDs), embeds them using sentence-transformers, and
-applies hierarchical clustering and topic modelling to produce interactive
-visualisations and structured cluster summaries for systematic literature
-reviews.
+The canonical single-file implementation lives at ``litcluster.py`` in the
+project root and is installed as a py-module via ``pyproject.toml``.  This
+package stub re-exports the public API so that both import styles work:
+
+    import litcluster          # imports the root module directly
+    from litcluster import ... # same
 """
 
 __version__ = "0.1.0"
 __author__ = "Vaibhav Deshmukh"
 __license__ = "MIT"
 
-from .cluster import LitCluster
-from .embed import PaperEmbedder
-
-__all__ = ["LitCluster", "PaperEmbedder"]
+# Re-export the public API from the single-file implementation.
+# The try/except handles the case where this src/ directory is on sys.path
+# but the root litcluster.py is not (e.g. during an editable install that
+# only exposes src/).
+try:
+    from litcluster import LitCluster, Paper, Cluster  # noqa: F401
+    __all__ = ["LitCluster", "Paper", "Cluster"]
+except ImportError:
+    __all__ = []

--- a/tests/test_litcluster.py
+++ b/tests/test_litcluster.py
@@ -1,19 +1,660 @@
-import sys, pathlib
-sys.path.insert(0, str(pathlib.Path(__file__).parent.parent))
+"""Comprehensive test suite for litcluster."""
 
-def test_import():
-    import litcluster as lc
-    assert hasattr(lc, 'LitCluster')
+from __future__ import annotations
 
-def test_paper():
-    import litcluster as lc
-    assert hasattr(lc, 'Paper')
+import csv
+import json
+import sys
+from pathlib import Path
 
-def test_cluster():
-    import litcluster as lc
-    assert hasattr(lc, 'Cluster')
+import pytest
 
-def test_tokenise():
-    import litcluster as lc
-    tokens = lc._tokenise('hello world test foo bar')
-    assert isinstance(tokens, list) and len(tokens) > 0
+sys.path.insert(0, str(Path(__file__).parent.parent))
+import litcluster as lc
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / shared sample data
+# ---------------------------------------------------------------------------
+
+SAMPLE_PAPERS = [
+    {
+        "paper_id": "p1",
+        "title": "Deep learning for natural language processing",
+        "abstract": "Neural networks for text classification and sentiment analysis.",
+        "authors": "Alice Smith",
+        "year": "2020",
+        "venue": "NeurIPS",
+        "doi": "10.1234/nlp1",
+        "keywords": "deep learning, NLP, neural networks",
+    },
+    {
+        "paper_id": "p2",
+        "title": "Transformer models in NLP",
+        "abstract": "Attention mechanisms and BERT for language understanding tasks.",
+        "authors": "Bob Jones",
+        "year": "2021",
+        "venue": "ACL",
+        "doi": "10.1234/nlp2",
+        "keywords": "transformers, BERT, attention",
+    },
+    {
+        "paper_id": "p3",
+        "title": "Graph neural networks for molecular property prediction",
+        "abstract": "Using GNNs to predict chemical properties of molecules.",
+        "authors": "Carol Lee",
+        "year": "2020",
+        "venue": "ICML",
+        "doi": "10.1234/chem1",
+        "keywords": "graph neural networks, chemistry, molecules",
+    },
+    {
+        "paper_id": "p4",
+        "title": "Molecular dynamics simulations of proteins",
+        "abstract": "Force field methods for protein structure simulation.",
+        "authors": "Dave Brown",
+        "year": "2019",
+        "venue": "JCTC",
+        "doi": "10.1234/chem2",
+        "keywords": "molecular dynamics, proteins, force field",
+    },
+    {
+        "paper_id": "p5",
+        "title": "Reinforcement learning from human feedback",
+        "abstract": "RLHF methods for aligning large language models with human values.",
+        "authors": "Eve Wilson",
+        "year": "2022",
+        "venue": "NeurIPS",
+        "doi": "10.1234/rl1",
+        "keywords": "reinforcement learning, RLHF, alignment",
+    },
+    {
+        "paper_id": "p6",
+        "title": "Protein folding prediction with deep learning",
+        "abstract": "AlphaFold and structure prediction using transformer neural networks.",
+        "authors": "Frank Garcia",
+        "year": "2021",
+        "venue": "Nature",
+        "doi": "10.1234/chem3",
+        "keywords": "protein folding, AlphaFold, deep learning",
+    },
+]
+
+SAMPLE_BIB = """\
+@article{smith2020,
+  title = {Deep learning for text},
+  author = {Smith, Alice},
+  year = {2020},
+  journal = {NeurIPS},
+  abstract = {Neural networks for natural language processing tasks.},
+  keywords = {deep learning, NLP},
+  doi = {10.1234/a1},
+}
+
+@article{jones2021,
+  title = {Transformer models},
+  author = {Jones, Bob},
+  year = {2021},
+  journal = {ACL},
+  abstract = {Attention mechanisms and BERT for text understanding.},
+  keywords = {transformers, BERT},
+  doi = {10.1234/a2},
+}
+
+@inproceedings{lee2020,
+  title = {Graph neural networks for chemistry},
+  author = {Lee, Carol},
+  year = {2020},
+  booktitle = {ICML},
+  abstract = {Predicting molecular properties with graph networks.},
+  keywords = {GNN, chemistry},
+}
+"""
+
+
+def _make_fitted(k: int = 2, **kw) -> lc.LitCluster:
+    """Return a fitted LitCluster built from SAMPLE_PAPERS."""
+    obj = lc.LitCluster(k=k, min_term_freq=1, **kw)
+    for p in SAMPLE_PAPERS:
+        obj.papers.append(lc.Paper(**p))
+    return obj.fit()
+
+
+# ---------------------------------------------------------------------------
+# Public API surface
+# ---------------------------------------------------------------------------
+
+class TestImports:
+    def test_litcluster_class(self):
+        assert hasattr(lc, "LitCluster")
+
+    def test_paper_class(self):
+        assert hasattr(lc, "Paper")
+
+    def test_cluster_class(self):
+        assert hasattr(lc, "Cluster")
+
+    def test_version(self):
+        assert hasattr(lc, "__version__")
+        assert lc.__version__
+
+    def test_all_exports(self):
+        for name in lc.__all__:
+            assert hasattr(lc, name)
+
+
+# ---------------------------------------------------------------------------
+# Text processing
+# ---------------------------------------------------------------------------
+
+class TestTokenise:
+    def test_basic(self):
+        tokens = lc._tokenise("hello world test foo bar")
+        assert isinstance(tokens, list)
+        assert len(tokens) > 0
+
+    def test_stopwords_removed(self):
+        tokens = lc._tokenise("the quick brown fox")
+        assert "the" not in tokens
+
+    def test_short_words_excluded(self):
+        tokens = lc._tokenise("a an ab abc abcd")
+        assert "a"  not in tokens
+        assert "an" not in tokens
+        assert "ab" not in tokens
+        assert "abc" in tokens
+
+    def test_case_normalised(self):
+        tokens = lc._tokenise("Deep LEARNING NLP")
+        assert "deep" in tokens
+        assert "learning" in tokens
+
+    def test_empty_string(self):
+        assert lc._tokenise("") == []
+
+    def test_numbers_excluded(self):
+        tokens = lc._tokenise("paper 2024 results analysis")
+        assert "2024" not in tokens
+
+
+class TestTfidf:
+    def test_basic(self):
+        docs = [["deep", "learning", "nlp"], ["transformers", "bert", "nlp"]]
+        vectors, vocab = lc._tfidf(docs)
+        assert len(vectors) == 2
+        assert "nlp" in vocab
+
+    def test_empty_input(self):
+        vectors, vocab = lc._tfidf([])
+        assert vectors == []
+        assert vocab == []
+
+    def test_min_freq_filters_terms(self):
+        docs = [["deep", "learning"], ["transformers", "bert"]]
+        _, vocab = lc._tfidf(docs, min_freq=2)
+        assert vocab == []
+
+    def test_min_freq_keeps_shared_terms(self):
+        docs = [["nlp", "deep"], ["nlp", "bert"]]
+        _, vocab = lc._tfidf(docs, min_freq=2)
+        assert "nlp" in vocab
+
+    def test_vector_values_nonnegative(self):
+        docs = [["a", "b", "c"], ["b", "c", "d"]]
+        vectors, _ = lc._tfidf(docs)
+        for vec in vectors:
+            for v in vec.values():
+                assert v >= 0.0
+
+    def test_all_empty_docs_after_filter(self):
+        docs = [["rare1"], ["rare2"]]
+        vectors, vocab = lc._tfidf(docs, min_freq=2)
+        assert vocab == []
+        assert len(vectors) == 2
+        for vec in vectors:
+            assert vec == {}
+
+
+class TestCosine:
+    def test_identical_vectors(self):
+        v = {"a": 1.0, "b": 2.0}
+        assert abs(lc._cosine(v, v) - 1.0) < 1e-9
+
+    def test_orthogonal_vectors(self):
+        assert lc._cosine({"x": 1.0}, {"y": 1.0}) == 0.0
+
+    def test_empty_vector(self):
+        assert lc._cosine({}, {"a": 1.0}) == 0.0
+        assert lc._cosine({"a": 1.0}, {}) == 0.0
+
+    def test_result_in_range(self):
+        a = {"a": 1.0, "b": 0.5}
+        b = {"a": 0.3, "b": 1.0, "c": 0.2}
+        sim = lc._cosine(a, b)
+        assert 0.0 <= sim <= 1.0
+
+
+class TestKmeans:
+    def test_two_distinct_groups(self):
+        docs = [["alpha", "beta"], ["alpha", "beta"], ["gamma", "delta"], ["gamma", "delta"]]
+        vectors, _ = lc._tfidf(docs)
+        labels = lc._kmeans(vectors, k=2)
+        assert len(labels) == 4
+        assert labels[0] == labels[1]
+        assert labels[2] == labels[3]
+        assert labels[0] != labels[2]
+
+    def test_empty_input(self):
+        assert lc._kmeans([], k=3) == []
+
+    def test_k_clamped_to_n(self):
+        docs = [["a"], ["b"]]
+        vectors, _ = lc._tfidf(docs)
+        labels = lc._kmeans(vectors, k=100)
+        assert len(set(labels)) <= 2
+
+    def test_reproducible_with_same_seed(self):
+        docs = [["a", "b"], ["c", "d"], ["e", "f"], ["g", "h"]]
+        vectors, _ = lc._tfidf(docs)
+        l1 = lc._kmeans(vectors, k=2, seed=42)
+        l2 = lc._kmeans(vectors, k=2, seed=42)
+        assert l1 == l2
+
+    def test_single_document(self):
+        vectors, _ = lc._tfidf([["nlp"]])
+        labels = lc._kmeans(vectors, k=5)
+        assert labels == [0]
+
+
+# ---------------------------------------------------------------------------
+# BibTeX field extractor
+# ---------------------------------------------------------------------------
+
+class TestBibtexField:
+    def test_braced_value(self):
+        entry = "@article{key, title = {Hello World}, year = {2020}}"
+        assert lc._bibtex_field(entry, "title") == "Hello World"
+        assert lc._bibtex_field(entry, "year") == "2020"
+
+    def test_quoted_value(self):
+        entry = '@article{key, title = "Hello World"}'
+        assert lc._bibtex_field(entry, "title") == "Hello World"
+
+    def test_nested_braces(self):
+        entry = "@article{key, title = {A {nested} title}}"
+        assert lc._bibtex_field(entry, "title") == "A {nested} title"
+
+    def test_missing_field_returns_empty(self):
+        entry = "@article{key, title = {Foo}}"
+        assert lc._bibtex_field(entry, "abstract") == ""
+
+    def test_multiline_abstract(self):
+        entry = "@article{key,\n  abstract = {Line one.\nLine two.},\n}"
+        result = lc._bibtex_field(entry, "abstract")
+        assert "Line one" in result
+        assert "Line two" in result
+
+    def test_bare_numeric_value(self):
+        entry = "@article{key, year = 2023, title = {T}}"
+        assert lc._bibtex_field(entry, "year") == "2023"
+
+
+# ---------------------------------------------------------------------------
+# Data structures
+# ---------------------------------------------------------------------------
+
+class TestPaper:
+    def test_text_property_combines_fields(self):
+        p = lc.Paper("id1", "Title words", abstract="Abstract text", keywords="key terms")
+        assert "Title words" in p.text
+        assert "Abstract text" in p.text
+        assert "key terms" in p.text
+
+    def test_to_dict_keys(self):
+        p = lc.Paper("id1", "Test Title", abstract="Test abstract")
+        d = p.to_dict()
+        assert d["paper_id"] == "id1"
+        assert d["title"] == "Test Title"
+        assert d["abstract"] == "Test abstract"
+
+    def test_defaults_are_empty_strings(self):
+        p = lc.Paper("id1", "Title")
+        assert p.abstract == ""
+        assert p.authors == ""
+        assert p.doi == ""
+
+
+class TestCluster:
+    def test_label_includes_top_terms(self):
+        c = lc.Cluster(1, top_terms=["nlp", "deep", "learning", "neural"])
+        assert "nlp" in c.label
+        assert "Cluster 1" in c.label
+
+    def test_label_only_shows_first_three_terms(self):
+        c = lc.Cluster(0, top_terms=["alpha", "beta", "gamma", "delta", "epsilon"])
+        assert "delta" not in c.label
+        assert "epsilon" not in c.label
+
+    def test_label_with_empty_terms(self):
+        c = lc.Cluster(2)
+        assert "Cluster 2" in c.label
+        assert "uncategorised" in c.label
+
+    def test_to_dict_structure(self):
+        p = lc.Paper("p1", "Title")
+        c = lc.Cluster(0, papers=[p], top_terms=["nlp"])
+        d = c.to_dict()
+        assert d["cluster_id"] == 0
+        assert d["size"] == 1
+        assert len(d["papers"]) == 1
+        assert d["top_terms"] == ["nlp"]
+
+
+# ---------------------------------------------------------------------------
+# Input loaders
+# ---------------------------------------------------------------------------
+
+class TestFromCsv:
+    def test_loads_all_papers(self, tmp_path):
+        f = tmp_path / "papers.csv"
+        with f.open("w", newline="") as fh:
+            w = csv.DictWriter(fh, fieldnames=list(SAMPLE_PAPERS[0].keys()))
+            w.writeheader()
+            w.writerows(SAMPLE_PAPERS)
+        obj = lc.LitCluster.from_csv(f)
+        assert len(obj.papers) == len(SAMPLE_PAPERS)
+        assert obj.papers[0].title == SAMPLE_PAPERS[0]["title"]
+
+    def test_missing_columns_default_to_empty(self, tmp_path):
+        f = tmp_path / "partial.csv"
+        f.write_text("title\nPaper One\nPaper Two\n", encoding="utf-8")
+        obj = lc.LitCluster.from_csv(f)
+        assert len(obj.papers) == 2
+        assert obj.papers[0].abstract == ""
+
+    def test_string_path_accepted(self, tmp_path):
+        f = tmp_path / "papers.csv"
+        with f.open("w", newline="") as fh:
+            csv.DictWriter(fh, fieldnames=list(SAMPLE_PAPERS[0].keys())).writeheader()
+        lc.LitCluster.from_csv(str(f))
+
+
+class TestFromJsonl:
+    def test_loads_all_papers(self, tmp_path):
+        f = tmp_path / "papers.jsonl"
+        f.write_text(
+            "\n".join(json.dumps(p) for p in SAMPLE_PAPERS), encoding="utf-8"
+        )
+        obj = lc.LitCluster.from_jsonl(f)
+        assert len(obj.papers) == len(SAMPLE_PAPERS)
+
+    def test_skips_blank_lines(self, tmp_path):
+        f = tmp_path / "papers.jsonl"
+        lines = [json.dumps(SAMPLE_PAPERS[0]), "", json.dumps(SAMPLE_PAPERS[1])]
+        f.write_text("\n".join(lines), encoding="utf-8")
+        obj = lc.LitCluster.from_jsonl(f)
+        assert len(obj.papers) == 2
+
+
+class TestFromBibtex:
+    def test_loads_all_entries(self, tmp_path):
+        f = tmp_path / "refs.bib"
+        f.write_text(SAMPLE_BIB, encoding="utf-8")
+        obj = lc.LitCluster.from_bibtex(f)
+        assert len(obj.papers) == 3
+
+    def test_entry_key_used_as_paper_id(self, tmp_path):
+        f = tmp_path / "refs.bib"
+        f.write_text(SAMPLE_BIB, encoding="utf-8")
+        obj = lc.LitCluster.from_bibtex(f)
+        assert obj.papers[0].paper_id == "smith2020"
+
+    def test_title_extracted(self, tmp_path):
+        f = tmp_path / "refs.bib"
+        f.write_text(SAMPLE_BIB, encoding="utf-8")
+        obj = lc.LitCluster.from_bibtex(f)
+        assert "deep learning" in obj.papers[0].title.lower()
+
+    def test_booktitle_used_as_venue(self, tmp_path):
+        f = tmp_path / "refs.bib"
+        f.write_text(SAMPLE_BIB, encoding="utf-8")
+        obj = lc.LitCluster.from_bibtex(f)
+        assert obj.papers[2].venue == "ICML"
+
+
+# ---------------------------------------------------------------------------
+# Fitting and clustering
+# ---------------------------------------------------------------------------
+
+class TestFit:
+    def test_produces_requested_clusters(self):
+        obj = _make_fitted(k=2)
+        assert len(obj.clusters) == 2
+
+    def test_all_papers_assigned(self):
+        obj = _make_fitted(k=2)
+        total = sum(len(c.papers) for c in obj.clusters)
+        assert total == len(SAMPLE_PAPERS)
+
+    def test_top_terms_nonempty(self):
+        obj = _make_fitted(k=2)
+        for c in obj.clusters:
+            assert len(c.top_terms) > 0
+
+    def test_empty_input_returns_self(self):
+        obj = lc.LitCluster(k=3).fit()
+        assert obj.clusters == []
+
+    def test_k_larger_than_n_clamped(self):
+        obj = lc.LitCluster(k=100, min_term_freq=1)
+        for p in SAMPLE_PAPERS[:2]:
+            obj.papers.append(lc.Paper(**p))
+        obj.fit()
+        assert len(obj.clusters) <= 2
+
+    def test_reproducible_with_same_seed(self):
+        obj1 = _make_fitted(k=3, seed=7)
+        obj2 = _make_fitted(k=3, seed=7)
+        assert obj1._labels == obj2._labels
+
+    def test_method_chaining(self):
+        obj = lc.LitCluster(k=2, min_term_freq=1)
+        for p in SAMPLE_PAPERS:
+            obj.papers.append(lc.Paper(**p))
+        result = obj.fit()
+        assert result is obj
+
+
+# ---------------------------------------------------------------------------
+# Quality metric
+# ---------------------------------------------------------------------------
+
+class TestSilhouette:
+    def test_returns_float_in_valid_range(self):
+        obj = _make_fitted(k=2)
+        s = obj.silhouette()
+        assert isinstance(s, float)
+        assert -1.0 <= s <= 1.0
+
+    def test_single_cluster_returns_zero(self):
+        obj = _make_fitted(k=1)
+        assert obj.silhouette() == 0.0
+
+    def test_unfitted_returns_zero(self):
+        obj = lc.LitCluster(k=2)
+        assert obj.silhouette() == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Export methods
+# ---------------------------------------------------------------------------
+
+class TestExportCsv:
+    def test_creates_file(self, tmp_path):
+        f = tmp_path / "out.csv"
+        _make_fitted().export_csv(f)
+        assert f.is_file()
+
+    def test_correct_row_count(self, tmp_path):
+        f = tmp_path / "out.csv"
+        _make_fitted().export_csv(f)
+        rows = list(csv.DictReader(f.open()))
+        assert len(rows) == len(SAMPLE_PAPERS)
+
+    def test_required_columns_present(self, tmp_path):
+        f = tmp_path / "out.csv"
+        _make_fitted().export_csv(f)
+        rows = list(csv.DictReader(f.open()))
+        for col in ("cluster_id", "cluster_label", "paper_id", "title"):
+            assert col in rows[0]
+
+
+class TestExportJson:
+    def test_creates_valid_json(self, tmp_path):
+        f = tmp_path / "out.json"
+        _make_fitted().export_json(f)
+        data = json.loads(f.read_text())
+        assert isinstance(data, list)
+
+    def test_cluster_structure(self, tmp_path):
+        f = tmp_path / "out.json"
+        obj = _make_fitted(k=2)
+        obj.export_json(f)
+        data = json.loads(f.read_text())
+        assert len(data) == 2
+        assert "cluster_id" in data[0]
+        assert "papers" in data[0]
+        assert "top_terms" in data[0]
+
+
+class TestExportHtml:
+    def test_creates_valid_html(self, tmp_path):
+        f = tmp_path / "out.html"
+        _make_fitted().export_html(f)
+        html = f.read_text()
+        assert "<!DOCTYPE html>" in html
+        assert "<table>" in html
+
+    def test_contains_cluster_labels(self, tmp_path):
+        f = tmp_path / "out.html"
+        obj = _make_fitted(k=2)
+        obj.export_html(f)
+        html = f.read_text()
+        assert "Cluster" in html
+
+    def test_doi_links(self, tmp_path):
+        f = tmp_path / "out.html"
+        _make_fitted().export_html(f)
+        html = f.read_text()
+        assert "https://doi.org/" in html
+
+    def test_html_escaping(self, tmp_path):
+        obj = lc.LitCluster(k=1, min_term_freq=1)
+        obj.papers.append(
+            lc.Paper("x", "<script>alert('xss')</script>", abstract="safe")
+        )
+        obj.fit()
+        f = tmp_path / "out.html"
+        obj.export_html(f)
+        html = f.read_text()
+        assert "<script>" not in html
+        assert "&lt;script&gt;" in html
+
+
+class TestSummary:
+    def test_contains_paper_count(self):
+        s = _make_fitted().summary()
+        assert str(len(SAMPLE_PAPERS)) in s
+
+    def test_contains_cluster_count(self):
+        obj = _make_fitted(k=2)
+        s = obj.summary()
+        assert "2" in s
+
+    def test_unfitted_message(self):
+        s = lc.LitCluster(k=2).summary()
+        assert "fit" in s.lower()
+
+
+# ---------------------------------------------------------------------------
+# Input validation
+# ---------------------------------------------------------------------------
+
+class TestValidation:
+    def test_k_zero_raises(self):
+        with pytest.raises(ValueError, match="k must be"):
+            lc.LitCluster(k=0)
+
+    def test_k_negative_raises(self):
+        with pytest.raises(ValueError):
+            lc.LitCluster(k=-1)
+
+    def test_max_iter_zero_raises(self):
+        with pytest.raises(ValueError, match="max_iter"):
+            lc.LitCluster(max_iter=0)
+
+    def test_min_term_freq_zero_raises(self):
+        with pytest.raises(ValueError, match="min_term_freq"):
+            lc.LitCluster(min_term_freq=0)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+class TestCLI:
+    def _write_jsonl(self, path: Path) -> None:
+        path.write_text(
+            "\n".join(json.dumps(p) for p in SAMPLE_PAPERS), encoding="utf-8"
+        )
+
+    def test_summary_output(self, tmp_path, capsys):
+        f = tmp_path / "papers.jsonl"
+        self._write_jsonl(f)
+        ret = lc.main([str(f), "-k", "2", "--min-freq", "1"])
+        assert ret == 0
+        captured = capsys.readouterr()
+        assert "papers" in captured.out.lower()
+
+    def test_csv_output(self, tmp_path):
+        f = tmp_path / "papers.jsonl"
+        self._write_jsonl(f)
+        out = tmp_path / "clusters.csv"
+        ret = lc.main([str(f), "-k", "2", "--format", "csv",
+                       "-o", str(out), "--min-freq", "1"])
+        assert ret == 0
+        assert out.is_file()
+        rows = list(csv.DictReader(out.open()))
+        assert len(rows) == len(SAMPLE_PAPERS)
+
+    def test_json_output(self, tmp_path):
+        f = tmp_path / "papers.jsonl"
+        self._write_jsonl(f)
+        out = tmp_path / "clusters.json"
+        ret = lc.main([str(f), "-k", "2", "--format", "json",
+                       "-o", str(out), "--min-freq", "1"])
+        assert ret == 0
+        data = json.loads(out.read_text())
+        assert len(data) == 2
+
+    def test_html_output(self, tmp_path):
+        f = tmp_path / "papers.jsonl"
+        self._write_jsonl(f)
+        out = tmp_path / "clusters.html"
+        ret = lc.main([str(f), "-k", "2", "--format", "html",
+                       "-o", str(out), "--min-freq", "1"])
+        assert ret == 0
+        assert "<html" in out.read_text().lower()
+
+    def test_missing_file_returns_error(self, tmp_path):
+        ret = lc.main(["nonexistent_file.csv"])
+        assert ret == 1
+
+    def test_bibtex_input(self, tmp_path, capsys):
+        f = tmp_path / "refs.bib"
+        f.write_text(SAMPLE_BIB, encoding="utf-8")
+        ret = lc.main([str(f), "-k", "2", "--min-freq", "1"])
+        assert ret == 0
+
+    def test_cli_alias(self):
+        assert lc._cli is lc.main


### PR DESCRIPTION
## Summary

- **Bug fixes** in `litcluster.py`: moved `import random` to module top level; fixed fragile BibTeX regex with a proper nested-brace-aware `_bibtex_field()` helper; fixed broken `pyproject.toml` entry point (`_cli` → `main`, alias retained); fixed `Cluster.label` when `top_terms` is empty; fixed `src/litcluster/__init__.py` broken imports (`.cluster`, `.embed` didn't exist)
- **New: Tkinter GUI** (`litcluster_gui.py`) — file browser, parameter spinboxes, background clustering thread, cluster/paper tree-views, paper detail pop-up, CSV/JSON/HTML export
- **New: `export_html()`** — self-contained interactive HTML report with collapsible cluster sections and clickable DOI links
- **New: `silhouette()`** — mean silhouette coefficient (cosine distance) as a clustering-quality indicator
- **New: `--format html` and `--version`** CLI flags
- **JOSS alignment**: `paper.md` updated to describe the actual TF-IDF + k-means implementation; `CHANGELOG.md` and `README.md` rewritten to match actual features
- **Test suite** expanded from 4 to 81 tests (unit, integration, CLI)

## Test plan

- [x] `pytest tests/ -v` — 81/81 pass
- [ ] Launch `python litcluster_gui.py` and verify GUI opens, loads a file, runs clustering, shows results, and exports HTML
- [ ] Run `litcluster --help` and `litcluster --version` to verify CLI entry point works after `pip install .`

https://claude.ai/code/session_01Gn4ruwfrbpWosG143vspqf

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gn4ruwfrbpWosG143vspqf)_