### PR TITLE
fix: JOSS-level debug, refine, and Tkinter GUI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,26 @@
+# Python
+__pycache__/
+*.py[cod]
+*.pyo
+*.pyd
+
+# Build / packaging
+*.egg-info/
+dist/
+build/
+*.egg
+
+# Virtual environments
+.venv/
+venv/
+env/
+
+# Pytest / coverage
+.pytest_cache/
+.coverage
+htmlcov/
+
+# Editor / OS
+.DS_Store
+*.swp
+*.swo

--- a/litcluster.py
+++ b/litcluster.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 """
-litcluster.py — Literature Clustering Tool
+litcluster — Literature Clustering Tool
 Clusters academic papers by topic using TF-IDF + k-means (pure stdlib).
-Stdlib-only. No external dependencies.
+Zero external dependencies. Python >= 3.8.
 """
 
 from __future__ import annotations
@@ -13,9 +13,14 @@ import json
 import math
 import re
 import sys
+import warnings
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
+
+__version__ = "0.1.0"
+__author__ = "Vaibhav Deshmukh"
+__license__ = "MIT"
 
 
 # ---------------------------------------------------------------------------
@@ -23,31 +28,40 @@ from typing import Dict, List, Optional, Tuple
 # ---------------------------------------------------------------------------
 
 _STOPWORDS = {
-    'a','an','the','and','or','but','in','on','at','to','for','of','with',
-    'by','from','is','was','are','were','be','been','being','have','has',
-    'had','do','does','did','will','would','could','should','may','might',
-    'this','that','these','those','it','its','we','our','they','their',
-    'as','if','not','no','nor','so','yet','both','either','whether',
-    'each','few','more','most','other','some','such','than','too','very',
-    'just','also','only','then','here','there','when','where','who','which',
-    'how','all','any','can','into','through','during','before','after',
-    'above','below','between','out','off','over','under','again','further',
-    'once','i','my','me','he','she','his','her','him','you','your',
+    'a', 'an', 'the', 'and', 'or', 'but', 'in', 'on', 'at', 'to', 'for',
+    'of', 'with', 'by', 'from', 'is', 'was', 'are', 'were', 'be', 'been',
+    'being', 'have', 'has', 'had', 'do', 'does', 'did', 'will', 'would',
+    'could', 'should', 'may', 'might', 'this', 'that', 'these', 'those',
+    'it', 'its', 'we', 'our', 'they', 'their', 'as', 'if', 'not', 'no',
+    'nor', 'so', 'yet', 'both', 'either', 'whether', 'each', 'few', 'more',
+    'most', 'other', 'some', 'such', 'than', 'too', 'very', 'just', 'also',
+    'only', 'then', 'here', 'there', 'when', 'where', 'who', 'which', 'how',
+    'all', 'any', 'can', 'into', 'through', 'during', 'before', 'after',
+    'above', 'below', 'between', 'out', 'off', 'over', 'under', 'again',
+    'further', 'once', 'i', 'my', 'me', 'he', 'she', 'his', 'her', 'him',
+    'you', 'your',
 }
 
 
 def _tokenise(text: str) -> List[str]:
+    """Lower-case, extract alphabetic tokens of length >= 3, remove stopwords."""
     tokens = re.findall(r"[a-zA-Z]{3,}", text.lower())
     return [t for t in tokens if t not in _STOPWORDS]
 
 
-def _tfidf(documents: List[List[str]]) -> Tuple[List[Dict[str,float]], List[str]]:
-    """Compute TF-IDF vectors. Returns (vectors, vocab)."""
+def _tfidf(
+    documents: List[List[str]],
+) -> Tuple[List[Dict[str, float]], List[str]]:
+    """Compute TF-IDF vectors for a list of token lists.
+
+    Returns ``(vectors, vocab)`` where each vector is a sparse dict mapping
+    term to TF-IDF weight.  IDF uses the smoothed formula
+    ``log((N + 1) / (df + 1)) + 1``.
+    """
     n = len(documents)
     if n == 0:
         return [], []
 
-    # Build vocab
     vocab_set: set = set()
     for doc in documents:
         vocab_set.update(doc)
@@ -55,15 +69,12 @@ def _tfidf(documents: List[List[str]]) -> Tuple[List[Dict[str,float]], List[str]
     term_idx = {t: i for i, t in enumerate(vocab)}
     V = len(vocab)
 
-    # Document frequency
     df = [0] * V
     for doc in documents:
-        doc_set = set(doc)
-        for t in doc_set:
+        for t in set(doc):
             if t in term_idx:
                 df[term_idx[t]] += 1
 
-    # TF-IDF
     vectors: List[Dict[str, float]] = []
     for doc in documents:
         tf: Dict[int, int] = {}
@@ -83,9 +94,10 @@ def _tfidf(documents: List[List[str]]) -> Tuple[List[Dict[str,float]], List[str]
 
 
 def _cosine(a: Dict[str, float], b: Dict[str, float]) -> float:
+    """Cosine similarity between two sparse TF-IDF vectors."""
     dot = sum(a.get(t, 0.0) * b.get(t, 0.0) for t in b)
-    norm_a = math.sqrt(sum(v*v for v in a.values()))
-    norm_b = math.sqrt(sum(v*v for v in b.values()))
+    norm_a = math.sqrt(sum(v * v for v in a.values()))
+    norm_b = math.sqrt(sum(v * v for v in b.values()))
     if norm_a == 0 or norm_b == 0:
         return 0.0
     return dot / (norm_a * norm_b)
@@ -97,44 +109,104 @@ def _kmeans(
     max_iter: int = 100,
     seed: int = 42,
 ) -> List[int]:
-    """Lloyd's k-means on sparse TF-IDF vectors."""
+    """Lloyd's k-means on sparse TF-IDF vectors.
+
+    Parameters
+    ----------
+    vectors:
+        Sparse TF-IDF representations (one dict per document).
+    k:
+        Target number of clusters; silently capped at ``len(vectors)``.
+    max_iter:
+        Maximum iteration count.
+    seed:
+        Random seed for centroid initialisation.
+
+    Returns
+    -------
+    List[int]
+        Per-document cluster labels (length == ``len(vectors)``).
+    """
+    import random
+
     n = len(vectors)
     if n == 0:
         return []
     k = min(k, n)
 
-    # Seeded centroid initialisation (evenly spaced)
-    import random
     rng = random.Random(seed)
     centroid_indices = rng.sample(range(n), k)
     centroids = [dict(vectors[i]) for i in centroid_indices]
     labels = [0] * n
 
     for _ in range(max_iter):
-        # Assignment
-        new_labels = []
+        new_labels: List[int] = []
         for vec in vectors:
-            best = max(range(k), key=lambda c: _cosine(vec, centroids[c]))
-            new_labels.append(best)
+            sims = [_cosine(vec, centroids[c]) for c in range(k)]
+            new_labels.append(sims.index(max(sims)))
 
         if new_labels == labels:
             break
         labels = new_labels
 
-        # Update centroids
         for c in range(k):
-            members = [vectors[i] for i, l in enumerate(labels) if l == c]
+            members = [vectors[i] for i, lbl in enumerate(labels) if lbl == c]
             if not members:
-                centroids[c] = dict(vectors[rng.randint(0, n-1)])
+                centroids[c] = dict(vectors[rng.randint(0, n - 1)])
                 continue
             new_centroid: Dict[str, float] = {}
             for vec in members:
                 for t, v in vec.items():
                     new_centroid[t] = new_centroid.get(t, 0.0) + v
             total = len(members)
-            centroids[c] = {t: v/total for t, v in new_centroid.items()}
+            centroids[c] = {t: v / total for t, v in new_centroid.items()}
 
     return labels
+
+
+# ---------------------------------------------------------------------------
+# BibTeX helper
+# ---------------------------------------------------------------------------
+
+def _bibtex_field(entry: str, field_name: str) -> str:
+    """Extract the value of *field_name* from a single BibTeX entry string.
+
+    Handles ``{...}`` and ``"..."`` delimiters and nested braces correctly.
+    Returns an empty string when the field is absent.
+    """
+    pattern = re.compile(
+        r'\b' + re.escape(field_name) + r'\s*=\s*',
+        re.IGNORECASE,
+    )
+    m = pattern.search(entry)
+    if not m:
+        return ""
+    start = m.end()
+    if start >= len(entry):
+        return ""
+
+    delimiter = entry[start]
+    if delimiter == '{':
+        depth, i = 0, start
+        while i < len(entry):
+            if entry[i] == '{':
+                depth += 1
+            elif entry[i] == '}':
+                depth -= 1
+                if depth == 0:
+                    return entry[start + 1:i].strip()
+            i += 1
+        return ""
+    if delimiter == '"':
+        i = start + 1
+        while i < len(entry):
+            if entry[i] == '"':
+                return entry[start + 1:i].strip()
+            i += 1
+        return ""
+    # Bare numeric value (e.g. year = 2024)
+    numeric = re.match(r'(\d+)', entry[start:])
+    return numeric.group(1) if numeric else ""
 
 
 # ---------------------------------------------------------------------------
@@ -143,6 +215,8 @@ def _kmeans(
 
 @dataclass
 class Paper:
+    """Represents a single scientific paper."""
+
     paper_id: str
     title: str
     abstract: str = ""
@@ -154,27 +228,42 @@ class Paper:
 
     @property
     def text(self) -> str:
+        """Combined text used for vectorisation (title + abstract + keywords)."""
         return f"{self.title} {self.abstract} {self.keywords}"
 
     def to_dict(self) -> dict:
+        """Serialise to a plain dictionary."""
         return {
-            "paper_id": self.paper_id, "title": self.title, "abstract": self.abstract,
-            "authors": self.authors, "year": self.year, "venue": self.venue,
-            "doi": self.doi, "keywords": self.keywords,
+            "paper_id": self.paper_id,
+            "title": self.title,
+            "abstract": self.abstract,
+            "authors": self.authors,
+            "year": self.year,
+            "venue": self.venue,
+            "doi": self.doi,
+            "keywords": self.keywords,
         }
+
+    def __repr__(self) -> str:
+        return f"Paper(id={self.paper_id!r}, title={self.title[:50]!r})"
 
 
 @dataclass
 class Cluster:
+    """A thematic cluster of papers with associated top terms."""
+
     cluster_id: int
     papers: List[Paper] = field(default_factory=list)
     top_terms: List[str] = field(default_factory=list)
 
     @property
     def label(self) -> str:
-        return f"Cluster {self.cluster_id}: {', '.join(self.top_terms[:3])}"
+        """Short human-readable label: 'Cluster N: term1, term2, term3'."""
+        terms = ", ".join(self.top_terms[:3]) if self.top_terms else "—"
+        return f"Cluster {self.cluster_id}: {terms}"
 
     def to_dict(self) -> dict:
+        """Serialise to a plain dictionary."""
         return {
             "cluster_id": self.cluster_id,
             "size": len(self.papers),
@@ -183,14 +272,55 @@ class Cluster:
             "papers": [p.to_dict() for p in self.papers],
         }
 
+    def __repr__(self) -> str:
+        return (
+            f"Cluster(id={self.cluster_id}, "
+            f"size={len(self.papers)}, terms={self.top_terms[:3]})"
+        )
+
 
 # ---------------------------------------------------------------------------
 # LitCluster
 # ---------------------------------------------------------------------------
 
 class LitCluster:
-    def __init__(self, k: int = 5, max_iter: int = 100, seed: int = 42,
-                 min_term_freq: int = 2):
+    """Cluster a collection of scientific papers using TF-IDF and k-means.
+
+    Parameters
+    ----------
+    k : int
+        Target number of clusters.  Silently capped at corpus size.
+    max_iter : int
+        Maximum k-means iterations.
+    seed : int
+        Random seed for reproducibility.
+    min_term_freq : int
+        Minimum document frequency for a term to enter the vocabulary.
+        Terms appearing in fewer documents are discarded before vectorisation.
+
+    Examples
+    --------
+    >>> lc = LitCluster(k=3, seed=0, min_term_freq=1)
+    >>> lc.add_paper(Paper("1", "Deep Learning", "Neural network methods."))
+    >>> lc.add_paper(Paper("2", "Clustering", "k-means algorithm for grouping."))
+    >>> lc.fit()
+    LitCluster(k=3, papers=2, clusters=2)
+    """
+
+    def __init__(
+        self,
+        k: int = 5,
+        max_iter: int = 100,
+        seed: int = 42,
+        min_term_freq: int = 2,
+    ) -> None:
+        if k < 1:
+            raise ValueError(f"k must be >= 1, got {k}")
+        if max_iter < 1:
+            raise ValueError(f"max_iter must be >= 1, got {max_iter}")
+        if min_term_freq < 1:
+            raise ValueError(f"min_term_freq must be >= 1, got {min_term_freq}")
+
         self.k = k
         self.max_iter = max_iter
         self.seed = seed
@@ -201,9 +331,20 @@ class LitCluster:
         self._vectors: List[Dict[str, float]] = []
         self._vocab: List[str] = []
 
+    # ------------------------------------------------------------------
+    # Loaders
+    # ------------------------------------------------------------------
+
     @classmethod
-    def from_csv(cls, path: Path, **kwargs) -> "LitCluster":
+    def from_csv(cls, path, **kwargs) -> "LitCluster":
+        """Load papers from a CSV file.
+
+        Expected columns: ``paper_id``, ``title``, ``abstract``, ``authors``,
+        ``year``, ``venue``, ``doi``, ``keywords`` (all optional except ``title``).
+        Accepts both ``Path`` objects and path strings.
+        """
         obj = cls(**kwargs)
+        path = Path(path)
         with path.open(encoding="utf-8", errors="replace", newline="") as fh:
             reader = csv.DictReader(fh)
             for i, row in enumerate(reader):
@@ -220,8 +361,10 @@ class LitCluster:
         return obj
 
     @classmethod
-    def from_jsonl(cls, path: Path, **kwargs) -> "LitCluster":
+    def from_jsonl(cls, path, **kwargs) -> "LitCluster":
+        """Load papers from a JSONL file (one JSON object per line)."""
         obj = cls(**kwargs)
+        path = Path(path)
         with path.open(encoding="utf-8") as fh:
             for i, line in enumerate(fh):
                 line = line.strip()
@@ -241,57 +384,102 @@ class LitCluster:
         return obj
 
     @classmethod
-    def from_bibtex(cls, path: Path, **kwargs) -> "LitCluster":
-        """Parse a BibTeX file for titles, abstracts, keywords."""
+    def from_bibtex(cls, path, **kwargs) -> "LitCluster":
+        """Load papers from a BibTeX (.bib) file.
+
+        Parses ``title``, ``abstract``, ``author``, ``year``, ``journal``/
+        ``booktitle``, ``doi``, and ``keywords`` fields.  Uses brace-aware
+        extraction so LaTeX-formatted values are handled correctly.
+        """
         obj = cls(**kwargs)
+        path = Path(path)
         text = path.read_text(encoding="utf-8", errors="replace")
         entries = re.split(r'(?=@\w+\s*\{)', text)
         for i, entry in enumerate(entries):
             if not entry.strip() or not entry.startswith('@'):
                 continue
-            def _get(field):
-                m = re.search(rf'{field}\s*=\s*[{{"](.*?)[}}"\,]', entry, re.IGNORECASE | re.DOTALL)
-                return m.group(1).strip() if m else ""
             m_key = re.match(r'@\w+\s*\{\s*(\S+?)[,}]', entry)
             key = m_key.group(1) if m_key else str(i)
             obj.papers.append(Paper(
-                paper_id=key, title=_get('title'), abstract=_get('abstract'),
-                authors=_get('author'), year=_get('year'),
-                venue=_get('journal') or _get('booktitle'),
-                doi=_get('doi'), keywords=_get('keywords'),
+                paper_id=key,
+                title=_bibtex_field(entry, 'title'),
+                abstract=_bibtex_field(entry, 'abstract'),
+                authors=_bibtex_field(entry, 'author'),
+                year=_bibtex_field(entry, 'year'),
+                venue=(
+                    _bibtex_field(entry, 'journal')
+                    or _bibtex_field(entry, 'booktitle')
+                ),
+                doi=_bibtex_field(entry, 'doi'),
+                keywords=_bibtex_field(entry, 'keywords'),
             ))
         return obj
 
+    def add_paper(self, paper: Paper) -> "LitCluster":
+        """Append *paper* to the corpus.
+
+        Returns *self* to support method chaining.  Call :meth:`fit` after
+        all papers have been added.
+        """
+        self.papers.append(paper)
+        return self
+
+    # ------------------------------------------------------------------
+    # Fitting
+    # ------------------------------------------------------------------
+
     def fit(self) -> "LitCluster":
+        """Run TF-IDF vectorisation followed by k-means clustering.
+
+        Populates :attr:`clusters` with :class:`Cluster` objects sorted by
+        cluster ID.  Returns *self* so calls can be chained.
+        """
         if not self.papers:
             return self
+
         tokens_list = [_tokenise(p.text) for p in self.papers]
 
-        # Filter rare terms
         if self.min_term_freq > 1:
             freq: Dict[str, int] = {}
             for tokens in tokens_list:
                 for t in set(tokens):
                     freq[t] = freq.get(t, 0) + 1
-            tokens_list = [[t for t in tokens if freq.get(t, 0) >= self.min_term_freq]
-                           for tokens in tokens_list]
+            tokens_list = [
+                [t for t in tokens if freq.get(t, 0) >= self.min_term_freq]
+                for tokens in tokens_list
+            ]
+
+        empty_count = sum(1 for t in tokens_list if not t)
+        if empty_count:
+            warnings.warn(
+                f"{empty_count} paper(s) produced empty token lists after "
+                "frequency filtering.  Consider lowering --min-freq.",
+                UserWarning,
+                stacklevel=2,
+            )
 
         self._vectors, self._vocab = _tfidf(tokens_list)
         self._labels = _kmeans(self._vectors, self.k, self.max_iter, self.seed)
 
-        # Build cluster objects
-        clusters: Dict[int, List] = {}
+        cluster_map: Dict[int, List[Paper]] = {}
         for paper, label in zip(self.papers, self._labels):
-            clusters.setdefault(label, []).append(paper)
+            cluster_map.setdefault(label, []).append(paper)
 
-        self.clusters = []
-        for cid in sorted(clusters):
-            top_terms = self._top_terms_for_cluster(cid, n=10)
-            self.clusters.append(Cluster(cluster_id=cid, papers=clusters[cid], top_terms=top_terms))
+        self.clusters = [
+            Cluster(
+                cluster_id=cid,
+                papers=cluster_map[cid],
+                top_terms=self._top_terms_for_cluster(cid, n=10),
+            )
+            for cid in sorted(cluster_map)
+        ]
         return self
 
     def _top_terms_for_cluster(self, cid: int, n: int = 10) -> List[str]:
-        member_vecs = [self._vectors[i] for i, l in enumerate(self._labels) if l == cid]
+        """Return the *n* highest-scoring terms for cluster *cid*."""
+        member_vecs = [
+            self._vectors[i] for i, lbl in enumerate(self._labels) if lbl == cid
+        ]
         if not member_vecs:
             return []
         scores: Dict[str, float] = {}
@@ -300,24 +488,64 @@ class LitCluster:
                 scores[t] = scores.get(t, 0.0) + v
         return sorted(scores, key=lambda t: -scores[t])[:n]
 
-    def export_csv(self, path: Path) -> None:
+    # ------------------------------------------------------------------
+    # Exports
+    # ------------------------------------------------------------------
+
+    def export_csv(self, path) -> None:
+        """Write clustering results to *path* as a CSV file."""
+        path = Path(path)
         with path.open("w", newline="", encoding="utf-8") as fh:
-            w = csv.writer(fh)
-            w.writerow(["cluster_id","cluster_label","paper_id","title","authors","year","venue","doi"])
+            writer = csv.writer(fh)
+            writer.writerow([
+                "cluster_id", "cluster_label",
+                "paper_id", "title", "authors", "year", "venue", "doi",
+            ])
             for cluster in self.clusters:
                 for p in cluster.papers:
-                    w.writerow([cluster.cluster_id, cluster.label, p.paper_id,
-                                p.title, p.authors, p.year, p.venue, p.doi])
+                    writer.writerow([
+                        cluster.cluster_id, cluster.label,
+                        p.paper_id, p.title, p.authors,
+                        p.year, p.venue, p.doi,
+                    ])
 
-    def export_json(self, path: Path) -> None:
+    def export_json(self, path) -> None:
+        """Write clustering results to *path* as a JSON file."""
+        path = Path(path)
         with path.open("w", encoding="utf-8") as fh:
-            json.dump([c.to_dict() for c in self.clusters], fh, indent=2, ensure_ascii=False)
+            json.dump(
+                [c.to_dict() for c in self.clusters],
+                fh,
+                indent=2,
+                ensure_ascii=False,
+            )
 
     def summary(self) -> str:
-        lines = [f"LitCluster: {len(self.papers)} papers in {len(self.clusters)} clusters", ""]
+        """Return a human-readable summary of clustering results."""
+        if not self.clusters:
+            return "No clusters — call .fit() first."
+        lines = [
+            f"LitCluster  v{__version__}",
+            f"  Corpus  : {len(self.papers)} papers",
+            f"  Clusters: {len(self.clusters)}",
+            f"  Vocab   : {len(self._vocab)} terms",
+            "",
+        ]
+        n_total = max(len(self.papers), 1)
         for c in self.clusters:
-            lines.append(f"  [{c.cluster_id}] {c.label} ({len(c.papers)} papers)")
+            pct = 100.0 * len(c.papers) / n_total
+            lines.append(
+                f"  [{c.cluster_id:>2d}]  {len(c.papers):>4d} papers"
+                f"  ({pct:4.1f}%)  {', '.join(c.top_terms[:5])}"
+            )
         return "\n".join(lines)
+
+    def __repr__(self) -> str:
+        return (
+            f"LitCluster(k={self.k}, "
+            f"papers={len(self.papers)}, "
+            f"clusters={len(self.clusters)})"
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -325,35 +553,58 @@ class LitCluster:
 # ---------------------------------------------------------------------------
 
 def _parse_args(argv=None):
-    p = argparse.ArgumentParser(prog="litcluster",
-                                description="Cluster academic papers by topic using TF-IDF + k-means.")
-    p.add_argument("input", help="Input file: CSV, JSONL, or .bib")
-    p.add_argument("-k", "--clusters", type=int, default=5, dest="k",
-                   help="Number of clusters (default: 5)")
-    p.add_argument("--format", choices=["csv","json","summary"], default="summary")
-    p.add_argument("--output", "-o", default=None, help="Output file (default: stdout/auto)")
-    p.add_argument("--seed", type=int, default=42)
-    p.add_argument("--max-iter", type=int, default=100)
-    p.add_argument("--min-freq", type=int, default=2,
-                   help="Minimum term frequency to include in vocabulary (default: 2)")
+    p = argparse.ArgumentParser(
+        prog="litcluster",
+        description="Cluster academic papers by topic using TF-IDF + k-means.",
+    )
+    p.add_argument("input", help="Input file: CSV, JSONL, or BibTeX (.bib)")
+    p.add_argument(
+        "-k", "--clusters", type=int, default=5, dest="k",
+        help="Number of clusters (default: 5)",
+    )
+    p.add_argument(
+        "--format", choices=["csv", "json", "summary"], default="summary",
+        help="Output format (default: summary)",
+    )
+    p.add_argument("--output", "-o", default=None,
+                   help="Output file path (default: stdout / auto-named)")
+    p.add_argument("--seed", type=int, default=42,
+                   help="Random seed (default: 42)")
+    p.add_argument("--max-iter", type=int, default=100,
+                   help="Maximum k-means iterations (default: 100)")
+    p.add_argument(
+        "--min-freq", type=int, default=2,
+        help="Minimum term document frequency (default: 2)",
+    )
+    p.add_argument("--version", action="version", version=f"litcluster {__version__}")
     return p.parse_args(argv)
 
 
 def main(argv=None) -> int:
+    """CLI entry point.  Returns an exit code (0 = success)."""
     args = _parse_args(argv)
     path = Path(args.input)
     if not path.is_file():
         print(f"Error: {path} not found", file=sys.stderr)
         return 1
 
-    suffix = path.suffix.lower()
-    kwargs = dict(k=args.k, max_iter=args.max_iter, seed=args.seed, min_term_freq=args.min_freq)
-    if suffix == ".bib":
-        lc = LitCluster.from_bibtex(path, **kwargs)
-    elif suffix == ".jsonl":
-        lc = LitCluster.from_jsonl(path, **kwargs)
-    else:
-        lc = LitCluster.from_csv(path, **kwargs)
+    kwargs = dict(
+        k=args.k,
+        max_iter=args.max_iter,
+        seed=args.seed,
+        min_term_freq=args.min_freq,
+    )
+    try:
+        suffix = path.suffix.lower()
+        if suffix == ".bib":
+            lc = LitCluster.from_bibtex(path, **kwargs)
+        elif suffix == ".jsonl":
+            lc = LitCluster.from_jsonl(path, **kwargs)
+        else:
+            lc = LitCluster.from_csv(path, **kwargs)
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        print(f"Error loading {path}: {exc}", file=sys.stderr)
+        return 1
 
     lc.fit()
 
@@ -374,6 +625,9 @@ def main(argv=None) -> int:
 
     return 0
 
+
+#: Alias kept for backwards-compatibility with older pyproject.toml entries.
+_cli = main
 
 if __name__ == "__main__":
     sys.exit(main())

--- a/litcluster_gui.py
+++ b/litcluster_gui.py
@@ -1,0 +1,508 @@
+#!/usr/bin/env python3
+"""
+litcluster_gui.py — Graphical interface for LitCluster.
+
+Launch with:
+    python litcluster_gui.py
+Or, after installation:
+    litcluster-gui
+
+Requires Python's built-in tkinter (install via your OS package manager if
+missing, e.g. ``apt install python3-tk`` on Debian/Ubuntu).
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import threading
+from pathlib import Path
+
+# Allow running directly from the repo root without installing the package.
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+try:
+    import tkinter as tk
+    from tkinter import filedialog, messagebox, scrolledtext, ttk
+except ImportError:
+    print(
+        "tkinter is not available.  Install it via your system package manager:\n"
+        "  Debian/Ubuntu : sudo apt install python3-tk\n"
+        "  Fedora/RHEL   : sudo dnf install python3-tkinter\n"
+        "  macOS (brew)  : brew install python-tk",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+from litcluster import Cluster, LitCluster, Paper, __version__
+
+
+# ---------------------------------------------------------------------------
+# Cluster detail pop-up
+# ---------------------------------------------------------------------------
+
+class _ClusterDetail(tk.Toplevel):
+    """Modal-ish window that lists all papers in one cluster."""
+
+    def __init__(self, parent: tk.Misc, cluster: Cluster) -> None:
+        super().__init__(parent)
+        self.title(cluster.label)
+        self.geometry("820x460")
+        self.resizable(True, True)
+
+        # Top bar: top-terms summary
+        top = ttk.Frame(self, padding=(8, 6, 8, 4))
+        top.pack(fill="x")
+        ttk.Label(
+            top,
+            text=f"Top terms:  {', '.join(cluster.top_terms)}",
+            font=("TkDefaultFont", 10, "italic"),
+        ).pack(anchor="w")
+        ttk.Separator(self).pack(fill="x", padx=8)
+
+        # Papers treeview
+        cols = ("paper_id", "title", "authors", "year", "venue")
+        tree = ttk.Treeview(self, columns=cols, show="headings", selectmode="browse")
+        for col, heading, width in [
+            ("paper_id", "ID",      90),
+            ("title",    "Title",  340),
+            ("authors",  "Authors",190),
+            ("year",     "Year",    55),
+            ("venue",    "Venue",  150),
+        ]:
+            tree.heading(col, text=heading)
+            tree.column(col, width=width, minwidth=40, anchor="w")
+
+        for p in cluster.papers:
+            tree.insert("", "end", values=(
+                p.paper_id, p.title, p.authors, p.year, p.venue,
+            ))
+
+        vsb = ttk.Scrollbar(self, orient="vertical",   command=tree.yview)
+        hsb = ttk.Scrollbar(self, orient="horizontal", command=tree.xview)
+        tree.configure(yscrollcommand=vsb.set, xscrollcommand=hsb.set)
+
+        hsb.pack(side="bottom", fill="x")
+        vsb.pack(side="right",  fill="y")
+        tree.pack(side="left",  fill="both", expand=True)
+
+        # Focus this window
+        self.transient(parent)
+        self.lift()
+
+
+# ---------------------------------------------------------------------------
+# Main application window
+# ---------------------------------------------------------------------------
+
+class LitClusterGUI:
+    """Main application window for LitCluster."""
+
+    def __init__(self, root: tk.Tk) -> None:
+        self.root = root
+        self.root.title(f"LitCluster {__version__}  —  Literature Clustering Tool")
+        self.root.geometry("1060x740")
+        self.root.minsize(820, 580)
+
+        self._lc: LitCluster | None = None
+        self._running = False
+        self._sort_col = ""
+        self._sort_reverse = False
+
+        self._build_menu()
+        self._build_controls()
+        self._build_notebook()
+        self._build_statusbar()
+
+    # ------------------------------------------------------------------
+    # Layout
+    # ------------------------------------------------------------------
+
+    def _build_menu(self) -> None:
+        menubar = tk.Menu(self.root)
+
+        file_menu = tk.Menu(menubar, tearoff=0)
+        file_menu.add_command(label="Open file…",   accelerator="Ctrl+O", command=self._browse)
+        file_menu.add_separator()
+        file_menu.add_command(label="Export CSV…",  command=self._export_csv)
+        file_menu.add_command(label="Export JSON…", command=self._export_json)
+        file_menu.add_separator()
+        file_menu.add_command(label="Exit",         command=self.root.quit)
+        menubar.add_cascade(label="File", menu=file_menu)
+
+        help_menu = tk.Menu(menubar, tearoff=0)
+        help_menu.add_command(label="About", command=self._show_about)
+        menubar.add_cascade(label="Help", menu=help_menu)
+
+        self.root.config(menu=menubar)
+        self.root.bind("<Control-o>", lambda _e: self._browse())
+
+    def _build_controls(self) -> None:
+        ctrl = ttk.Frame(self.root, padding=(10, 6, 10, 2))
+        ctrl.pack(fill="x")
+
+        # File row
+        file_frame = ttk.LabelFrame(ctrl, text="Input file", padding=6)
+        file_frame.pack(fill="x", pady=(0, 6))
+
+        self._file_var = tk.StringVar()
+        ttk.Entry(file_frame, textvariable=self._file_var, width=72).pack(
+            side="left", fill="x", expand=True,
+        )
+        ttk.Button(file_frame, text="Browse…", command=self._browse).pack(
+            side="left", padx=(6, 0),
+        )
+
+        # Parameters row
+        params_frame = ttk.LabelFrame(ctrl, text="Clustering parameters", padding=6)
+        params_frame.pack(fill="x", pady=(0, 6))
+
+        self._k_var    = tk.IntVar(value=5)
+        self._iter_var = tk.IntVar(value=100)
+        self._seed_var = tk.IntVar(value=42)
+        self._freq_var = tk.IntVar(value=2)
+
+        for col, label, var, lo, hi in [
+            (0, "Clusters (k)",    self._k_var,    1,     100),
+            (1, "Max iterations",  self._iter_var, 10,   2000),
+            (2, "Random seed",     self._seed_var,  0,  99999),
+            (3, "Min term freq",   self._freq_var,  1,     50),
+        ]:
+            cell = ttk.Frame(params_frame)
+            cell.grid(row=0, column=col, padx=16, sticky="w")
+            ttk.Label(cell, text=label).pack(anchor="w")
+            ttk.Spinbox(cell, from_=lo, to=hi, textvariable=var, width=9).pack()
+
+        # Action row
+        btn_row = ttk.Frame(ctrl)
+        btn_row.pack(fill="x", pady=(0, 4))
+
+        self._run_btn = ttk.Button(
+            btn_row, text="▶  Run clustering", command=self._run,
+        )
+        self._run_btn.pack(side="left", padx=(0, 10))
+
+        self._progress = ttk.Progressbar(btn_row, mode="indeterminate", length=180)
+        self._progress.pack(side="left")
+
+        ttk.Button(btn_row, text="Export JSON…", command=self._export_json).pack(
+            side="right", padx=(4, 0),
+        )
+        ttk.Button(btn_row, text="Export CSV…",  command=self._export_csv).pack(
+            side="right",
+        )
+
+    def _build_notebook(self) -> None:
+        self._nb = ttk.Notebook(self.root)
+        self._nb.pack(fill="both", expand=True, padx=10, pady=(0, 4))
+
+        # --- Summary tab ---
+        self._summary_text = scrolledtext.ScrolledText(
+            self._nb,
+            wrap=tk.WORD,
+            font=("Courier", 10),
+            state="disabled",
+            background="#f8f8f8",
+        )
+        self._nb.add(self._summary_text, text="  Summary  ")
+
+        # --- Clusters tab ---
+        self._build_clusters_tab()
+
+        # --- All papers tab ---
+        self._build_papers_tab()
+
+    def _build_clusters_tab(self) -> None:
+        frame = ttk.Frame(self._nb)
+        self._nb.add(frame, text="  Clusters  ")
+
+        cols = ("id", "size", "pct", "top_terms")
+        self._clusters_tree = ttk.Treeview(
+            frame, columns=cols, show="headings", selectmode="browse",
+        )
+        for col, heading, width, anchor in [
+            ("id",       "ID",        55,  "center"),
+            ("size",     "Papers",    72,  "center"),
+            ("pct",      "%",         62,  "center"),
+            ("top_terms","Top terms", 800, "w"),
+        ]:
+            self._clusters_tree.heading(col, text=heading)
+            self._clusters_tree.column(col, width=width, anchor=anchor, minwidth=40)
+
+        vsb = ttk.Scrollbar(frame, orient="vertical", command=self._clusters_tree.yview)
+        self._clusters_tree.configure(yscrollcommand=vsb.set)
+
+        self._clusters_tree.pack(side="left", fill="both", expand=True)
+        vsb.pack(side="right", fill="y")
+
+        self._clusters_tree.bind("<Double-1>", self._on_cluster_double_click)
+        self._clusters_tree.bind("<Return>",   self._on_cluster_double_click)
+
+        hint = ttk.Label(
+            frame,
+            text="Double-click or press Enter on a cluster to see its papers.",
+            foreground="gray",
+            font=("TkDefaultFont", 9, "italic"),
+        )
+        hint.place(relx=0.5, rely=0.995, anchor="s")
+
+    def _build_papers_tab(self) -> None:
+        frame = ttk.Frame(self._nb)
+        self._nb.add(frame, text="  All papers  ")
+
+        cols = ("cluster", "paper_id", "title", "authors", "year", "venue")
+        self._papers_tree = ttk.Treeview(
+            frame, columns=cols, show="headings", selectmode="browse",
+        )
+        for col, heading, width in [
+            ("cluster",  "Cluster",  72),
+            ("paper_id", "ID",       90),
+            ("title",    "Title",   360),
+            ("authors",  "Authors", 200),
+            ("year",     "Year",     55),
+            ("venue",    "Venue",   180),
+        ]:
+            self._papers_tree.heading(
+                col, text=heading,
+                command=lambda c=col: self._sort_papers(c),
+            )
+            self._papers_tree.column(col, width=width, minwidth=40, anchor="w")
+
+        vsb = ttk.Scrollbar(frame, orient="vertical",   command=self._papers_tree.yview)
+        hsb = ttk.Scrollbar(frame, orient="horizontal", command=self._papers_tree.xview)
+        self._papers_tree.configure(yscrollcommand=vsb.set, xscrollcommand=hsb.set)
+
+        hsb.pack(side="bottom", fill="x")
+        vsb.pack(side="right",  fill="y")
+        self._papers_tree.pack(side="left", fill="both", expand=True)
+
+    def _build_statusbar(self) -> None:
+        self._status_var = tk.StringVar(value="Ready — open a file and run clustering.")
+        ttk.Label(
+            self.root,
+            textvariable=self._status_var,
+            relief="sunken",
+            anchor="w",
+            padding=(6, 2),
+        ).pack(fill="x", side="bottom")
+
+    # ------------------------------------------------------------------
+    # Actions
+    # ------------------------------------------------------------------
+
+    def _browse(self) -> None:
+        path = filedialog.askopenfilename(
+            title="Select input file",
+            filetypes=[
+                ("BibTeX",     "*.bib"),
+                ("CSV",        "*.csv"),
+                ("JSONL",      "*.jsonl"),
+                ("All files",  "*.*"),
+            ],
+        )
+        if path:
+            self._file_var.set(path)
+            self._set_status(f"File selected: {path}")
+
+    def _run(self) -> None:
+        if self._running:
+            return
+        path_str = self._file_var.get().strip()
+        if not path_str:
+            messagebox.showwarning("No file", "Please select an input file first.")
+            return
+        path = Path(path_str)
+        if not path.is_file():
+            messagebox.showerror("File not found", f"Cannot find:\n{path}")
+            return
+
+        self._running = True
+        self._run_btn.config(state="disabled")
+        self._progress.start(12)
+        self._set_status("Running clustering…")
+
+        def _worker() -> None:
+            try:
+                kwargs = dict(
+                    k=self._k_var.get(),
+                    max_iter=self._iter_var.get(),
+                    seed=self._seed_var.get(),
+                    min_term_freq=self._freq_var.get(),
+                )
+                suffix = path.suffix.lower()
+                if suffix == ".bib":
+                    obj = LitCluster.from_bibtex(path, **kwargs)
+                elif suffix == ".jsonl":
+                    obj = LitCluster.from_jsonl(path, **kwargs)
+                else:
+                    obj = LitCluster.from_csv(path, **kwargs)
+                obj.fit()
+                self.root.after(0, lambda: self._on_done(obj))
+            except Exception as exc:  # noqa: BLE001
+                self.root.after(0, lambda: self._on_error(exc))
+
+        threading.Thread(target=_worker, daemon=True).start()
+
+    def _on_done(self, obj: LitCluster) -> None:
+        self._lc = obj
+        self._progress.stop()
+        self._run_btn.config(state="normal")
+        self._running = False
+        self._populate_results()
+        n = len(obj.papers)
+        k = len(obj.clusters)
+        self._set_status(
+            f"Done — {n} paper{'s' if n != 1 else ''} clustered into "
+            f"{k} group{'s' if k != 1 else ''}.  "
+            "Double-click a cluster to inspect its papers."
+        )
+        self._nb.select(0)
+
+    def _on_error(self, exc: Exception) -> None:
+        self._progress.stop()
+        self._run_btn.config(state="normal")
+        self._running = False
+        self._set_status(f"Error: {exc}")
+        messagebox.showerror("Clustering failed", str(exc))
+
+    # ------------------------------------------------------------------
+    # Populate results
+    # ------------------------------------------------------------------
+
+    def _populate_results(self) -> None:
+        obj = self._lc
+        assert obj is not None
+
+        # Summary tab
+        self._summary_text.config(state="normal")
+        self._summary_text.delete("1.0", tk.END)
+        self._summary_text.insert("1.0", obj.summary())
+        self._summary_text.config(state="disabled")
+
+        # Clusters tab
+        self._clusters_tree.delete(*self._clusters_tree.get_children())
+        n_total = max(len(obj.papers), 1)
+        for c in obj.clusters:
+            pct = f"{100 * len(c.papers) / n_total:.1f}"
+            self._clusters_tree.insert(
+                "", "end",
+                iid=str(c.cluster_id),
+                values=(c.cluster_id, len(c.papers), pct, ", ".join(c.top_terms)),
+            )
+
+        # Papers tab — color-code alternate clusters for readability
+        self._papers_tree.delete(*self._papers_tree.get_children())
+        for c in obj.clusters:
+            tag = "even" if c.cluster_id % 2 == 0 else "odd"
+            for p in c.papers:
+                self._papers_tree.insert(
+                    "", "end", tags=(tag,),
+                    values=(c.cluster_id, p.paper_id, p.title,
+                            p.authors, p.year, p.venue),
+                )
+        self._papers_tree.tag_configure("even", background="#f0f4ff")
+        self._papers_tree.tag_configure("odd",  background="#ffffff")
+
+        # Reset sort state
+        self._sort_col = ""
+        self._sort_reverse = False
+
+    # ------------------------------------------------------------------
+    # Cluster detail pop-up
+    # ------------------------------------------------------------------
+
+    def _on_cluster_double_click(self, _event=None) -> None:
+        if not self._lc:
+            return
+        sel = self._clusters_tree.selection()
+        if not sel:
+            return
+        cid = int(sel[0])
+        cluster = next((c for c in self._lc.clusters if c.cluster_id == cid), None)
+        if cluster:
+            _ClusterDetail(self.root, cluster)
+
+    # ------------------------------------------------------------------
+    # Sortable papers table
+    # ------------------------------------------------------------------
+
+    def _sort_papers(self, col: str) -> None:
+        rows = [
+            (self._papers_tree.set(k, col), k)
+            for k in self._papers_tree.get_children()
+        ]
+        reverse = self._sort_col == col and not self._sort_reverse
+        rows.sort(key=lambda x: x[0].lower(), reverse=reverse)
+        for idx, (_, k) in enumerate(rows):
+            self._papers_tree.move(k, "", idx)
+        self._sort_col = col
+        self._sort_reverse = reverse
+        # Update heading to show sort direction
+        arrow = " ▲" if not reverse else " ▼"
+        for c in ("cluster", "paper_id", "title", "authors", "year", "venue"):
+            heading = c.replace("_", " ").title()
+            self._papers_tree.heading(
+                c, text=heading + (arrow if c == col else ""),
+            )
+
+    # ------------------------------------------------------------------
+    # Exports
+    # ------------------------------------------------------------------
+
+    def _export_csv(self) -> None:
+        if not self._lc or not self._lc.clusters:
+            messagebox.showwarning("No results", "Run clustering first.")
+            return
+        path = filedialog.asksaveasfilename(
+            defaultextension=".csv",
+            filetypes=[("CSV", "*.csv"), ("All files", "*.*")],
+        )
+        if path:
+            self._lc.export_csv(Path(path))
+            self._set_status(f"Exported CSV → {path}")
+
+    def _export_json(self) -> None:
+        if not self._lc or not self._lc.clusters:
+            messagebox.showwarning("No results", "Run clustering first.")
+            return
+        path = filedialog.asksaveasfilename(
+            defaultextension=".json",
+            filetypes=[("JSON", "*.json"), ("All files", "*.*")],
+        )
+        if path:
+            self._lc.export_json(Path(path))
+            self._set_status(f"Exported JSON → {path}")
+
+    # ------------------------------------------------------------------
+    # Utilities
+    # ------------------------------------------------------------------
+
+    def _set_status(self, msg: str) -> None:
+        self._status_var.set(msg)
+
+    def _show_about(self) -> None:
+        messagebox.showinfo(
+            "About LitCluster",
+            f"LitCluster  v{__version__}\n\n"
+            "Semantic clustering and topic modelling\n"
+            "of scientific literature.\n\n"
+            "Supported formats: BibTeX (.bib), CSV, JSONL\n"
+            "Algorithm: TF-IDF + k-means (pure Python)\n\n"
+            "Author: Vaibhav Deshmukh\n"
+            "License: MIT",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    """Launch the LitCluster GUI."""
+    root = tk.Tk()
+    LitClusterGUI(root)
+    root.mainloop()
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,8 @@ classifiers = [
 ]
 
 [project.scripts]
-litcluster = "litcluster:_cli"
+litcluster = "litcluster:main"
+litcluster-gui = "litcluster_gui:main"
 
 [tool.setuptools]
-py-modules = ["litcluster"]
+py-modules = ["litcluster", "litcluster_gui"]

--- a/src/litcluster/__init__.py
+++ b/src/litcluster/__init__.py
@@ -1,18 +1,17 @@
 """
 litcluster: Semantic clustering and topic modelling of scientific literature.
 
-Ingests collections of scientific abstracts or full papers (via DOI lists,
-BibTeX files, or arXiv IDs), embeds them using sentence-transformers, and
-applies hierarchical clustering and topic modelling to produce interactive
-visualisations and structured cluster summaries for systematic literature
-reviews.
+Ingests collections of scientific abstracts or full papers (via BibTeX files,
+CSV, or JSONL), embeds them using TF-IDF vectorisation, and applies k-means
+clustering to produce structured cluster summaries for literature reviews.
+
+All functionality lives in the top-level ``litcluster`` module::
+
+    from litcluster import LitCluster, Paper, Cluster
+
+Zero external dependencies — pure Python standard library.
 """
 
 __version__ = "0.1.0"
 __author__ = "Vaibhav Deshmukh"
 __license__ = "MIT"
-
-from .cluster import LitCluster
-from .embed import PaperEmbedder
-
-__all__ = ["LitCluster", "PaperEmbedder"]

--- a/tests/test_litcluster.py
+++ b/tests/test_litcluster.py
@@ -1,19 +1,582 @@
-import sys, pathlib
+"""
+Test suite for litcluster.
+
+Covers: imports, data structures, text-processing primitives, clustering
+pipeline, file loaders (CSV / JSONL / BibTeX), export functions, and
+edge-case robustness.
+"""
+
+import csv
+import json
+import pathlib
+import sys
+import warnings
+
+import pytest
+
+# Ensure the repo root is on the path when running without installation.
 sys.path.insert(0, str(pathlib.Path(__file__).parent.parent))
 
-def test_import():
-    import litcluster as lc
-    assert hasattr(lc, 'LitCluster')
+import litcluster as lc
+from litcluster import (
+    Cluster,
+    LitCluster,
+    Paper,
+    _cosine,
+    _kmeans,
+    _tfidf,
+    _tokenise,
+    _bibtex_field,
+)
 
-def test_paper():
-    import litcluster as lc
-    assert hasattr(lc, 'Paper')
 
-def test_cluster():
-    import litcluster as lc
-    assert hasattr(lc, 'Cluster')
+# ---------------------------------------------------------------------------
+# Public API surface
+# ---------------------------------------------------------------------------
 
-def test_tokenise():
-    import litcluster as lc
-    tokens = lc._tokenise('hello world test foo bar')
-    assert isinstance(tokens, list) and len(tokens) > 0
+def test_import_litcluster():
+    assert hasattr(lc, "LitCluster")
+
+
+def test_import_paper():
+    assert hasattr(lc, "Paper")
+
+
+def test_import_cluster():
+    assert hasattr(lc, "Cluster")
+
+
+def test_import_tokenise():
+    assert hasattr(lc, "_tokenise")
+
+
+def test_version_string():
+    assert hasattr(lc, "__version__")
+    assert isinstance(lc.__version__, str)
+
+
+# ---------------------------------------------------------------------------
+# Paper dataclass
+# ---------------------------------------------------------------------------
+
+def test_paper_creation():
+    p = Paper(paper_id="p1", title="Test Paper", abstract="An abstract.")
+    assert p.paper_id == "p1"
+    assert p.title == "Test Paper"
+    assert p.abstract == "An abstract."
+
+
+def test_paper_text_combines_fields():
+    p = Paper("1", "TF-IDF Clustering", abstract="Vectorisation method.", keywords="nlp tfidf")
+    assert "TF-IDF Clustering" in p.text
+    assert "Vectorisation method." in p.text
+    assert "nlp tfidf" in p.text
+
+
+def test_paper_to_dict_keys():
+    p = Paper(paper_id="x", title="Hello")
+    d = p.to_dict()
+    for key in ("paper_id", "title", "abstract", "authors", "year", "venue", "doi", "keywords"):
+        assert key in d
+
+
+def test_paper_to_dict_values():
+    p = Paper(paper_id="42", title="Deep Learning", abstract="Neural nets", year="2024")
+    d = p.to_dict()
+    assert d["paper_id"] == "42"
+    assert d["year"] == "2024"
+
+
+def test_paper_repr():
+    p = Paper(paper_id="1", title="A Very Long Title That Exceeds Fifty Characters In Total")
+    r = repr(p)
+    assert "Paper" in r
+    assert "1" in r
+
+
+# ---------------------------------------------------------------------------
+# Cluster dataclass
+# ---------------------------------------------------------------------------
+
+def test_cluster_label_with_terms():
+    c = Cluster(cluster_id=0, top_terms=["machine", "learning", "neural", "network"])
+    assert "Cluster 0" in c.label
+    assert "machine" in c.label
+
+
+def test_cluster_label_without_terms():
+    c = Cluster(cluster_id=2)
+    assert "Cluster 2" in c.label
+    assert "—" in c.label
+
+
+def test_cluster_to_dict():
+    p = Paper("1", "Test")
+    c = Cluster(cluster_id=1, papers=[p], top_terms=["topic"])
+    d = c.to_dict()
+    assert d["cluster_id"] == 1
+    assert d["size"] == 1
+    assert d["top_terms"] == ["topic"]
+    assert len(d["papers"]) == 1
+
+
+def test_cluster_repr():
+    c = Cluster(cluster_id=3, papers=[Paper("1", "X")], top_terms=["a", "b"])
+    assert "Cluster" in repr(c)
+    assert "3" in repr(c)
+
+
+# ---------------------------------------------------------------------------
+# _tokenise
+# ---------------------------------------------------------------------------
+
+def test_tokenise_returns_list():
+    assert isinstance(_tokenise("hello world"), list)
+
+
+def test_tokenise_min_length():
+    tokens = _tokenise("a ab abc abcd")
+    assert "a" not in tokens
+    assert "ab" not in tokens
+    assert "abc" in tokens
+    assert "abcd" in tokens
+
+
+def test_tokenise_removes_stopwords():
+    tokens = _tokenise("the and or but in on at for of with")
+    assert len(tokens) == 0
+
+
+def test_tokenise_lowercases():
+    tokens = _tokenise("MACHINE Learning Neural")
+    assert "machine" in tokens
+    assert "learning" in tokens
+
+
+def test_tokenise_empty():
+    assert _tokenise("") == []
+
+
+def test_tokenise_numbers_excluded():
+    # Only alpha tokens matched
+    tokens = _tokenise("123 456 abc")
+    assert "123" not in tokens
+    assert "456" not in tokens
+    assert "abc" in tokens
+
+
+# ---------------------------------------------------------------------------
+# _tfidf
+# ---------------------------------------------------------------------------
+
+def test_tfidf_basic_shape():
+    docs = [["machine", "learning"], ["clustering", "kmeans"]]
+    vectors, vocab = _tfidf(docs)
+    assert len(vectors) == 2
+    assert len(vocab) == 4
+    assert all(isinstance(v, dict) for v in vectors)
+
+
+def test_tfidf_empty_corpus():
+    vectors, vocab = _tfidf([])
+    assert vectors == []
+    assert vocab == []
+
+
+def test_tfidf_single_doc():
+    vectors, vocab = _tfidf([["hello", "world"]])
+    assert len(vectors) == 1
+    assert len(vocab) == 2
+
+
+def test_tfidf_weights_positive():
+    docs = [["neural", "network", "deep"], ["cluster", "kmeans", "distance"]]
+    vectors, _ = _tfidf(docs)
+    for vec in vectors:
+        assert all(v > 0 for v in vec.values())
+
+
+def test_tfidf_shared_term_lower_idf():
+    """A term shared across all docs should have lower weight than a unique one."""
+    docs = [
+        ["shared", "unique_a"],
+        ["shared", "unique_b"],
+    ]
+    vectors, _ = _tfidf(docs)
+    # 'shared' appears in both docs; unique terms appear in one
+    assert vectors[0]["shared"] < vectors[0]["unique_a"]
+
+
+# ---------------------------------------------------------------------------
+# _cosine
+# ---------------------------------------------------------------------------
+
+def test_cosine_identical_vectors():
+    v = {"machine": 1.0, "learning": 0.5}
+    assert abs(_cosine(v, v) - 1.0) < 1e-9
+
+
+def test_cosine_orthogonal_vectors():
+    a = {"machine": 1.0}
+    b = {"learning": 1.0}
+    assert _cosine(a, b) == 0.0
+
+
+def test_cosine_empty_vector():
+    assert _cosine({}, {"machine": 1.0}) == 0.0
+    assert _cosine({"machine": 1.0}, {}) == 0.0
+
+
+def test_cosine_partial_overlap():
+    a = {"x": 1.0, "y": 1.0}
+    b = {"y": 1.0, "z": 1.0}
+    sim = _cosine(a, b)
+    assert 0.0 < sim < 1.0
+
+
+# ---------------------------------------------------------------------------
+# _kmeans
+# ---------------------------------------------------------------------------
+
+def test_kmeans_empty():
+    assert _kmeans([], k=3) == []
+
+
+def test_kmeans_k_capped_at_n():
+    docs = [["apple"]]
+    vectors, _ = _tfidf(docs)
+    labels = _kmeans(vectors, k=10, seed=0)
+    assert len(labels) == 1
+
+
+def test_kmeans_label_count():
+    docs = [["machine", "learning"], ["deep", "network"], ["cluster", "kmeans"]]
+    vectors, _ = _tfidf(docs)
+    labels = _kmeans(vectors, k=2, seed=42)
+    assert len(labels) == 3
+    assert set(labels) <= {0, 1}
+
+
+def test_kmeans_reproducible():
+    docs = [
+        ["machine", "learning", "neural"],
+        ["clustering", "kmeans", "unsupervised"],
+        ["deep", "network", "convolutional"],
+        ["text", "classification", "sentiment"],
+    ]
+    vectors, _ = _tfidf(docs)
+    l1 = _kmeans(vectors, k=2, seed=7)
+    l2 = _kmeans(vectors, k=2, seed=7)
+    assert l1 == l2
+
+
+# ---------------------------------------------------------------------------
+# _bibtex_field
+# ---------------------------------------------------------------------------
+
+def test_bibtex_field_braces():
+    entry = 'title = {Deep Learning Methods},'
+    assert _bibtex_field(entry, 'title') == 'Deep Learning Methods'
+
+
+def test_bibtex_field_quotes():
+    entry = 'title = "Quoted Title",'
+    assert _bibtex_field(entry, 'title') == 'Quoted Title'
+
+
+def test_bibtex_field_numeric():
+    entry = 'year = 2024,'
+    assert _bibtex_field(entry, 'year') == '2024'
+
+
+def test_bibtex_field_nested_braces():
+    entry = 'title = {A {LaTeX} Title},'
+    assert _bibtex_field(entry, 'title') == 'A {LaTeX} Title'
+
+
+def test_bibtex_field_missing():
+    assert _bibtex_field('author = {Smith}', 'title') == ''
+
+
+def test_bibtex_field_case_insensitive():
+    entry = 'TITLE = {Hello},'
+    assert _bibtex_field(entry, 'title') == 'Hello'
+
+
+# ---------------------------------------------------------------------------
+# LitCluster — construction & validation
+# ---------------------------------------------------------------------------
+
+def test_litcluster_invalid_k():
+    with pytest.raises(ValueError, match="k must be"):
+        LitCluster(k=0)
+
+
+def test_litcluster_invalid_max_iter():
+    with pytest.raises(ValueError, match="max_iter"):
+        LitCluster(max_iter=0)
+
+
+def test_litcluster_invalid_min_term_freq():
+    with pytest.raises(ValueError, match="min_term_freq"):
+        LitCluster(min_term_freq=0)
+
+
+def test_litcluster_repr():
+    obj = LitCluster(k=3)
+    assert "LitCluster" in repr(obj)
+    assert "k=3" in repr(obj)
+
+
+# ---------------------------------------------------------------------------
+# LitCluster — add_paper & fit
+# ---------------------------------------------------------------------------
+
+def _make_papers():
+    return [
+        Paper("1", "Machine Learning Survey",
+              "Overview of supervised and unsupervised machine learning algorithms."),
+        Paper("2", "Deep Neural Networks",
+              "Neural network architectures for image classification and object detection."),
+        Paper("3", "K-means Clustering Algorithm",
+              "Clustering methods for unsupervised data grouping and partitioning."),
+        Paper("4", "Unsupervised Clustering Techniques",
+              "Approaches for high-dimensional data clustering and analysis."),
+        Paper("5", "Natural Language Processing",
+              "Text classification and sentiment analysis using transformer models."),
+        Paper("6", "Transformer Language Models",
+              "Large language model fine-tuning for downstream NLP tasks."),
+    ]
+
+
+def test_add_paper_returns_self():
+    obj = LitCluster(k=2, min_term_freq=1)
+    p = Paper("1", "Test")
+    result = obj.add_paper(p)
+    assert result is obj
+
+
+def test_add_paper_appends():
+    obj = LitCluster(k=2, min_term_freq=1)
+    obj.add_paper(Paper("1", "A"))
+    obj.add_paper(Paper("2", "B"))
+    assert len(obj.papers) == 2
+
+
+def test_fit_produces_clusters():
+    obj = LitCluster(k=3, seed=42, min_term_freq=1)
+    for p in _make_papers():
+        obj.add_paper(p)
+    obj.fit()
+    assert len(obj.clusters) == 3
+
+
+def test_fit_all_papers_assigned():
+    papers = _make_papers()
+    obj = LitCluster(k=2, seed=42, min_term_freq=1)
+    for p in papers:
+        obj.add_paper(p)
+    obj.fit()
+    total = sum(len(c.papers) for c in obj.clusters)
+    assert total == len(papers)
+
+
+def test_fit_top_terms_populated():
+    obj = LitCluster(k=2, seed=42, min_term_freq=1)
+    for p in _make_papers():
+        obj.add_paper(p)
+    obj.fit()
+    for c in obj.clusters:
+        assert len(c.top_terms) > 0
+
+
+def test_fit_empty_corpus():
+    obj = LitCluster(k=5)
+    obj.fit()
+    assert obj.clusters == []
+
+
+def test_fit_warns_on_empty_token_lists():
+    """Papers filtered to empty token lists should trigger a UserWarning."""
+    obj = LitCluster(k=2, min_term_freq=100)  # freq threshold too high
+    for p in _make_papers():
+        obj.add_paper(p)
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        obj.fit()
+    assert any(issubclass(warning.category, UserWarning) for warning in w)
+
+
+def test_fit_method_chaining():
+    obj = LitCluster(k=2, seed=0, min_term_freq=1)
+    for p in _make_papers():
+        obj.add_paper(p)
+    result = obj.fit()
+    assert result is obj
+
+
+def test_fit_k_greater_than_n():
+    obj = LitCluster(k=20, seed=42, min_term_freq=1)
+    obj.add_paper(Paper("1", "Only paper", abstract="Single document test."))
+    obj.fit()
+    assert len(obj.clusters) == 1
+
+
+# ---------------------------------------------------------------------------
+# LitCluster — summary
+# ---------------------------------------------------------------------------
+
+def test_summary_before_fit():
+    obj = LitCluster()
+    s = obj.summary()
+    assert "fit" in s.lower() or "cluster" in s.lower()
+
+
+def test_summary_after_fit():
+    obj = LitCluster(k=2, seed=42, min_term_freq=1)
+    for p in _make_papers():
+        obj.add_paper(p)
+    obj.fit()
+    s = obj.summary()
+    assert "papers" in s.lower()
+    assert "clusters" in s.lower()
+    assert str(len(_make_papers())) in s
+
+
+# ---------------------------------------------------------------------------
+# LitCluster — file loaders
+# ---------------------------------------------------------------------------
+
+def test_from_csv(tmp_path):
+    csv_file = tmp_path / "papers.csv"
+    with csv_file.open("w", newline="", encoding="utf-8") as fh:
+        writer = csv.DictWriter(
+            fh, fieldnames=["paper_id", "title", "abstract", "year"]
+        )
+        writer.writeheader()
+        writer.writerow({"paper_id": "1", "title": "Hello", "abstract": "World", "year": "2024"})
+        writer.writerow({"paper_id": "2", "title": "Foo", "abstract": "Bar", "year": "2023"})
+
+    obj = LitCluster.from_csv(csv_file)
+    assert len(obj.papers) == 2
+    assert obj.papers[0].title == "Hello"
+    assert obj.papers[1].year == "2023"
+
+
+def test_from_csv_missing_optional_columns(tmp_path):
+    csv_file = tmp_path / "minimal.csv"
+    with csv_file.open("w", newline="", encoding="utf-8") as fh:
+        writer = csv.DictWriter(fh, fieldnames=["title"])
+        writer.writeheader()
+        writer.writerow({"title": "Minimal Paper"})
+
+    obj = LitCluster.from_csv(csv_file)
+    assert len(obj.papers) == 1
+    assert obj.papers[0].abstract == ""
+
+
+def test_from_jsonl(tmp_path):
+    jsonl_file = tmp_path / "papers.jsonl"
+    jsonl_file.write_text(
+        json.dumps({"paper_id": "a", "title": "Alpha", "abstract": "First."}) + "\n"
+        + json.dumps({"paper_id": "b", "title": "Beta",  "abstract": "Second."}) + "\n"
+        + "\n",  # blank line should be skipped
+        encoding="utf-8",
+    )
+    obj = LitCluster.from_jsonl(jsonl_file)
+    assert len(obj.papers) == 2
+    assert obj.papers[0].title == "Alpha"
+
+
+def test_from_bibtex(tmp_path):
+    bib = tmp_path / "refs.bib"
+    bib.write_text(
+        "@article{smith2024,\n"
+        "  title  = {Deep Learning for Science},\n"
+        "  abstract = {We propose a neural approach.},\n"
+        "  author = {Smith, Jane},\n"
+        "  year   = {2024},\n"
+        "  journal = {Nature},\n"
+        "}\n",
+        encoding="utf-8",
+    )
+    obj = LitCluster.from_bibtex(bib)
+    assert len(obj.papers) == 1
+    assert obj.papers[0].title == "Deep Learning for Science"
+    assert obj.papers[0].year == "2024"
+    assert obj.papers[0].venue == "Nature"
+    assert obj.papers[0].authors == "Smith, Jane"
+
+
+def test_from_bibtex_multiple_entries(tmp_path):
+    bib = tmp_path / "multi.bib"
+    bib.write_text(
+        "@article{a,title={Alpha},year={2020}}\n"
+        "@inproceedings{b,title={Beta},year={2021}}\n",
+        encoding="utf-8",
+    )
+    obj = LitCluster.from_bibtex(bib)
+    assert len(obj.papers) == 2
+
+
+def test_from_bibtex_nested_braces(tmp_path):
+    bib = tmp_path / "nested.bib"
+    bib.write_text(
+        "@article{x,\n"
+        "  title = {A {Nested} Title},\n"
+        "  year = 2022,\n"
+        "}\n",
+        encoding="utf-8",
+    )
+    obj = LitCluster.from_bibtex(bib)
+    assert "Nested" in obj.papers[0].title
+
+
+# ---------------------------------------------------------------------------
+# LitCluster — exports
+# ---------------------------------------------------------------------------
+
+def test_export_csv(tmp_path):
+    obj = LitCluster(k=2, seed=42, min_term_freq=1)
+    for p in _make_papers():
+        obj.add_paper(p)
+    obj.fit()
+
+    out = tmp_path / "results.csv"
+    obj.export_csv(out)
+    assert out.exists()
+
+    with out.open(encoding="utf-8") as fh:
+        rows = list(csv.DictReader(fh))
+    assert len(rows) == len(_make_papers())
+    assert "cluster_id" in rows[0]
+    assert "title" in rows[0]
+
+
+def test_export_json(tmp_path):
+    obj = LitCluster(k=2, seed=42, min_term_freq=1)
+    for p in _make_papers():
+        obj.add_paper(p)
+    obj.fit()
+
+    out = tmp_path / "results.json"
+    obj.export_json(out)
+    assert out.exists()
+
+    data = json.loads(out.read_text(encoding="utf-8"))
+    assert isinstance(data, list)
+    assert len(data) == 2
+    for cluster in data:
+        assert "cluster_id" in cluster
+        assert "papers" in cluster
+        assert "top_terms" in cluster
+
+
+def test_export_csv_path_accepts_string(tmp_path):
+    obj = LitCluster(k=2, seed=0, min_term_freq=1)
+    for p in _make_papers():
+        obj.add_paper(p)
+    obj.fit()
+    out = str(tmp_path / "str_path.csv")
+    obj.export_csv(out)
+    assert pathlib.Path(out).exists()


### PR DESCRIPTION
## Summary

- **Fix critical bugs** in `litcluster.py` that prevented the CLI entry point from working and caused crashes on edge-case inputs
- **Refine to JOSS quality**: robust BibTeX parser, input validation, warnings, richer API, and full docstrings
- **Expand test suite** from 4 to 63 passing tests covering every function and file format
- **Add `litcluster_gui.py`**: a full Tkinter GUI (zero extra dependencies) with tabs, sortable tables, cluster detail pop-ups, and CSV/JSON export

## Detailed changes

### `litcluster.py`
- Replace fragile single-char BibTeX regex with `_bibtex_field()` — a proper brace-depth parser that handles nested LaTeX braces (e.g. `title = {A {LaTeX} Title}`)
- Add `__version__`, `__author__`, `__license__` module constants
- Add `_cli = main` alias so `pyproject.toml`'s console-script entry point resolves correctly (was a `AttributeError` at install time)
- Validate constructor arguments (`k`, `max_iter`, `min_term_freq`) and raise `ValueError` with clear messages
- Add `LitCluster.add_paper()` for building a corpus programmatically
- Emit `UserWarning` when frequency filtering empties all token lists
- Improve `summary()`: shows vocab size and per-cluster percentage
- Add `__repr__` to `Paper`, `Cluster`, and `LitCluster`
- Add `--version` CLI flag; wrap file loading in `try/except`
- Accept both `Path` and `str` in all loader/export methods

### `src/litcluster/__init__.py`
- Remove imports of non-existent `.cluster` and `.embed` modules (was an `ImportError` on every import); keep metadata only

### `pyproject.toml`
- Fix entry point: `litcluster:_cli` → `litcluster:main` (with `_cli` alias kept for back-compat)
- Add `litcluster-gui` console script pointing to `litcluster_gui:main`
- Add `litcluster_gui` to `py-modules`

### `tests/test_litcluster.py`
- 63 tests (was 4); all pass under pytest 9.0 / Python 3.11
- Covers: public API surface, `Paper`/`Cluster` dataclasses, `_tokenise`, `_tfidf`, `_cosine`, `_kmeans`, `_bibtex_field`, `LitCluster` construction, fit pipeline, summary, CSV/JSONL/BibTeX loaders, CSV/JSON export, and edge cases (empty corpus, k > n, missing columns, nested BibTeX braces, warning emission)

### `litcluster_gui.py` (new)
- Full Tkinter GUI — zero extra dependencies beyond Python's stdlib
- Three tabs: **Summary** (monospaced text), **Clusters** (treeview; double-click opens paper detail pop-up), **All papers** (sortable treeview with alternate-row colouring)
- Spinbox controls for k, max iterations, random seed, and min term frequency
- Background thread for clustering so the UI stays responsive
- Indeterminate progress bar during clustering
- Export CSV / Export JSON via buttons and File menu
- Graceful `ImportError` message with install instructions when tkinter is absent

## Test plan
- [ ] `pytest tests/ -v` — 63 passed, 0 failed
- [ ] `python -m py_compile litcluster_gui.py` — syntax OK
- [ ] `python litcluster.py --help` — CLI help renders correctly
- [ ] Load a `.bib` / `.csv` / `.jsonl` file in the GUI and verify clustering + export

https://claude.ai/code/session_01GPna5bWF9QAu5983zNfA4R

---
_Generated by [Claude Code](https://claude.ai/code/session_01GPna5bWF9QAu5983zNfA4R)_